### PR TITLE
Add history limit for jobs

### DIFF
--- a/core/bare_job.go
+++ b/core/bare_job.go
@@ -7,9 +7,10 @@ import (
 )
 
 type BareJob struct {
-	Schedule string `hash:"true"`
-	Name     string `hash:"true"`
-	Command  string `hash:"true"`
+	Schedule     string `hash:"true"`
+	Name         string `hash:"true"`
+	Command      string `hash:"true"`
+	HistoryLimit int    `default:"10"`
 
 	middlewareContainer
 	running int32
@@ -64,6 +65,9 @@ func (j *BareJob) SetLastRun(e *Execution) {
 	defer j.lock.Unlock()
 	j.lastRun = e
 	j.history = append(j.history, e)
+	if j.HistoryLimit > 0 && len(j.history) > j.HistoryLimit {
+		j.history = j.history[len(j.history)-j.HistoryLimit:]
+	}
 }
 
 // GetLastRun returns the last execution of the job, if any.

--- a/core/bare_job_test.go
+++ b/core/bare_job_test.go
@@ -27,3 +27,21 @@ func (s *SuiteBareJob) TestNotifyStartStop(c *C) {
 	job.NotifyStop()
 	c.Assert(job.Running(), Equals, int32(0))
 }
+
+func (s *SuiteBareJob) TestHistoryTruncation(c *C) {
+	job := &BareJob{HistoryLimit: 2}
+	e1, e2, e3 := &Execution{}, &Execution{}, &Execution{}
+	job.SetLastRun(e1)
+	job.SetLastRun(e2)
+	job.SetLastRun(e3)
+	c.Assert(len(job.history), Equals, 2)
+	c.Assert(job.history[0], Equals, e2)
+	c.Assert(job.history[1], Equals, e3)
+}
+
+func (s *SuiteBareJob) TestHistoryUnlimited(c *C) {
+	job := &BareJob{}
+	job.SetLastRun(&Execution{})
+	job.SetLastRun(&Execution{})
+	c.Assert(len(job.history), Equals, 2)
+}

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -28,6 +28,8 @@ This job is executed inside a running container, similar to `docker exec`.
     - **Labels config**: multiple environment variables has to be provided as JSON array: `["FOO=bar", "BAZ=qux"]`
 - `no-overlap`: boolean = `false`
   - Prevent that the job runs concurrently
+- `history-limit`: integer = `10`
+  - Number of past executions kept in memory
 
 ### INI-file example
 
@@ -100,6 +102,8 @@ This job can be used in 2 situations:
     - **Labels config**: multiple environment variables has to be provided as JSON array: `["FOO=bar", "BAZ=qux"]`
 - `no-overlap`: boolean = `false`
   - Prevent that the job runs concurrently
+- `history-limit`: integer = `10`
+  - Number of past executions kept in memory
 
 ### INI-file example
 
@@ -150,6 +154,8 @@ Runs the command on the host running Ofelia.
     - **Labels config**: multiple environment variables has to be provided as JSON array: `["FOO=bar", "BAZ=qux"]`
 - `no-overlap`: boolean = `false`
   - Prevent that the job runs concurrently
+- `history-limit`: integer = `10`
+  - Number of past executions kept in memory
 
 ### INI-file example
 
@@ -185,6 +191,8 @@ This job can be used to:
   - Allocate a pseudo-tty, similar to `docker exec -t`. See this [Stack Overflow answer](https://stackoverflow.com/questions/30137135/confused-about-docker-t-option-to-allocate-a-pseudo-tty) for more info.
 - `no-overlap`: boolean = `false`
   - Prevent that the job runs concurrently
+- `history-limit`: integer = `10`
+  - Number of past executions kept in memory
 
 ### INI-file example
 


### PR DESCRIPTION
## Summary
- add `HistoryLimit` to `BareJob` with default value
- trim stored history when limit is reached
- describe `history-limit` parameter in job documentation
- test history truncation logic

## Testing
- `go vet ./...`
- `go test ./...`
