### PR TITLE
Fix docker handler ticker when poll interval <=0

### DIFF
--- a/cli/docker_config_handler.go
+++ b/cli/docker_config_handler.go
@@ -89,6 +89,11 @@ func NewDockerHandler(notifier dockerLabelsUpdate, logger core.Logger, cfg *Dock
 }
 
 func (c *DockerHandler) watch() {
+	if c.pollInterval <= 0 {
+		// Skip polling when interval is not positive
+		return
+	}
+
 	ticker := time.NewTicker(c.pollInterval)
 	defer ticker.Stop()
 	for range ticker.C {

--- a/cli/docker_handler_test.go
+++ b/cli/docker_handler_test.go
@@ -154,3 +154,35 @@ func (s *DockerHandlerSuite) TestPollingDisabled(c *C) {
 	case <-time.After(time.Millisecond * 150):
 	}
 }
+
+// TestWatchInvalidInterval verifies that watch exits immediately when
+// PollInterval is zero or negative.
+func (s *DockerHandlerSuite) TestWatchInvalidInterval(c *C) {
+	h := &DockerHandler{pollInterval: 0, notifier: &dummyNotifier{}, logger: &TestLogger{}}
+	done := make(chan struct{})
+	go func() {
+		h.watch()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// ok
+	case <-time.After(time.Millisecond * 50):
+		c.Error("watch did not return for zero interval")
+	}
+
+	h = &DockerHandler{pollInterval: -time.Second, notifier: &dummyNotifier{}, logger: &TestLogger{}}
+	done = make(chan struct{})
+	go func() {
+		h.watch()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// ok
+	case <-time.After(time.Millisecond * 50):
+		c.Error("watch did not return for negative interval")
+	}
+}


### PR DESCRIPTION
## Summary
- prevent ticker panic for non-positive Docker poll interval
- test watch exits immediately for zero and negative interval

## Testing
- `go vet ./...`
- `go test ./...`
