### PR TITLE
Scope exec jobs by container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ docker run -it --rm \
 
 Labels format: `ofelia.<JOB_TYPE>.<JOB_NAME>.<JOB_PARAMETER>=<PARAMETER_VALUE>`.
 This type of configuration supports all the capabilities provided by INI files, including the global logging options.
+For `job-exec` labels, Ofelia automatically prefixes the container name to the job name to avoid collisions. A label `ofelia.job-exec.optimize` on a container named `gitlab` will result in a job called `gitlab.optimize`.
 
 Also, it is possible to configure `job-exec` by setting labels configurations on the target container. To do that, additional label `ofelia.enabled=true` need to be present on the target container.
 

--- a/cli/config_extra_test.go
+++ b/cli/config_extra_test.go
@@ -69,7 +69,7 @@ func (s *SuiteConfig) TestDockerLabelsUpdateExecJobs(c *C) {
 	}
 	cfg.dockerLabelsUpdate(labelsAdd)
 	c.Assert(len(cfg.ExecJobs), Equals, 1)
-	j := cfg.ExecJobs["foo"]
+	j := cfg.ExecJobs["container1.foo"]
 	// Verify schedule and command set
 	c.Assert(j.GetSchedule(), Equals, "@every 5s")
 	c.Assert(j.GetCommand(), Equals, "echo foo")
@@ -87,7 +87,7 @@ func (s *SuiteConfig) TestDockerLabelsUpdateExecJobs(c *C) {
 	}
 	cfg.dockerLabelsUpdate(labelsChange)
 	c.Assert(len(cfg.ExecJobs), Equals, 1)
-	j2 := cfg.ExecJobs["foo"]
+	j2 := cfg.ExecJobs["container1.foo"]
 	c.Assert(j2.GetSchedule(), Equals, "@every 10s")
 	entries = cfg.sh.Entries()
 	c.Assert(len(entries), Equals, 1)

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -286,11 +286,11 @@ func (s *SuiteConfig) TestLabelsConfig(c *C) {
 			},
 			ExpectedConfig: Config{
 				ExecJobs: map[string]*ExecJobConfig{
-					"job1": &ExecJobConfig{ExecJob: core.ExecJob{BareJob: core.BareJob{
+					"some.job1": &ExecJobConfig{ExecJob: core.ExecJob{BareJob: core.BareJob{
 						Schedule: "schedule1",
 						Command:  "command1",
 					}}},
-					"job2": &ExecJobConfig{ExecJob: core.ExecJob{
+					"other.job2": &ExecJobConfig{ExecJob: core.ExecJob{
 						BareJob: core.BareJob{
 							Schedule: "schedule2",
 							Command:  "command2",
@@ -313,7 +313,7 @@ func (s *SuiteConfig) TestLabelsConfig(c *C) {
 			},
 			ExpectedConfig: Config{
 				ExecJobs: map[string]*ExecJobConfig{
-					"job1": &ExecJobConfig{ExecJob: core.ExecJob{BareJob: core.BareJob{
+					"some.job1": &ExecJobConfig{ExecJob: core.ExecJob{BareJob: core.BareJob{
 						Schedule: "schedule1",
 						Command:  "command1",
 					}},

--- a/cli/docker-labels.go
+++ b/cli/docker-labels.go
@@ -43,17 +43,21 @@ func (c *Config) buildFromDockerLabels(labels map[string]map[string]string) erro
 			}
 
 			jobType, jobName, jopParam := parts[1], parts[2], parts[3]
+			scopedJobName := jobName
+			if jobType == jobExec {
+				scopedJobName = c + "." + jobName
+			}
 			switch {
 			case jobType == jobExec: // only job exec can be provided on the non-service container
-				if _, ok := execJobs[jobName]; !ok {
-					execJobs[jobName] = make(map[string]interface{})
+				if _, ok := execJobs[scopedJobName]; !ok {
+					execJobs[scopedJobName] = make(map[string]interface{})
 				}
 
-				setJobParam(execJobs[jobName], jopParam, v)
+				setJobParam(execJobs[scopedJobName], jopParam, v)
 				// since this label was placed not on the service container
 				// this means we need to `exec` command in this container
 				if !isServiceContainer {
-					execJobs[jobName]["container"] = c
+					execJobs[scopedJobName]["container"] = c
 				}
 			case jobType == jobLocal && isServiceContainer:
 				if _, ok := localJobs[jobName]; !ok {

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -52,6 +52,8 @@ docker run -it --rm \
         nginx
 ```
 
+When specifying exec jobs via labels, Ofelia adds the container name as a prefix to the job name. This prevents jobs from different containers with the same label from clashing. In the example above, the job will be called `nginx.flush-nginx-logs`.
+
 ## `run`
 
 This job can be used in 2 situations:


### PR DESCRIPTION
## Summary
- prefix job-exec names with the container name when reading labels
- adjust tests for container-scoped job names
- document automatic job name scoping in README and docs

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.25.0.3:8080: connect: no route to host)*