### PR TITLE
Add Docker events watching and polling options

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ docker run -it --rm \
 
 **Ofelia** reads labels of all Docker containers for configuration by default. To apply on a subset of containers only, use the flag `--docker-filter` (or `-f`) similar to the [filtering for `docker ps`](https://docs.docker.com/engine/reference/commandline/ps/#filter). E.g. to apply to current docker compose project only using `label` filter:
 
+By default Ofelia polls Docker every 10 seconds for label changes. The interval can be changed with `--docker-poll-interval`. Event based updates can be enabled with `--docker-events`; when enabled, polling can be disabled with `--docker-no-poll`.
+
 ```yaml
 version: "3"
 services:

--- a/cli/config.go
+++ b/cli/config.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"time"
+
 	"github.com/netresearch/ofelia/core"
 	"github.com/netresearch/ofelia/middlewares"
 
@@ -73,7 +75,7 @@ func (c *Config) InitializeApp() error {
 	c.buildSchedulerMiddlewares(c.sh)
 
 	var err error
-	c.dockerHandler, err = newDockerHandler(c, c.logger, c.Docker.Filters)
+	c.dockerHandler, err = newDockerHandler(c, c.logger, &c.Docker)
 	if err != nil {
 		return err
 	}
@@ -344,5 +346,8 @@ func (c *RunServiceConfig) buildMiddlewares() {
 }
 
 type DockerConfig struct {
-	Filters []string `mapstructure:"filters"`
+	Filters        []string      `mapstructure:"filters"`
+	PollInterval   time.Duration `mapstructure:"poll-interval" default:"10s"`
+	UseEvents      bool          `mapstructure:"events" default:"false"`
+	DisablePolling bool          `mapstructure:"no-poll" default:"false"`
 }

--- a/cli/config_extra_test.go
+++ b/cli/config_extra_test.go
@@ -1,12 +1,12 @@
 package cli
 
 import (
+	"errors"
 	"io/ioutil"
 	"os"
-	"errors"
-	
+
 	"github.com/netresearch/ofelia/core"
-	
+
 	. "gopkg.in/check.v1"
 )
 
@@ -40,7 +40,7 @@ func (s *SuiteConfig) TestInitializeAppErrorDockerHandler(c *C) {
 	// Override newDockerHandler to simulate factory error
 	orig := newDockerHandler
 	defer func() { newDockerHandler = orig }()
-	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, filters []string) (*DockerHandler, error) {
+	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig) (*DockerHandler, error) {
 		return nil, errors.New("factory error")
 	}
 
@@ -55,7 +55,7 @@ func (s *SuiteConfig) TestDockerLabelsUpdateExecJobs(c *C) {
 	// Prepare initial Config
 	cfg := NewConfig(&TestLogger{})
 	cfg.logger = &TestLogger{}
-		cfg.dockerHandler = &DockerHandler{}
+	cfg.dockerHandler = &DockerHandler{}
 	cfg.sh = core.NewScheduler(&TestLogger{})
 	cfg.buildSchedulerMiddlewares(cfg.sh)
 	cfg.ExecJobs = make(map[string]*ExecJobConfig)

--- a/cli/config_initialize_test.go
+++ b/cli/config_initialize_test.go
@@ -1,13 +1,13 @@
 package cli
 
 import (
-    "net/http"
-    "net/http/httptest"
-    "testing"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 
-    docker "github.com/fsouza/go-dockerclient"
-    . "gopkg.in/check.v1"
-    "github.com/netresearch/ofelia/core"
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/netresearch/ofelia/core"
+	. "gopkg.in/check.v1"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -19,37 +19,40 @@ var _ = Suite(&ConfigInitSuite{})
 
 // TestInitializeAppSuccess verifies that InitializeApp succeeds when Docker handler connects and no containers are found.
 func (s *ConfigInitSuite) TestInitializeAppSuccess(c *C) {
-    // HTTP test server returning empty container list
-    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        if r.URL.Path == "/containers/json" {
-            w.Header().Set("Content-Type", "application/json")
-            w.Write([]byte("[]"))
-            return
-        }
-        http.NotFound(w, r)
-    }))
-    defer ts.Close()
+	// HTTP test server returning empty container list
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/containers/json" {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte("[]"))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
 
-    // Override newDockerHandler to use the test server
-    origFactory := newDockerHandler
-    defer func() { newDockerHandler = origFactory }()
-    newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, filters []string) (*DockerHandler, error) {
-        client, err := docker.NewClient(ts.URL)
-        if err != nil {
-            return nil, err
-        }
-        return &DockerHandler{
-            filters:      filters,
-            notifier:     notifier,
-            logger:       logger,
-            dockerClient: client,
-        }, nil
-    }
+	// Override newDockerHandler to use the test server
+	origFactory := newDockerHandler
+	defer func() { newDockerHandler = origFactory }()
+	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig) (*DockerHandler, error) {
+		client, err := docker.NewClient(ts.URL)
+		if err != nil {
+			return nil, err
+		}
+		return &DockerHandler{
+			filters:        cfg.Filters,
+			notifier:       notifier,
+			logger:         logger,
+			dockerClient:   client,
+			pollInterval:   cfg.PollInterval,
+			useEvents:      cfg.UseEvents,
+			disablePolling: cfg.DisablePolling,
+		}, nil
+	}
 
-    cfg := NewConfig(&TestLogger{})
-    cfg.Docker.Filters = []string{}
-    err := cfg.InitializeApp()
-    c.Assert(err, IsNil)
-    c.Assert(cfg.sh, NotNil)
-    c.Assert(cfg.dockerHandler, NotNil)
+	cfg := NewConfig(&TestLogger{})
+	cfg.Docker.Filters = []string{}
+	err := cfg.InitializeApp()
+	c.Assert(err, IsNil)
+	c.Assert(cfg.sh, NotNil)
+	c.Assert(cfg.dockerHandler, NotNil)
 }

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -7,17 +7,21 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/netresearch/ofelia/core"
 )
 
 // DaemonCommand daemon process
 type DaemonCommand struct {
-	ConfigFile    string   `long:"config" description:"configuration file" default:"/etc/ofelia.conf"`
-	DockerFilters []string `short:"f" long:"docker-filter" description:"Filter for docker containers"`
-	LogLevel      string   `long:"log-level" description:"Set log level"`
-	EnablePprof   bool     `long:"enable-pprof" description:"Enable the pprof HTTP server"`
-	PprofAddr     string   `long:"pprof-address" description:"Address for the pprof HTTP server to listen on" default:"127.0.0.1:8080"`
+	ConfigFile         string        `long:"config" description:"configuration file" default:"/etc/ofelia.conf"`
+	DockerFilters      []string      `short:"f" long:"docker-filter" description:"Filter for docker containers"`
+	DockerPollInterval time.Duration `long:"docker-poll-interval" description:"Interval for docker polling" default:"10s"`
+	DockerUseEvents    bool          `long:"docker-events" description:"Use docker events instead of polling"`
+	DockerNoPoll       bool          `long:"docker-no-poll" description:"Disable polling docker for labels"`
+	LogLevel           string        `long:"log-level" description:"Set log level"`
+	EnablePprof        bool          `long:"enable-pprof" description:"Enable the pprof HTTP server"`
+	PprofAddr          string        `long:"pprof-address" description:"Address for the pprof HTTP server to listen on" default:"127.0.0.1:8080"`
 
 	scheduler  *core.Scheduler
 	signals    chan os.Signal
@@ -55,6 +59,9 @@ func (c *DaemonCommand) boot() (err error) {
 		c.Logger.Debugf("Error loading config file %v: %v", c.ConfigFile, err)
 	}
 	config.Docker.Filters = c.DockerFilters
+	config.Docker.PollInterval = c.DockerPollInterval
+	config.Docker.UseEvents = c.DockerUseEvents
+	config.Docker.DisablePolling = c.DockerNoPoll
 
 	if c.LogLevel == "" {
 		ApplyLogLevel(config.Global.LogLevel)

--- a/cli/daemon_boot_test.go
+++ b/cli/daemon_boot_test.go
@@ -39,7 +39,7 @@ func (s *DaemonBootSuite) TestBootLogsConfigError(c *C) {
 
 	orig := newDockerHandler
 	defer func() { newDockerHandler = orig }()
-	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, filters []string) (*DockerHandler, error) {
+	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig) (*DockerHandler, error) {
 		return nil, errors.New("docker unavailable")
 	}
 
@@ -69,7 +69,7 @@ func (s *DaemonBootSuite) TestBootLogsConfigErrorSuppressed(c *C) {
 
 	orig := newDockerHandler
 	defer func() { newDockerHandler = orig }()
-	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, filters []string) (*DockerHandler, error) {
+	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig) (*DockerHandler, error) {
 		return nil, errors.New("docker unavailable")
 	}
 

--- a/cli/docker_handler_test.go
+++ b/cli/docker_handler_test.go
@@ -3,21 +3,32 @@ package cli
 // SPDX-License-Identifier: MIT
 
 import (
-    // dummyNotifier implements dockerLabelsUpdate for testing
-    "fmt"
-    "net/http"
-    "net/http/httptest"
-    "os"
-    "strings"
+	// dummyNotifier implements dockerLabelsUpdate for testing
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"time"
 
-    . "gopkg.in/check.v1"
-    docker "github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/fsouza/go-dockerclient/testing"
+	. "gopkg.in/check.v1"
 )
 
 // dummyNotifier implements dockerLabelsUpdate
 type dummyNotifier struct{}
 
 func (d *dummyNotifier) dockerLabelsUpdate(labels map[string]map[string]string) {}
+
+type chanNotifier struct{ ch chan struct{} }
+
+func (d *chanNotifier) dockerLabelsUpdate(labels map[string]map[string]string) {
+	select {
+	case d.ch <- struct{}{}:
+	default:
+	}
+}
 
 // DockerHandlerSuite contains tests for DockerHandler methods
 type DockerHandlerSuite struct{}
@@ -26,65 +37,65 @@ var _ = Suite(&DockerHandlerSuite{})
 
 // TestBuildDockerClientError verifies that buildDockerClient returns an error when DOCKER_HOST is invalid
 func (s *DockerHandlerSuite) TestBuildDockerClientError(c *C) {
-    orig := os.Getenv("DOCKER_HOST")
-    defer os.Setenv("DOCKER_HOST", orig)
-    os.Setenv("DOCKER_HOST", "=")
+	orig := os.Getenv("DOCKER_HOST")
+	defer os.Setenv("DOCKER_HOST", orig)
+	os.Setenv("DOCKER_HOST", "=")
 
-    h := &DockerHandler{}
-    _, err := h.buildDockerClient()
-    c.Assert(err, NotNil)
+	h := &DockerHandler{}
+	_, err := h.buildDockerClient()
+	c.Assert(err, NotNil)
 }
 
 // TestNewDockerHandlerErrorInfo verifies that NewDockerHandler returns an error when Info() fails
 func (s *DockerHandlerSuite) TestNewDockerHandlerErrorInfo(c *C) {
-    orig := os.Getenv("DOCKER_HOST")
-    defer os.Setenv("DOCKER_HOST", orig)
-    // Use a host that will refuse connections
-    os.Setenv("DOCKER_HOST", "tcp://127.0.0.1:0")
+	orig := os.Getenv("DOCKER_HOST")
+	defer os.Setenv("DOCKER_HOST", orig)
+	// Use a host that will refuse connections
+	os.Setenv("DOCKER_HOST", "tcp://127.0.0.1:0")
 
-    notifier := &dummyNotifier{}
-    handler, err := NewDockerHandler(notifier, &TestLogger{}, nil)
-    c.Assert(handler, IsNil)
-    c.Assert(err, NotNil)
+	notifier := &dummyNotifier{}
+	handler, err := NewDockerHandler(notifier, &TestLogger{}, &DockerConfig{})
+	c.Assert(handler, IsNil)
+	c.Assert(err, NotNil)
 }
 
 // TestGetDockerLabelsInvalidFilter verifies that GetDockerLabels returns an error on invalid filter strings
 func (s *DockerHandlerSuite) TestGetDockerLabelsInvalidFilter(c *C) {
-    h := &DockerHandler{filters: []string{"invalidfilter"}, logger: &TestLogger{}}
-    _, err := h.GetDockerLabels()
-    c.Assert(err, NotNil)
-    c.Assert(err.Error(), Equals, "invalid docker filter: invalidfilter")
+	h := &DockerHandler{filters: []string{"invalidfilter"}, logger: &TestLogger{}}
+	_, err := h.GetDockerLabels()
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "invalid docker filter: invalidfilter")
 }
 
 // TestGetDockerLabelsNoContainers verifies that GetDockerLabels returns ErrNoContainerWithOfeliaEnabled when no containers match
 func (s *DockerHandlerSuite) TestGetDockerLabelsNoContainers(c *C) {
-    // HTTP server returning empty container list
-    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        if strings.HasPrefix(r.URL.Path, "/containers/json") {
-            w.Header().Set("Content-Type", "application/json")
-            w.Write([]byte("[]"))
-            return
-        }
-        http.NotFound(w, r)
-    }))
-    defer ts.Close()
+	// HTTP server returning empty container list
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/containers/json") {
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte("[]"))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
 
-    client, err := docker.NewClient(ts.URL)
-    c.Assert(err, IsNil)
+	client, err := docker.NewClient(ts.URL)
+	c.Assert(err, IsNil)
 
-    h := &DockerHandler{filters: []string{}, logger: &TestLogger{}}
-    h.dockerClient = client
-    _, err = h.GetDockerLabels()
-    c.Assert(err, Equals, ErrNoContainerWithOfeliaEnabled)
+	h := &DockerHandler{filters: []string{}, logger: &TestLogger{}}
+	h.dockerClient = client
+	_, err = h.GetDockerLabels()
+	c.Assert(err, Equals, ErrNoContainerWithOfeliaEnabled)
 }
 
 // TestGetDockerLabelsValid verifies that GetDockerLabels filters and returns only ofelia-prefixed labels
 func (s *DockerHandlerSuite) TestGetDockerLabelsValid(c *C) {
-    // HTTP server returning one container with mixed labels
-    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        if strings.HasPrefix(r.URL.Path, "/containers/json") {
-            w.Header().Set("Content-Type", "application/json")
-            fmt.Fprintf(w, `[
+	// HTTP server returning one container with mixed labels
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/containers/json") {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `[
                 {"Names":["/cont1"],"Labels":{
                     "ofelia.enabled":"true",
                     "ofelia.job-exec.foo.schedule":"@every 1s",
@@ -92,26 +103,54 @@ func (s *DockerHandlerSuite) TestGetDockerLabelsValid(c *C) {
                     "other.label":"ignore"
                 }}
             ]`)
-            return
-        }
-        http.NotFound(w, r)
-    }))
-    defer ts.Close()
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer ts.Close()
 
-    client, err := docker.NewClient(ts.URL)
-    c.Assert(err, IsNil)
+	client, err := docker.NewClient(ts.URL)
+	c.Assert(err, IsNil)
 
-    h := &DockerHandler{filters: []string{}, logger: &TestLogger{}}
-    h.dockerClient = client
-    labels, err := h.GetDockerLabels()
-    c.Assert(err, IsNil)
+	h := &DockerHandler{filters: []string{}, logger: &TestLogger{}}
+	h.dockerClient = client
+	labels, err := h.GetDockerLabels()
+	c.Assert(err, IsNil)
 
-    expected := map[string]map[string]string{
-        "cont1": {
-            "ofelia.enabled":               "true",
-            "ofelia.job-exec.foo.schedule": "@every 1s",
-            "ofelia.job-run.bar.schedule":  "@every 2s",
-        },
-    }
-    c.Assert(labels, DeepEquals, expected)
+	expected := map[string]map[string]string{
+		"cont1": {
+			"ofelia.enabled":               "true",
+			"ofelia.job-exec.foo.schedule": "@every 1s",
+			"ofelia.job-run.bar.schedule":  "@every 2s",
+		},
+	}
+	c.Assert(labels, DeepEquals, expected)
+}
+
+// TestPollingDisabled ensures no updates are triggered when polling is disabled and no events occur
+func (s *DockerHandlerSuite) TestPollingDisabled(c *C) {
+	ch := make(chan struct{}, 1)
+	notifier := &chanNotifier{ch: ch}
+
+	server, err := testing.NewServer("127.0.0.1:0", nil, nil)
+	c.Assert(err, IsNil)
+	defer server.Stop()
+	server.CustomHandler("/containers/json", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `[{"Names":["/cont"],"Labels":{"ofelia.enabled":"true"}}]`)
+	}))
+	tsURL := server.URL()
+
+	os.Setenv("DOCKER_HOST", "tcp://"+strings.TrimPrefix(tsURL, "http://"))
+	defer os.Unsetenv("DOCKER_HOST")
+
+	cfg := &DockerConfig{Filters: []string{}, PollInterval: time.Millisecond * 50, UseEvents: false, DisablePolling: true}
+	_, err = NewDockerHandler(notifier, &TestLogger{}, cfg)
+	c.Assert(err, IsNil)
+
+	select {
+	case <-ch:
+		c.Error("unexpected update")
+	case <-time.After(time.Millisecond * 150):
+	}
 }


### PR DESCRIPTION
## Summary
- add PollInterval, UseEvents and DisablePolling fields to DockerConfig
- expose `--docker-poll-interval`, `--docker-events`, `--docker-no-poll` flags
- update DockerHandler to respect polling options and handle docker events
- document new options in README
- adjust tests and add polling disable test

## Testing
- `go test ./...`
