### PR TITLE
Fix Save middleware folder creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ See [Architecture overview](docs/architecture.md) for details about the schedule
 **Ofelia** comes with three different logging drivers that can be configured in the `[global]` section or as top-level Docker labels:
 
 - `mail` to send mails
-- `save` to save structured execution reports to a directory
+- `save` to save structured execution reports to a directory. The destination folder is created automatically.
 - `slack` to send messages via a slack webhook
 
 ### Global Options
@@ -119,7 +119,7 @@ See [Architecture overview](docs/architecture.md) for details about the schedule
 - `email-from` - mail address of the sender of the mail.
 - `mail-only-on-error` - only send a mail if the execution was not successful.
 
-- `save-folder` - directory in which the reports shall be written.
+- `save-folder` - directory in which the reports shall be written. The folder is created automatically if it does not exist.
 - `save-only-on-error` - only save a report if the execution was not successful.
 
 - `slack-webhook` - URL of the slack webhook.

--- a/middlewares/save.go
+++ b/middlewares/save.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/netresearch/ofelia/core"
 )
@@ -52,9 +53,15 @@ func (m *Save) Run(ctx *core.Context) error {
 }
 
 func (m *Save) saveToDisk(ctx *core.Context) error {
+	if err := os.MkdirAll(m.SaveFolder, 0o755); err != nil {
+		return err
+	}
+
+	safeName := strings.NewReplacer("/", "_", "\\", "_").Replace(ctx.Job.GetName())
+
 	root := filepath.Join(m.SaveFolder, fmt.Sprintf(
 		"%s_%s",
-		ctx.Execution.Date.Format("20060102_150405"), ctx.Job.GetName(),
+		ctx.Execution.Date.Format("20060102_150405"), safeName,
 	))
 
 	e := ctx.Execution


### PR DESCRIPTION
## Summary
- ensure Save middleware creates output directory
- sanitize job names when creating save filenames
- document folder auto-creation for Save middleware

## Testing
- `go vet ./...`
- `go test ./...`
