### PR TITLE
Fix service timeout check in RunServiceJob

### DIFF
--- a/core/common.go
+++ b/core/common.go
@@ -18,7 +18,7 @@ var (
 	// it as skipped.
 	ErrSkippedExecution   = errors.New("skipped execution")
 	ErrUnexpected         = errors.New("error unexpected, docker has returned exit code -1, maybe wrong user?")
-	ErrMaxTimeRunning     = errors.New("the job has exceed the maximum allowed time running.")
+	ErrMaxTimeRunning     = errors.New("the job has exceeded the maximum allowed time running.")
 	ErrLocalImageNotFound = errors.New("couldn't find image on the host")
 )
 

--- a/core/runservice.go
+++ b/core/runservice.go
@@ -126,9 +126,9 @@ func (j *RunServiceJob) watchContainer(ctx *Context, svcID string) error {
 
 	go func() {
 		defer wg.Done()
-		for _ = range svcChecker.C {
+		for range svcChecker.C {
 
-			if svc.CreatedAt.After(time.Now().Add(maxProcessDuration)) {
+			if time.Since(svc.CreatedAt) > maxProcessDuration {
 				err = ErrMaxTimeRunning
 				return
 			}


### PR DESCRIPTION
## Summary
- fix timeout comparison in `RunServiceJob.watchContainer`
- fix typo in `ErrMaxTimeRunning` message

## Testing
- `go test ./...` *(fails: no route to host)*