### PR TITLE
Add Docker events watching and polling options

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ docker run -it --rm \
         nginx
 ```
 
-**Ofelia** reads labels of all Docker containers for configuration by default. To apply on a subset of containers only, use the flag `--docker-filter` (or `-f`) similar to the [filtering for `docker ps`](https://docs.docker.com/engine/reference/commandline/ps/#filter). E.g. to apply to current docker compose project only using `label` filter:
+**Ofelia** reads labels of all Docker containers for configuration by default. To apply on a subset of containers only, use the flag `--docker-filter` (or `-f`) similar to the [filtering for `docker ps`](https://docs.docker.com/engine/reference/commandline/ps/#filter). E.g. to apply only to the current Docker Compose project using a `label` filter:
 
 You can also configure how often Ofelia polls Docker for label changes. The default interval is `10s`. Override it with `--docker-poll-interval` or the `poll-interval` option in the `[docker]` section of the config file.
 
@@ -159,6 +159,11 @@ services:
       ofelia.job-exec.datecron.schedule: "@every 5s"
       ofelia.job-exec.datecron.command: "uname -a"
 ```
+
+Ofelia polls Docker every 10 seconds to detect label changes. The interval can
+be adjusted using `--docker-poll-interval`. Event-based updates can be enabled
+with `--docker-events`; when enabled, polling can be disabled entirely with
+`--docker-no-poll`.
 
 ### Dynamic Docker configuration
 

--- a/cli/config.go
+++ b/cli/config.go
@@ -75,7 +75,7 @@ func (c *Config) InitializeApp() error {
 	c.buildSchedulerMiddlewares(c.sh)
 
 	var err error
-	c.dockerHandler, err = newDockerHandler(c, c.logger, c.Docker.Filters, c.Docker.PollInterval)
+	c.dockerHandler, err = newDockerHandler(c, c.logger, &c.Docker)
 	if err != nil {
 		return err
 	}
@@ -346,6 +346,8 @@ func (c *RunServiceConfig) buildMiddlewares() {
 }
 
 type DockerConfig struct {
-	Filters      []string      `mapstructure:"filters"`
-	PollInterval time.Duration `gcfg:"poll-interval" mapstructure:"poll-interval" default:"10s"`
+	Filters        []string      `mapstructure:"filters"`
+	PollInterval   time.Duration `mapstructure:"poll-interval" default:"10s"`
+	UseEvents      bool          `mapstructure:"events" default:"false"`
+	DisablePolling bool          `mapstructure:"no-poll" default:"false"`
 }

--- a/cli/config_extra_test.go
+++ b/cli/config_extra_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
-	"time"
 
 	"github.com/netresearch/ofelia/core"
 
@@ -41,7 +40,7 @@ func (s *SuiteConfig) TestInitializeAppErrorDockerHandler(c *C) {
 	// Override newDockerHandler to simulate factory error
 	orig := newDockerHandler
 	defer func() { newDockerHandler = orig }()
-	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, filters []string, interval time.Duration) (*DockerHandler, error) {
+	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig) (*DockerHandler, error) {
 		return nil, errors.New("factory error")
 	}
 

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -16,7 +16,9 @@ import (
 type DaemonCommand struct {
 	ConfigFile         string        `long:"config" description:"configuration file" default:"/etc/ofelia.conf"`
 	DockerFilters      []string      `short:"f" long:"docker-filter" description:"Filter for docker containers"`
-	DockerPollInterval time.Duration `long:"docker-poll-interval" description:"Interval for polling docker events"`
+	DockerPollInterval time.Duration `long:"docker-poll-interval" description:"Interval for docker polling" default:"10s"`
+	DockerUseEvents    bool          `long:"docker-events" description:"Use docker events instead of polling"`
+	DockerNoPoll       bool          `long:"docker-no-poll" description:"Disable polling docker for labels"`
 	LogLevel           string        `long:"log-level" description:"Set log level"`
 	EnablePprof        bool          `long:"enable-pprof" description:"Enable the pprof HTTP server"`
 	PprofAddr          string        `long:"pprof-address" description:"Address for the pprof HTTP server to listen on" default:"127.0.0.1:8080"`
@@ -57,9 +59,9 @@ func (c *DaemonCommand) boot() (err error) {
 		c.Logger.Debugf("Error loading config file %v: %v", c.ConfigFile, err)
 	}
 	config.Docker.Filters = c.DockerFilters
-	if c.DockerPollInterval != 0 {
-		config.Docker.PollInterval = c.DockerPollInterval
-	}
+	config.Docker.PollInterval = c.DockerPollInterval
+	config.Docker.UseEvents = c.DockerUseEvents
+	config.Docker.DisablePolling = c.DockerNoPoll
 
 	if c.LogLevel == "" {
 		ApplyLogLevel(config.Global.LogLevel)

--- a/cli/daemon_boot_test.go
+++ b/cli/daemon_boot_test.go
@@ -40,7 +40,7 @@ func (s *DaemonBootSuite) TestBootLogsConfigError(c *C) {
 
 	orig := newDockerHandler
 	defer func() { newDockerHandler = orig }()
-	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, filters []string, interval time.Duration) (*DockerHandler, error) {
+	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig) (*DockerHandler, error) {
 		return nil, errors.New("docker unavailable")
 	}
 
@@ -70,7 +70,7 @@ func (s *DaemonBootSuite) TestBootLogsConfigErrorSuppressed(c *C) {
 
 	orig := newDockerHandler
 	defer func() { newDockerHandler = orig }()
-	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, filters []string, interval time.Duration) (*DockerHandler, error) {
+	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig) (*DockerHandler, error) {
 		return nil, errors.New("docker unavailable")
 	}
 

--- a/cli/daemon_boot_test.go
+++ b/cli/daemon_boot_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/netresearch/ofelia/core"
 	logging "github.com/op/go-logging"

--- a/cli/docker_config_handler.go
+++ b/cli/docker_config_handler.go
@@ -12,11 +12,13 @@ import (
 var ErrNoContainerWithOfeliaEnabled = errors.New("Couldn't find containers with label 'ofelia.enabled=true'")
 
 type DockerHandler struct {
-	filters      []string
-	dockerClient *docker.Client
-	notifier     dockerLabelsUpdate
-	logger       core.Logger
-	pollInterval time.Duration
+	filters        []string
+	dockerClient   *docker.Client
+	notifier       dockerLabelsUpdate
+	logger         core.Logger
+	pollInterval   time.Duration
+	useEvents      bool
+	disablePolling bool
 }
 
 type dockerLabelsUpdate interface {
@@ -42,12 +44,14 @@ func (c *DockerHandler) buildDockerClient() (*docker.Client, error) {
 	return client, nil
 }
 
-func NewDockerHandler(notifier dockerLabelsUpdate, logger core.Logger, filters []string, interval time.Duration) (*DockerHandler, error) {
+func NewDockerHandler(notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig) (*DockerHandler, error) {
 	c := &DockerHandler{
-		filters:      filters,
-		notifier:     notifier,
-		logger:       logger,
-		pollInterval: interval,
+		filters:        cfg.Filters,
+		notifier:       notifier,
+		logger:         logger,
+		pollInterval:   cfg.PollInterval,
+		useEvents:      cfg.UseEvents,
+		disablePolling: cfg.DisablePolling,
 	}
 
 	var err error
@@ -61,24 +65,24 @@ func NewDockerHandler(notifier dockerLabelsUpdate, logger core.Logger, filters [
 		return nil, err
 	}
 
-	go c.watch()
+	if !c.disablePolling {
+		go c.watch()
+	}
+	if c.useEvents {
+		go c.watchEvents()
+	}
 	return c, nil
 }
 
 func (c *DockerHandler) watch() {
-	// Poll for changes
 	ticker := time.NewTicker(c.pollInterval)
 	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			labels, err := c.GetDockerLabels()
-			// Do not print or care if there is no container up right now
-			if err != nil && !errors.Is(err, ErrNoContainerWithOfeliaEnabled) {
-				c.logger.Debugf("%v", err)
-			}
-			c.notifier.dockerLabelsUpdate(labels)
+	for range ticker.C {
+		labels, err := c.GetDockerLabels()
+		if err != nil && !errors.Is(err, ErrNoContainerWithOfeliaEnabled) {
+			c.logger.Debugf("%v", err)
 		}
+		c.notifier.dockerLabelsUpdate(labels)
 	}
 }
 
@@ -129,4 +133,21 @@ func (c *DockerHandler) GetDockerLabels() (map[string]map[string]string, error) 
 	}
 
 	return labels, nil
+}
+
+func (c *DockerHandler) watchEvents() {
+	ch := make(chan *docker.APIEvents)
+	if err := c.dockerClient.AddEventListenerWithOptions(docker.EventsOptions{
+		Filters: map[string][]string{"type": {"container"}},
+	}, ch); err != nil {
+		c.logger.Debugf("%v", err)
+		return
+	}
+	for range ch {
+		labels, err := c.GetDockerLabels()
+		if err != nil && !errors.Is(err, ErrNoContainerWithOfeliaEnabled) {
+			c.logger.Debugf("%v", err)
+		}
+		c.notifier.dockerLabelsUpdate(labels)
+	}
 }


### PR DESCRIPTION
## Summary
- add PollInterval, UseEvents and DisablePolling fields to DockerConfig
- expose `--docker-poll-interval`, `--docker-events`, `--docker-no-poll` flags
- update DockerHandler to respect polling options and handle docker events
- document new options in README
- adjust tests and add polling disable test
- clarify docs about docker polling options

## Testing
- `go test ./...`
