### PR TITLE
Add architecture and testing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ You can configure four different kinds of jobs:
 - `job-service-run`: runs the command inside a new "run-once" service, for running inside a swarm
 
 See [Jobs reference documentation](docs/jobs.md) for all available parameters.
+See [Architecture overview](docs/architecture.md) for details about the scheduler, job types and middleware.
 
 ### Logging
 
@@ -216,3 +217,7 @@ gofmt -l $(git ls-files '*.go')
 ```
 
 The pipeline fails if any file is not properly formatted or if `go vet` reports issues.
+
+### Testing
+
+See [running tests](docs/tests.md) for Docker requirements and how to run `go test`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,21 @@
+# Architecture Overview
+
+Ofelia is built around a pluggable scheduler that manages different job types and middleware.
+
+## Scheduler
+
+The scheduler wraps [robfig/cron](https://github.com/robfig/cron) and keeps track of all registered jobs. It runs them according to their cron expressions and exposes methods to start or stop execution. Each job is wrapped so execution metadata and middleware can be handled.
+
+## Job types
+
+Jobs implement a common interface and can be executed in several ways:
+
+- **`exec`** – run a command inside an existing container similar to `docker exec`.
+- **`run`** – start a new container for every execution.
+- **`local`** – execute a command on the host where Ofelia runs.
+- **`service-run`** – run a one‑off service in a Docker swarm.
+
+## Middleware
+
+Middleware hooks are executed around every job. Ofelia provides built-in middleware for logging via mail, saving execution reports and sending Slack messages. Custom middleware can be added by implementing the interface in `core` and attaching it to the scheduler or to individual jobs.
+

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,0 +1,12 @@
+# Running Tests
+
+The unit tests expect Go to be installed and a Docker daemon available. The CI pipeline starts Docker before running the test suite.
+
+1. Install Docker and make sure the daemon is running.
+2. Fetch dependencies and run the tests:
+
+```sh
+go test ./...
+```
+
+Some tests start a mocked Docker server and do not require network access, but Docker must be present so the client library works correctly.


### PR DESCRIPTION
## Summary
- document scheduler, job types and middleware
- add instructions for running tests
- link new docs from README

## Testing
- `go vet ./...`
- `go test ./...`
