### PR TITLE
Clarify vendor exclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 bin/
 coverage.txt
 *coverage*
+vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,8 @@ This repository is written in Go. Follow these rules when contributing:
   `feat:`, `fix:`, `docs:`) for all commits.
 - Write a comprehensive commit message body that thoroughly describes every
   change introduced.
+
+## Repository Hygiene
+- Manage dependencies exclusively with Go modules.
+- Do **not** vendor or commit downloaded modules. Avoid running `go mod vendor`.
+- Ensure the `vendor/` directory is ignored via `.gitignore`.


### PR DESCRIPTION
## Summary
- refine repository hygiene guidelines for dependency management
- reiterate vendor directory is ignored in `.gitignore`

## Testing
- `go vet ./...`
- `go test ./...`
