### PR TITLE
Add Docker poll interval configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ docker run -it --rm \
 
 **Ofelia** reads labels of all Docker containers for configuration by default. To apply on a subset of containers only, use the flag `--docker-filter` (or `-f`) similar to the [filtering for `docker ps`](https://docs.docker.com/engine/reference/commandline/ps/#filter). E.g. to apply to current docker compose project only using `label` filter:
 
+You can also configure how often Ofelia polls Docker for label changes. The default interval is `10s`. Override it with `--docker-poll-interval` or the `poll-interval` option in the `[docker]` section of the config file.
+
 ```yaml
 version: "3"
 services:

--- a/cli/config.go
+++ b/cli/config.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"time"
+
 	"github.com/netresearch/ofelia/core"
 	"github.com/netresearch/ofelia/middlewares"
 
@@ -73,7 +75,7 @@ func (c *Config) InitializeApp() error {
 	c.buildSchedulerMiddlewares(c.sh)
 
 	var err error
-	c.dockerHandler, err = newDockerHandler(c, c.logger, c.Docker.Filters)
+	c.dockerHandler, err = newDockerHandler(c, c.logger, c.Docker.Filters, c.Docker.PollInterval)
 	if err != nil {
 		return err
 	}
@@ -344,5 +346,6 @@ func (c *RunServiceConfig) buildMiddlewares() {
 }
 
 type DockerConfig struct {
-	Filters []string `mapstructure:"filters"`
+	Filters      []string      `mapstructure:"filters"`
+	PollInterval time.Duration `gcfg:"poll-interval" mapstructure:"poll-interval" default:"10s"`
 }

--- a/cli/config_extra_test.go
+++ b/cli/config_extra_test.go
@@ -1,12 +1,13 @@
 package cli
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
-	"errors"
-	
+	"time"
+
 	"github.com/netresearch/ofelia/core"
-	
+
 	. "gopkg.in/check.v1"
 )
 
@@ -40,7 +41,7 @@ func (s *SuiteConfig) TestInitializeAppErrorDockerHandler(c *C) {
 	// Override newDockerHandler to simulate factory error
 	orig := newDockerHandler
 	defer func() { newDockerHandler = orig }()
-	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, filters []string) (*DockerHandler, error) {
+	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, filters []string, interval time.Duration) (*DockerHandler, error) {
 		return nil, errors.New("factory error")
 	}
 
@@ -55,7 +56,7 @@ func (s *SuiteConfig) TestDockerLabelsUpdateExecJobs(c *C) {
 	// Prepare initial Config
 	cfg := NewConfig(&TestLogger{})
 	cfg.logger = &TestLogger{}
-		cfg.dockerHandler = &DockerHandler{}
+	cfg.dockerHandler = &DockerHandler{}
 	cfg.sh = core.NewScheduler(&TestLogger{})
 	cfg.buildSchedulerMiddlewares(cfg.sh)
 	cfg.ExecJobs = make(map[string]*ExecJobConfig)

--- a/cli/config_initialize_test.go
+++ b/cli/config_initialize_test.go
@@ -1,13 +1,14 @@
 package cli
 
 import (
-    "net/http"
-    "net/http/httptest"
-    "testing"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
 
-    docker "github.com/fsouza/go-dockerclient"
-    . "gopkg.in/check.v1"
-    "github.com/netresearch/ofelia/core"
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/netresearch/ofelia/core"
+	. "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -19,37 +20,39 @@ var _ = Suite(&ConfigInitSuite{})
 
 // TestInitializeAppSuccess verifies that InitializeApp succeeds when Docker handler connects and no containers are found.
 func (s *ConfigInitSuite) TestInitializeAppSuccess(c *C) {
-    // HTTP test server returning empty container list
-    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        if r.URL.Path == "/containers/json" {
-            w.Header().Set("Content-Type", "application/json")
-            w.Write([]byte("[]"))
-            return
-        }
-        http.NotFound(w, r)
-    }))
-    defer ts.Close()
+	// HTTP test server returning empty container list
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/containers/json" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte("[]"))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
 
-    // Override newDockerHandler to use the test server
-    origFactory := newDockerHandler
-    defer func() { newDockerHandler = origFactory }()
-    newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, filters []string) (*DockerHandler, error) {
-        client, err := docker.NewClient(ts.URL)
-        if err != nil {
-            return nil, err
-        }
-        return &DockerHandler{
-            filters:      filters,
-            notifier:     notifier,
-            logger:       logger,
-            dockerClient: client,
-        }, nil
-    }
+	// Override newDockerHandler to use the test server
+	origFactory := newDockerHandler
+	defer func() { newDockerHandler = origFactory }()
+	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, filters []string, interval time.Duration) (*DockerHandler, error) {
+		client, err := docker.NewClient(ts.URL)
+		if err != nil {
+			return nil, err
+		}
+		return &DockerHandler{
+			filters:      filters,
+			notifier:     notifier,
+			logger:       logger,
+			dockerClient: client,
+			pollInterval: interval,
+		}, nil
+	}
 
-    cfg := NewConfig(&TestLogger{})
-    cfg.Docker.Filters = []string{}
-    err := cfg.InitializeApp()
-    c.Assert(err, IsNil)
-    c.Assert(cfg.sh, NotNil)
-    c.Assert(cfg.dockerHandler, NotNil)
+	cfg := NewConfig(&TestLogger{})
+	cfg.Docker.Filters = []string{}
+	err := cfg.InitializeApp()
+	c.Assert(err, IsNil)
+	c.Assert(cfg.sh, NotNil)
+	c.Assert(cfg.dockerHandler, NotNil)
+	c.Assert(cfg.dockerHandler.pollInterval, Equals, cfg.Docker.PollInterval)
 }

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -7,17 +7,19 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/netresearch/ofelia/core"
 )
 
 // DaemonCommand daemon process
 type DaemonCommand struct {
-	ConfigFile    string   `long:"config" description:"configuration file" default:"/etc/ofelia.conf"`
-	DockerFilters []string `short:"f" long:"docker-filter" description:"Filter for docker containers"`
-	LogLevel      string   `long:"log-level" description:"Set log level"`
-	EnablePprof   bool     `long:"enable-pprof" description:"Enable the pprof HTTP server"`
-	PprofAddr     string   `long:"pprof-address" description:"Address for the pprof HTTP server to listen on" default:"127.0.0.1:8080"`
+	ConfigFile         string        `long:"config" description:"configuration file" default:"/etc/ofelia.conf"`
+	DockerFilters      []string      `short:"f" long:"docker-filter" description:"Filter for docker containers"`
+	DockerPollInterval time.Duration `long:"docker-poll-interval" description:"Interval for polling docker events"`
+	LogLevel           string        `long:"log-level" description:"Set log level"`
+	EnablePprof        bool          `long:"enable-pprof" description:"Enable the pprof HTTP server"`
+	PprofAddr          string        `long:"pprof-address" description:"Address for the pprof HTTP server to listen on" default:"127.0.0.1:8080"`
 
 	scheduler  *core.Scheduler
 	signals    chan os.Signal
@@ -55,6 +57,9 @@ func (c *DaemonCommand) boot() (err error) {
 		c.Logger.Debugf("Error loading config file %v: %v", c.ConfigFile, err)
 	}
 	config.Docker.Filters = c.DockerFilters
+	if c.DockerPollInterval != 0 {
+		config.Docker.PollInterval = c.DockerPollInterval
+	}
 
 	if c.LogLevel == "" {
 		ApplyLogLevel(config.Global.LogLevel)

--- a/cli/daemon_boot_test.go
+++ b/cli/daemon_boot_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/netresearch/ofelia/core"
 	logging "github.com/op/go-logging"
@@ -39,7 +40,7 @@ func (s *DaemonBootSuite) TestBootLogsConfigError(c *C) {
 
 	orig := newDockerHandler
 	defer func() { newDockerHandler = orig }()
-	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, filters []string) (*DockerHandler, error) {
+	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, filters []string, interval time.Duration) (*DockerHandler, error) {
 		return nil, errors.New("docker unavailable")
 	}
 
@@ -69,7 +70,7 @@ func (s *DaemonBootSuite) TestBootLogsConfigErrorSuppressed(c *C) {
 
 	orig := newDockerHandler
 	defer func() { newDockerHandler = orig }()
-	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, filters []string) (*DockerHandler, error) {
+	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, filters []string, interval time.Duration) (*DockerHandler, error) {
 		return nil, errors.New("docker unavailable")
 	}
 

--- a/cli/docker_handler_test.go
+++ b/cli/docker_handler_test.go
@@ -3,15 +3,16 @@ package cli
 // SPDX-License-Identifier: MIT
 
 import (
-    // dummyNotifier implements dockerLabelsUpdate for testing
-    "fmt"
-    "net/http"
-    "net/http/httptest"
-    "os"
-    "strings"
+	// dummyNotifier implements dockerLabelsUpdate for testing
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"time"
 
-    . "gopkg.in/check.v1"
-    docker "github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
+	. "gopkg.in/check.v1"
 )
 
 // dummyNotifier implements dockerLabelsUpdate
@@ -26,65 +27,87 @@ var _ = Suite(&DockerHandlerSuite{})
 
 // TestBuildDockerClientError verifies that buildDockerClient returns an error when DOCKER_HOST is invalid
 func (s *DockerHandlerSuite) TestBuildDockerClientError(c *C) {
-    orig := os.Getenv("DOCKER_HOST")
-    defer os.Setenv("DOCKER_HOST", orig)
-    os.Setenv("DOCKER_HOST", "=")
+	orig := os.Getenv("DOCKER_HOST")
+	defer os.Setenv("DOCKER_HOST", orig)
+	os.Setenv("DOCKER_HOST", "=")
 
-    h := &DockerHandler{}
-    _, err := h.buildDockerClient()
-    c.Assert(err, NotNil)
+	h := &DockerHandler{}
+	_, err := h.buildDockerClient()
+	c.Assert(err, NotNil)
 }
 
 // TestNewDockerHandlerErrorInfo verifies that NewDockerHandler returns an error when Info() fails
 func (s *DockerHandlerSuite) TestNewDockerHandlerErrorInfo(c *C) {
-    orig := os.Getenv("DOCKER_HOST")
-    defer os.Setenv("DOCKER_HOST", orig)
-    // Use a host that will refuse connections
-    os.Setenv("DOCKER_HOST", "tcp://127.0.0.1:0")
+	orig := os.Getenv("DOCKER_HOST")
+	defer os.Setenv("DOCKER_HOST", orig)
+	// Use a host that will refuse connections
+	os.Setenv("DOCKER_HOST", "tcp://127.0.0.1:0")
 
-    notifier := &dummyNotifier{}
-    handler, err := NewDockerHandler(notifier, &TestLogger{}, nil)
-    c.Assert(handler, IsNil)
-    c.Assert(err, NotNil)
+	notifier := &dummyNotifier{}
+	handler, err := NewDockerHandler(notifier, &TestLogger{}, nil, time.Second)
+	c.Assert(handler, IsNil)
+	c.Assert(err, NotNil)
+}
+
+// TestNewDockerHandlerInterval verifies that the poll interval is stored
+func (s *DockerHandlerSuite) TestNewDockerHandlerInterval(c *C) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/info" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte("{}"))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
+
+	orig := os.Getenv("DOCKER_HOST")
+	defer os.Setenv("DOCKER_HOST", orig)
+	os.Setenv("DOCKER_HOST", ts.URL)
+
+	notifier := &dummyNotifier{}
+	handler, err := NewDockerHandler(notifier, &TestLogger{}, nil, 2*time.Second)
+	c.Assert(err, IsNil)
+	c.Assert(handler.pollInterval, Equals, 2*time.Second)
 }
 
 // TestGetDockerLabelsInvalidFilter verifies that GetDockerLabels returns an error on invalid filter strings
 func (s *DockerHandlerSuite) TestGetDockerLabelsInvalidFilter(c *C) {
-    h := &DockerHandler{filters: []string{"invalidfilter"}, logger: &TestLogger{}}
-    _, err := h.GetDockerLabels()
-    c.Assert(err, NotNil)
-    c.Assert(err.Error(), Equals, "invalid docker filter: invalidfilter")
+	h := &DockerHandler{filters: []string{"invalidfilter"}, logger: &TestLogger{}}
+	_, err := h.GetDockerLabels()
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "invalid docker filter: invalidfilter")
 }
 
 // TestGetDockerLabelsNoContainers verifies that GetDockerLabels returns ErrNoContainerWithOfeliaEnabled when no containers match
 func (s *DockerHandlerSuite) TestGetDockerLabelsNoContainers(c *C) {
-    // HTTP server returning empty container list
-    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        if strings.HasPrefix(r.URL.Path, "/containers/json") {
-            w.Header().Set("Content-Type", "application/json")
-            w.Write([]byte("[]"))
-            return
-        }
-        http.NotFound(w, r)
-    }))
-    defer ts.Close()
+	// HTTP server returning empty container list
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/containers/json") {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte("[]"))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
 
-    client, err := docker.NewClient(ts.URL)
-    c.Assert(err, IsNil)
+	client, err := docker.NewClient(ts.URL)
+	c.Assert(err, IsNil)
 
-    h := &DockerHandler{filters: []string{}, logger: &TestLogger{}}
-    h.dockerClient = client
-    _, err = h.GetDockerLabels()
-    c.Assert(err, Equals, ErrNoContainerWithOfeliaEnabled)
+	h := &DockerHandler{filters: []string{}, logger: &TestLogger{}}
+	h.dockerClient = client
+	_, err = h.GetDockerLabels()
+	c.Assert(err, Equals, ErrNoContainerWithOfeliaEnabled)
 }
 
 // TestGetDockerLabelsValid verifies that GetDockerLabels filters and returns only ofelia-prefixed labels
 func (s *DockerHandlerSuite) TestGetDockerLabelsValid(c *C) {
-    // HTTP server returning one container with mixed labels
-    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        if strings.HasPrefix(r.URL.Path, "/containers/json") {
-            w.Header().Set("Content-Type", "application/json")
-            fmt.Fprintf(w, `[
+	// HTTP server returning one container with mixed labels
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/containers/json") {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `[
                 {"Names":["/cont1"],"Labels":{
                     "ofelia.enabled":"true",
                     "ofelia.job-exec.foo.schedule":"@every 1s",
@@ -92,26 +115,26 @@ func (s *DockerHandlerSuite) TestGetDockerLabelsValid(c *C) {
                     "other.label":"ignore"
                 }}
             ]`)
-            return
-        }
-        http.NotFound(w, r)
-    }))
-    defer ts.Close()
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
 
-    client, err := docker.NewClient(ts.URL)
-    c.Assert(err, IsNil)
+	client, err := docker.NewClient(ts.URL)
+	c.Assert(err, IsNil)
 
-    h := &DockerHandler{filters: []string{}, logger: &TestLogger{}}
-    h.dockerClient = client
-    labels, err := h.GetDockerLabels()
-    c.Assert(err, IsNil)
+	h := &DockerHandler{filters: []string{}, logger: &TestLogger{}}
+	h.dockerClient = client
+	labels, err := h.GetDockerLabels()
+	c.Assert(err, IsNil)
 
-    expected := map[string]map[string]string{
-        "cont1": {
-            "ofelia.enabled":               "true",
-            "ofelia.job-exec.foo.schedule": "@every 1s",
-            "ofelia.job-run.bar.schedule":  "@every 2s",
-        },
-    }
-    c.Assert(labels, DeepEquals, expected)
+	expected := map[string]map[string]string{
+		"cont1": {
+			"ofelia.enabled":               "true",
+			"ofelia.job-exec.foo.schedule": "@every 1s",
+			"ofelia.job-run.bar.schedule":  "@every 2s",
+		},
+	}
+	c.Assert(labels, DeepEquals, expected)
 }


### PR DESCRIPTION
## Summary
- configure poll interval for Docker handler
- expose CLI flag `--docker-poll-interval`
- document polling interval
- test poll interval initialization

## Testing
- `go test ./...`