### PR TITLE
Fix CLI defaults overriding docker config

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,8 @@ You can also configure how often Ofelia polls Docker for label changes and reloa
 the INI configuration when the file has changed. The default interval is `10s`.
 Override it with `--docker-poll-interval` or the `poll-interval` option in the
 `[docker]` section of the config file. Set it to `0` to disable both polling and
-automatic reloads.
+automatic reloads. Command-line values only override the configuration when the
+flags are explicitly provided.
 
 Because the Docker image defines an `ENTRYPOINT`, pass the scheduler
 arguments as a list in `command:` so Compose does not treat them as a single

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -15,16 +15,16 @@ import (
 
 // DaemonCommand daemon process
 type DaemonCommand struct {
-	ConfigFile         string        `long:"config" description:"configuration file" default:"/etc/ofelia/config.ini"`
-	DockerFilters      []string      `short:"f" long:"docker-filter" description:"Filter for docker containers"`
-	DockerPollInterval time.Duration `long:"docker-poll-interval" description:"Interval for docker polling and INI reload (0 disables)" default:"10s"`
-	DockerUseEvents    bool          `long:"docker-events" description:"Use docker events instead of polling"`
-	DockerNoPoll       bool          `long:"docker-no-poll" description:"Disable polling docker for labels"`
-	LogLevel           string        `long:"log-level" description:"Set log level (overrides config)"`
-	EnablePprof        bool          `long:"enable-pprof" description:"Enable the pprof HTTP server"`
-	PprofAddr          string        `long:"pprof-address" description:"Address for the pprof HTTP server to listen on" default:"127.0.0.1:8080"`
-	EnableWeb          bool          `long:"enable-web" description:"Enable the web UI"`
-	WebAddr            string        `long:"web-address" description:"Address for the web UI HTTP server to listen on" default:":8081"`
+	ConfigFile         string         `long:"config" description:"configuration file" default:"/etc/ofelia/config.ini"`
+	DockerFilters      []string       `short:"f" long:"docker-filter" description:"Filter for docker containers"`
+	DockerPollInterval *time.Duration `long:"docker-poll-interval" description:"Interval for docker polling and INI reload (0 disables)"`
+	DockerUseEvents    *bool          `long:"docker-events" description:"Use docker events instead of polling"`
+	DockerNoPoll       *bool          `long:"docker-no-poll" description:"Disable polling docker for labels"`
+	LogLevel           string         `long:"log-level" description:"Set log level (overrides config)"`
+	EnablePprof        bool           `long:"enable-pprof" description:"Enable the pprof HTTP server"`
+	PprofAddr          string         `long:"pprof-address" description:"Address for the pprof HTTP server to listen on" default:"127.0.0.1:8080"`
+	EnableWeb          bool           `long:"enable-web" description:"Enable the web UI"`
+	WebAddr            string         `long:"web-address" description:"Address for the web UI HTTP server to listen on" default:":8081"`
 
 	scheduler   *core.Scheduler
 	signals     chan os.Signal
@@ -60,10 +60,18 @@ func (c *DaemonCommand) boot() (err error) {
 	if err != nil {
 		c.Logger.Warningf("Could not load config file %q: %v", c.ConfigFile, err)
 	}
-	config.Docker.Filters = c.DockerFilters
-	config.Docker.PollInterval = c.DockerPollInterval
-	config.Docker.UseEvents = c.DockerUseEvents
-	config.Docker.DisablePolling = c.DockerNoPoll
+	if len(c.DockerFilters) > 0 {
+		config.Docker.Filters = c.DockerFilters
+	}
+	if c.DockerPollInterval != nil {
+		config.Docker.PollInterval = *c.DockerPollInterval
+	}
+	if c.DockerUseEvents != nil {
+		config.Docker.UseEvents = *c.DockerUseEvents
+	}
+	if c.DockerNoPoll != nil {
+		config.Docker.DisablePolling = *c.DockerNoPoll
+	}
 
 	// Apply global settings from config if flags were not provided
 	if !c.EnableWeb {


### PR DESCRIPTION
## Notes
- Adjusted daemon option parsing so Docker settings are changed only when the corresponding CLI flags are present.
- Documented the behavior in the README.

## Summary
- make Docker flag fields optional and apply them only when set
- clarify in README that CLI flags override config only when explicitly provided

## Testing
- `go vet ./...`
- `go test ./...`
