### PR TITLE
Fix service config typo

### DIFF
--- a/test/test-config.ini
+++ b/test/test-config.ini
@@ -1,4 +1,4 @@
-[job-service-run "servie-executed-on-new-container"]
+[job-service-run "service-executed-on-new-container"]
 schedule = 0,20,40 * * * *
 image = ubuntu
 command =  sleep 10


### PR DESCRIPTION
## Summary
- fix typo in `test/test-config.ini` service name

## Testing
- `go test ./...`
