### PR TITLE
Add web and pprof config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ See [Architecture overview](docs/architecture.md) for details about the schedule
 - `slack-webhook` - URL of the slack webhook.
 - `slack-only-on-error` - only send a slack message if the execution was not successful.
 - `log-level` - logging level (DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL). When set in the config file this level is applied from startup unless `--log-level` is provided.
+- `enable-web` - enable the built-in web UI.
+- `web-address` - address for the web UI server (default `:8081`).
+- `enable-pprof` - enable the pprof debug server.
+- `pprof-address` - address for the pprof server (default `127.0.0.1:8080`).
 
 ### INI-style configuration
 
@@ -133,6 +137,10 @@ Run with `ofelia daemon --config=/path/to/config.ini`
 save-folder = /var/log/ofelia_reports
 save-only-on-error = true
 log-level = INFO
+enable-web = true
+web-address = :8081
+enable-pprof = true
+pprof-address = 127.0.0.1:8080
 
 [job-exec "job-executed-on-running-container"]
 schedule = @hourly
@@ -167,6 +175,10 @@ docker run -it --rm \
     --label ofelia.save-folder="/var/log/ofelia_reports" \
     --label ofelia.save-only-on-error="true" \
     --label ofelia.log-level="INFO" \
+    --label ofelia.enable-web="true" \
+    --label ofelia.web-address=":8081" \
+    --label ofelia.enable-pprof="true" \
+    --label ofelia.pprof-address="127.0.0.1:8080" \
         ghcr.io/netresearch/ofelia:latest daemon
 ```
 

--- a/cli/config.go
+++ b/cli/config.go
@@ -26,6 +26,10 @@ type Config struct {
 		middlewares.SaveConfig  `mapstructure:",squash"`
 		middlewares.MailConfig  `mapstructure:",squash"`
 		LogLevel                string `gcfg:"log-level" mapstructure:"log-level"`
+		EnableWeb               bool   `gcfg:"enable-web" mapstructure:"enable-web" default:"false"`
+		WebAddr                 string `gcfg:"web-address" mapstructure:"web-address" default:":8081"`
+		EnablePprof             bool   `gcfg:"enable-pprof" mapstructure:"enable-pprof" default:"false"`
+		PprofAddr               string `gcfg:"pprof-address" mapstructure:"pprof-address" default:"127.0.0.1:8080"`
 	}
 	ExecJobs      map[string]*ExecJobConfig    `gcfg:"job-exec" mapstructure:"job-exec,squash"`
 	RunJobs       map[string]*RunJobConfig     `gcfg:"job-run" mapstructure:"job-run,squash"`

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -52,8 +52,6 @@ func (c *DaemonCommand) Execute(args []string) error {
 }
 
 func (c *DaemonCommand) boot() (err error) {
-	c.pprofServer = &http.Server{Addr: c.PprofAddr}
-
 	// Apply CLI log level before reading config
 	ApplyLogLevel(c.LogLevel)
 
@@ -66,6 +64,22 @@ func (c *DaemonCommand) boot() (err error) {
 	config.Docker.PollInterval = c.DockerPollInterval
 	config.Docker.UseEvents = c.DockerUseEvents
 	config.Docker.DisablePolling = c.DockerNoPoll
+
+	// Apply global settings from config if flags were not provided
+	if !c.EnableWeb {
+		c.EnableWeb = config.Global.EnableWeb
+	}
+	if c.WebAddr == ":8081" && config.Global.WebAddr != "" {
+		c.WebAddr = config.Global.WebAddr
+	}
+	if !c.EnablePprof {
+		c.EnablePprof = config.Global.EnablePprof
+	}
+	if c.PprofAddr == "127.0.0.1:8080" && config.Global.PprofAddr != "" {
+		c.PprofAddr = config.Global.PprofAddr
+	}
+
+	c.pprofServer = &http.Server{Addr: c.PprofAddr}
 
 	if c.LogLevel == "" {
 		ApplyLogLevel(config.Global.LogLevel)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,3 +19,20 @@ Jobs implement a common interface and can be executed in several ways:
 
 Middleware hooks are executed around every job. Ofelia provides built-in middleware for logging via mail, saving execution reports and sending Slack messages. Custom middleware can be added by implementing the interface in `core` and attaching it to the scheduler or to individual jobs.
 
+## HTTP interfaces
+
+Ofelia can optionally expose a small web UI and Go's `pprof` debug server. Both
+servers are configured in the `[global]` section of the INI file or through
+Docker labels on the service container:
+
+```ini
+[global]
+enable-web = true
+web-address = :8081
+enable-pprof = true
+pprof-address = 127.0.0.1:8080
+```
+
+The equivalent labels are `ofelia.enable-web`, `ofelia.web-address`,
+`ofelia.enable-pprof` and `ofelia.pprof-address`.
+


### PR DESCRIPTION
## Summary
- add optional web and pprof fields to global config
- allow daemon to read web/pprof settings from config if flags are unset
- document configuration of web UI and pprof server

## Testing
- `go vet ./...`
- `go test ./...`
