### PR TITLE
Handle cron logger key-value pairs

### DIFF
--- a/core/cron_utils.go
+++ b/core/cron_utils.go
@@ -1,5 +1,7 @@
 package core
 
+import "strings"
+
 // Implement the cron logger interface
 type CronUtils struct {
 	Logger Logger
@@ -10,9 +12,30 @@ func NewCronUtils(l Logger) *CronUtils {
 }
 
 func (c *CronUtils) Info(msg string, keysAndValues ...interface{}) {
-	c.Logger.Debugf(msg) // TODO, pass in the keysAndValues
+	format := cronFormatString(len(keysAndValues))
+	args := append([]interface{}{msg}, keysAndValues...)
+	c.Logger.Debugf(format, args...)
 }
 
 func (c *CronUtils) Error(err error, msg string, keysAndValues ...interface{}) {
-	c.Logger.Errorf("msg: %v, error: %v", msg, err) // TODO, pass in the keysAndValues
+	format := cronFormatString(len(keysAndValues) + 2)
+	args := append([]interface{}{msg, "error", err}, keysAndValues...)
+	c.Logger.Errorf(format, args...)
+}
+
+// cronFormatString returns a logfmt-like format string for the number of
+// key/value pairs. This mirrors the format used by robfig/cron.
+func cronFormatString(numKeysAndValues int) string {
+	var sb strings.Builder
+	sb.WriteString("%s")
+	if numKeysAndValues > 0 {
+		sb.WriteString(", ")
+	}
+	for i := 0; i < numKeysAndValues/2; i++ {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString("%v=%v")
+	}
+	return sb.String()
 }

--- a/core/cron_utils_test.go
+++ b/core/cron_utils_test.go
@@ -1,0 +1,52 @@
+package core
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+// stubLogger and logCall are defined in context_log_test.go and reused here.
+
+func TestCronUtilsInfoForwardsArgs(t *testing.T) {
+	logger := &stubLogger{}
+	cu := NewCronUtils(logger)
+	cu.Info("msg", "a", 1, "b", 2)
+	if len(logger.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(logger.calls))
+	}
+	call := logger.calls[0]
+	if call.method != "Debugf" {
+		t.Errorf("expected method Debugf, got %s", call.method)
+	}
+	expectedFormat := cronFormatString(4)
+	if call.format != expectedFormat {
+		t.Errorf("expected format %q, got %q", expectedFormat, call.format)
+	}
+	wantArgs := []interface{}{"msg", "a", 1, "b", 2}
+	if !reflect.DeepEqual(call.args, wantArgs) {
+		t.Errorf("expected args %v, got %v", wantArgs, call.args)
+	}
+}
+
+func TestCronUtilsErrorForwardsArgs(t *testing.T) {
+	logger := &stubLogger{}
+	cu := NewCronUtils(logger)
+	err := errors.New("boom")
+	cu.Error(err, "fail", "k", "v")
+	if len(logger.calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(logger.calls))
+	}
+	call := logger.calls[0]
+	if call.method != "Errorf" {
+		t.Errorf("expected method Errorf, got %s", call.method)
+	}
+	expectedFormat := cronFormatString(4)
+	if call.format != expectedFormat {
+		t.Errorf("expected format %q, got %q", expectedFormat, call.format)
+	}
+	wantArgs := []interface{}{"fail", "error", err, "k", "v"}
+	if !reflect.DeepEqual(call.args, wantArgs) {
+		t.Errorf("expected args %v, got %v", wantArgs, call.args)
+	}
+}


### PR DESCRIPTION
## Summary
- pass cron Info/Error values to the wrapped logger
- add tests ensuring CronUtils forwards logging arguments

## Testing
- `go test ./...`