### PR TITLE
Fix config defaults

### DIFF
--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -15,7 +15,7 @@ import (
 
 // DaemonCommand daemon process
 type DaemonCommand struct {
-	ConfigFile         string        `long:"config" description:"configuration file" default:"/etc/ofelia.conf"`
+	ConfigFile         string        `long:"config" description:"configuration file"`
 	DockerFilters      []string      `short:"f" long:"docker-filter" description:"Filter for docker containers"`
 	DockerPollInterval time.Duration `long:"docker-poll-interval" description:"Interval for docker polling and INI reload (0 disables)" default:"10s"`
 	DockerUseEvents    bool          `long:"docker-events" description:"Use docker events instead of polling"`

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -10,7 +10,7 @@ import (
 
 // ValidateCommand validates the config file
 type ValidateCommand struct {
-	ConfigFile string `long:"config" description:"configuration file" default:"/etc/ofelia.conf"`
+	ConfigFile string `long:"config" description:"configuration file"`
 	LogLevel   string `long:"log-level" description:"Set log level (overrides config)"`
 	Logger     core.Logger
 }

--- a/ofelia.go
+++ b/ofelia.go
@@ -43,7 +43,7 @@ func main() {
 	// Pre-parse log-level flag to configure logger early
 	var pre struct {
 		LogLevel   string `long:"log-level"`
-		ConfigFile string `long:"config" default:"/etc/ofelia.conf"`
+		ConfigFile string `long:"config" default:"/etc/ofelia/config.ini"`
 	}
 	preParser := flags.NewParser(&pre, flags.IgnoreUnknown)
 	remainingArgs, _ := preParser.ParseArgs(os.Args[1:])


### PR DESCRIPTION
## Summary
- drop redundant config defaults from daemon/validate commands
- keep single default path in `ofelia.go`

## Testing
- `go vet ./...`
- `go test ./...`
