### PR TITLE
Fix #88 config error logging

### DIFF
--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -48,7 +48,7 @@ func (c *DaemonCommand) boot() (err error) {
 	// Always try to read the config file, as there are options such as globals or some tasks that can be specified there and not in docker
 	config, err := BuildFromFile(c.ConfigFile, c.Logger)
 	if err != nil {
-		c.Logger.Debugf("Config file: %v not found", c.ConfigFile)
+		c.Logger.Debugf("Error loading config file %v: %v", c.ConfigFile, err)
 	}
 	config.Docker.Filters = c.DockerFilters
 

--- a/cli/daemon_boot_test.go
+++ b/cli/daemon_boot_test.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/netresearch/ofelia/core"
+	. "gopkg.in/check.v1"
+)
+
+func TestDaemonBoot(t *testing.T) { TestingT(t) }
+
+type DaemonBootSuite struct{}
+
+var _ = Suite(&DaemonBootSuite{})
+
+// BufferLogger collects formatted logs in memory for inspection.
+type BufferLogger struct{ buf bytes.Buffer }
+
+func (l *BufferLogger) Criticalf(format string, args ...interface{}) {
+	fmt.Fprintf(&l.buf, format, args...)
+	l.buf.WriteByte('\n')
+}
+func (l *BufferLogger) Debugf(format string, args ...interface{}) {
+	fmt.Fprintf(&l.buf, format, args...)
+	l.buf.WriteByte('\n')
+}
+func (l *BufferLogger) Errorf(format string, args ...interface{}) {
+	fmt.Fprintf(&l.buf, format, args...)
+	l.buf.WriteByte('\n')
+}
+func (l *BufferLogger) Noticef(format string, args ...interface{}) {
+	fmt.Fprintf(&l.buf, format, args...)
+	l.buf.WriteByte('\n')
+}
+func (l *BufferLogger) Warningf(format string, args ...interface{}) {
+	fmt.Fprintf(&l.buf, format, args...)
+	l.buf.WriteByte('\n')
+}
+
+func (l *BufferLogger) String() string { return l.buf.String() }
+
+func (s *DaemonBootSuite) TestBootLogsConfigError(c *C) {
+	tmpFile, err := os.CreateTemp("", "ofelia_bad_*.ini")
+	c.Assert(err, IsNil)
+	defer os.Remove(tmpFile.Name())
+
+	_, err = tmpFile.WriteString("[global]\nno-overlap = true\n")
+	c.Assert(err, IsNil)
+	tmpFile.Close()
+
+	logger := &BufferLogger{}
+	cmd := &DaemonCommand{ConfigFile: tmpFile.Name(), Logger: logger}
+
+	orig := newDockerHandler
+	defer func() { newDockerHandler = orig }()
+	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, filters []string) (*DockerHandler, error) {
+		return nil, errors.New("docker unavailable")
+	}
+
+	_ = cmd.boot()
+
+	logOutput := logger.String()
+	c.Assert(strings.Contains(logOutput, "no-overlap"), Equals, true)
+	c.Assert(strings.Contains(logOutput, "not found"), Equals, false)
+}


### PR DESCRIPTION
## Summary
- improve log message when config file parsing fails
- add regression test to ensure boot logs the parse error instead of `not found`

## Testing
- `go test ./...`
