### PR TITLE
Add test for missing config warning

### DIFF
--- a/cli/daemon_boot_test.go
+++ b/cli/daemon_boot_test.go
@@ -83,3 +83,31 @@ func (s *DaemonBootSuite) TestBootLogsConfigErrorSuppressed(c *C) {
 	}
 	c.Assert(debugMsg, Equals, false)
 }
+
+func (s *DaemonBootSuite) TestBootLogsMissingConfig(c *C) {
+	tmpFile, err := os.CreateTemp("", "ofelia_missing_*.ini")
+	c.Assert(err, IsNil)
+	path := tmpFile.Name()
+	tmpFile.Close()
+	os.Remove(path)
+
+	backend, logger := newMemoryLogger(logging.DEBUG)
+	defer logging.Reset()
+	cmd := &DaemonCommand{ConfigFile: path, Logger: logger, LogLevel: "DEBUG"}
+
+	orig := newDockerHandler
+	defer func() { newDockerHandler = orig }()
+	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig, cli dockerClient) (*DockerHandler, error) {
+		return nil, errors.New("docker unavailable")
+	}
+
+	_ = cmd.boot()
+
+	var warnMsg bool
+	for n := backend.Head(); n != nil; n = n.Next() {
+		if n.Record.Level == logging.WARNING && strings.Contains(n.Record.Message(), "Could not load config file") {
+			warnMsg = true
+		}
+	}
+	c.Assert(warnMsg, Equals, true)
+}


### PR DESCRIPTION
## Summary
- ensure daemon warns when config file path is missing

## Testing
- `go vet ./...`
- `go test ./...`
