### PR TITLE
Improve config reload logging

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -289,6 +289,8 @@ func (c *Config) iniConfigUpdate() error {
 		return nil
 	}
 
+	c.logger.Debugf("reloading config from %s", c.configPath)
+
 	parsed, err := BuildFromFile(c.configPath, c.logger)
 	if err != nil {
 		return err

--- a/cli/docker_config_handler.go
+++ b/cli/docker_config_handler.go
@@ -103,8 +103,9 @@ func (c *DockerHandler) watch() {
 		}
 		c.notifier.dockerLabelsUpdate(labels)
 		if cfg, ok := c.notifier.(*Config); ok {
+			cfg.logger.Debugf("reloading config file %s", cfg.configPath)
 			if err := cfg.iniConfigUpdate(); err != nil {
-				c.logger.Debugf("%v", err)
+				c.logger.Warningf("%v", err)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- log config reload attempts at debug level
- warn about reload errors

## Testing
- `go vet ./...`
- `go test ./...`
