### PR TITLE
Improve logging caller info

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ See [Architecture overview](docs/architecture.md) for details about the schedule
 - `slack-only-on-error` - only send a slack message if the execution was not successful.
 - `log-level` - logging level (DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL). When set in the config file this level is applied from startup unless `--log-level` is provided.
 
+Log output now includes the original file and line of the logging call instead of the adapter location.
+
 ### INI-style configuration
 
 Run with `ofelia daemon --config=/path/to/config.ini`

--- a/core/logrus_logger.go
+++ b/core/logrus_logger.go
@@ -1,6 +1,10 @@
 package core
 
-import "github.com/sirupsen/logrus"
+import (
+	"runtime"
+
+	"github.com/sirupsen/logrus"
+)
 
 // LogrusAdapter wraps a logrus.Logger to satisfy the Logger interface.
 type LogrusAdapter struct {
@@ -9,22 +13,37 @@ type LogrusAdapter struct {
 
 var _ Logger = (*LogrusAdapter)(nil)
 
+func (l *LogrusAdapter) logf(level logrus.Level, format string, args ...interface{}) {
+	var frame *runtime.Frame
+	if pc, file, line, ok := runtime.Caller(2); ok {
+		frame = &runtime.Frame{PC: pc, File: file, Line: line, Function: runtime.FuncForPC(pc).Name()}
+	}
+
+	prev := l.Logger.ReportCaller
+	l.Logger.ReportCaller = false
+	defer func() { l.Logger.ReportCaller = prev }()
+
+	entry := logrus.NewEntry(l.Logger)
+	entry.Caller = frame
+	entry.Logf(level, format, args...)
+}
+
 func (l *LogrusAdapter) Criticalf(format string, args ...interface{}) {
-	l.Logger.Logf(logrus.FatalLevel, format, args...)
+	l.logf(logrus.FatalLevel, format, args...)
 }
 
 func (l *LogrusAdapter) Debugf(format string, args ...interface{}) {
-	l.Logger.Debugf(format, args...)
+	l.logf(logrus.DebugLevel, format, args...)
 }
 
 func (l *LogrusAdapter) Errorf(format string, args ...interface{}) {
-	l.Logger.Errorf(format, args...)
+	l.logf(logrus.ErrorLevel, format, args...)
 }
 
 func (l *LogrusAdapter) Noticef(format string, args ...interface{}) {
-	l.Logger.Infof(format, args...)
+	l.logf(logrus.InfoLevel, format, args...)
 }
 
 func (l *LogrusAdapter) Warningf(format string, args ...interface{}) {
-	l.Logger.Warnf(format, args...)
+	l.logf(logrus.WarnLevel, format, args...)
 }

--- a/ofelia.go
+++ b/ofelia.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/jessevdk/go-flags"
@@ -25,6 +27,9 @@ func buildLogger(level string) core.Logger {
 		ForceColors:     true,
 		DisableQuote:    true,
 		TimestampFormat: "2006-01-02 15:04:05",
+		CallerPrettyfier: func(frame *runtime.Frame) (string, string) {
+			return "", fmt.Sprintf("%s:%d", filepath.Base(frame.File), frame.Line)
+		},
 	})
 	lvl, err := logrus.ParseLevel(strings.ToLower(level))
 	if err != nil {


### PR DESCRIPTION
## Summary
- copy the caller frame when logging through `LogrusAdapter`
- toggle `ReportCaller` so the original call site is preserved
- trim file paths using `CallerPrettyfier`
- document the improved caller info in README

## Testing
- `go vet ./...`
- `go test ./...`
