### PR TITLE
Add INI reload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Label your Docker containers and let this Go-powered daemon handle the schedule.
 - **Logging middlewares** integrate with systems like Slack or StatsD to report
   job output and status.
 - **Dynamic Docker detection** polls containers at an interval controlled by
-  `--docker-poll-interval` or listens for events with `--docker-events`.
+  `--docker-poll-interval` or listens for events with `--docker-events`. The same
+  interval also controls automatic reloads of `ofelia.ini`.
 - **Config validation** via the `validate` command to check your configuration
   before running.
 - **Optional pprof server** enabled with `--enable-pprof` and bound via
@@ -194,7 +195,10 @@ via `ofelia.ini`.
 
 **Ofelia** reads labels of all Docker containers for configuration by default. To apply on a subset of containers only, use the flag `--docker-filter` (or `-f`) similar to the [filtering for `docker ps`](https://docs.docker.com/engine/reference/commandline/ps/#filter). E.g. to apply only to the current Docker Compose project using a `label` filter:
 
-You can also configure how often Ofelia polls Docker for label changes. The default interval is `10s`. Override it with `--docker-poll-interval` or the `poll-interval` option in the `[docker]` section of the config file.
+You can also configure how often Ofelia polls Docker for label changes and reloads
+the INI configuration. The default interval is `10s`. Override it with
+`--docker-poll-interval` or the `poll-interval` option in the `[docker]` section
+of the config file. Set it to `0` to disable both polling and automatic reloads.
 
 ```yaml
 version: "3"
@@ -217,10 +221,11 @@ services:
       ofelia.job-exec.datecron.command: "uname -a"
 ```
 
-Ofelia polls Docker every 10 seconds to detect label changes. The interval can
-be adjusted using `--docker-poll-interval`. Event-based updates can be enabled
-with `--docker-events`; when enabled, polling can be disabled entirely with
-`--docker-no-poll`.
+Ofelia polls Docker every 10 seconds to detect label changes and reload the INI
+file. The interval can be adjusted using `--docker-poll-interval`. Event-based
+updates can be enabled with `--docker-events`; when enabled, polling can be
+disabled entirely with `--docker-no-poll`. Setting the interval to `0` also
+disables both label polling and INI reloads.
 
 ### Dynamic Docker configuration
 

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -17,7 +17,7 @@ import (
 type DaemonCommand struct {
 	ConfigFile         string        `long:"config" description:"configuration file" default:"/etc/ofelia.conf"`
 	DockerFilters      []string      `short:"f" long:"docker-filter" description:"Filter for docker containers"`
-	DockerPollInterval time.Duration `long:"docker-poll-interval" description:"Interval for docker polling" default:"10s"`
+	DockerPollInterval time.Duration `long:"docker-poll-interval" description:"Interval for docker polling and INI reload (0 disables)" default:"10s"`
 	DockerUseEvents    bool          `long:"docker-events" description:"Use docker events instead of polling"`
 	DockerNoPoll       bool          `long:"docker-no-poll" description:"Disable polling docker for labels"`
 	LogLevel           string        `long:"log-level" description:"Set log level"`

--- a/cli/docker_config_handler.go
+++ b/cli/docker_config_handler.go
@@ -79,7 +79,7 @@ func NewDockerHandler(notifier dockerLabelsUpdate, logger core.Logger, cfg *Dock
 		return nil, err
 	}
 
-	if !c.disablePolling {
+	if !c.disablePolling && c.pollInterval > 0 {
 		go c.watch()
 	}
 	if c.useEvents {
@@ -97,6 +97,11 @@ func (c *DockerHandler) watch() {
 			c.logger.Debugf("%v", err)
 		}
 		c.notifier.dockerLabelsUpdate(labels)
+		if cfg, ok := c.notifier.(*Config); ok {
+			if err := cfg.iniConfigUpdate(); err != nil {
+				c.logger.Debugf("%v", err)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- store config file path in `Config`
- reparse INI file on each poll interval and apply job diffs
- call INI reload from Docker polling loop
- allow poll interval 0 to disable label polling and INI reload
- document new behaviour in help text and README
- test `iniConfigUpdate`

## Testing
- `go vet ./...`
- `go test ./...`