### PR TITLE
Update daemon config warning

### DIFF
--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -60,7 +60,7 @@ func (c *DaemonCommand) boot() (err error) {
 	// Always try to read the config file, as there are options such as globals or some tasks that can be specified there and not in docker
 	config, err := BuildFromFile(c.ConfigFile, c.Logger)
 	if err != nil {
-		c.Logger.Debugf("Error loading config file %v: %v", c.ConfigFile, err)
+		c.Logger.Warningf("Could not load config file %q: %v", c.ConfigFile, err)
 	}
 	config.Docker.Filters = c.DockerFilters
 	config.Docker.PollInterval = c.DockerPollInterval

--- a/cli/daemon_boot_test.go
+++ b/cli/daemon_boot_test.go
@@ -45,13 +45,13 @@ func (s *DaemonBootSuite) TestBootLogsConfigError(c *C) {
 
 	_ = cmd.boot()
 
-	var debugMsg bool
+	var warnMsg bool
 	for n := backend.Head(); n != nil; n = n.Next() {
-		if n.Record.Level == logging.DEBUG && strings.Contains(n.Record.Message(), "no-overlap") {
-			debugMsg = true
+		if n.Record.Level == logging.WARNING && strings.Contains(n.Record.Message(), "Could not load config file") {
+			warnMsg = true
 		}
 	}
-	c.Assert(debugMsg, Equals, true)
+	c.Assert(warnMsg, Equals, true)
 }
 
 func (s *DaemonBootSuite) TestBootLogsConfigErrorSuppressed(c *C) {


### PR DESCRIPTION
## Summary
- warn when the daemon cannot load the config file
- adjust boot tests for the new warning

## Testing
- `go vet ./...`
- `go test ./...`
