### PR TITLE
Add container naming option for run jobs

### DIFF
--- a/core/runjob.go
+++ b/core/runjob.go
@@ -21,6 +21,11 @@ type RunJob struct {
 	Client  *docker.Client `json:"-"`
 	User    string         `default:"root"`
 
+	// ContainerName specifies the name of the container to be created. If
+	// nil, the job name will be used. If set to an empty string, Docker
+	// will assign a random name.
+	ContainerName *string `gcfg:"container-name" mapstructure:"container-name"`
+
 	TTY bool `default:"false"`
 
 	// do not use bool values with "default:true" because if
@@ -177,7 +182,12 @@ func (j *RunJob) pullImage() error {
 }
 
 func (j *RunJob) buildContainer() (*docker.Container, error) {
+	name := j.Name
+	if j.ContainerName != nil {
+		name = *j.ContainerName
+	}
 	c, err := j.Client.CreateContainer(docker.CreateContainerOptions{
+		Name: name,
 		Config: &docker.Config{
 			Image:        j.Image,
 			AttachStdin:  false,

--- a/core/runjob_test.go
+++ b/core/runjob_test.go
@@ -65,6 +65,7 @@ func (s *SuiteRunJob) TestRun(c *C) {
 	c.Assert(container.Config.Cmd, DeepEquals, []string{"echo", "-a", "foo bar"})
 	c.Assert(container.Config.User, Equals, job.User)
 	c.Assert(container.Config.Image, Equals, job.Image)
+	c.Assert(container.Name, Equals, job.Name)
 	c.Assert(container.State.Running, Equals, true)
 	c.Assert(container.Config.Env, DeepEquals, job.Environment)
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -74,6 +74,9 @@ This job can be used in 2 situations:
   - Connect the container to this network
 - `hostname`: string (1)
   - Define the hostname of the instantiated container, e.g. `test-server`
+- `container-name`: string (1)
+  - Name assigned to the created container. Defaults to the job name. If left
+    empty, Docker will choose a random name.
 - `delete`: boolean = `true` (1)
   - Delete the container after the job is finished. Similar to `docker run --rm`
 - **`container`: string** (2)


### PR DESCRIPTION
## Summary
- add `ContainerName` field to `RunJob`
- allow new containers to use the job name unless overridden
- document the `container-name` parameter
- verify container names in tests

## Testing
- `go test ./...`