### PR TITLE
Add env var overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Label your Docker containers and let this Go-powered daemon handle the schedule.
 
 - [Features](#features)
 - [Using it](#using-it)
+- [Environment variables](#environment-variables)
 - [Configuration](#configuration)
 - [Development](#development)
 - [License](#license)
@@ -75,6 +76,24 @@ server for profiling. Use `--pprof-address` to set the listening address
 (default `127.0.0.1:8080`).
 When `--enable-web` is specified, the daemon serves a small web UI at
 `--web-address` (default `:8081`) to inspect job status.
+
+### Environment variables
+
+You can configure the same options with environment variables. When set,
+they override values from the config file and Docker labels.
+
+| Variable | Corresponding flag | Description |
+| --- | --- | --- |
+| `OFELIA_CONFIG` | `--config` | Path to the configuration file |
+| `OFELIA_DOCKER_FILTER` | `--docker-filter` | Docker container filter (comma separated for multiple) |
+| `OFELIA_POLL_INTERVAL` | `--docker-poll-interval` | Interval for Docker polling and config reload |
+| `OFELIA_DOCKER_EVENTS` | `--docker-events` | Use Docker events instead of polling |
+| `OFELIA_DOCKER_NO_POLL` | `--docker-no-poll` | Disable polling Docker for labels |
+| `OFELIA_LOG_LEVEL` | `--log-level` | Set the log level |
+| `OFELIA_ENABLE_PPROF` | `--enable-pprof` | Enable the pprof HTTP server |
+| `OFELIA_PPROF_ADDRESS` | `--pprof-address` | Address for the pprof server |
+| `OFELIA_ENABLE_WEB` | `--enable-web` | Enable the web UI |
+| `OFELIA_WEB_ADDRESS` | `--web-address` | Address for the web UI server |
 
 ## Configuration
 

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -15,16 +15,16 @@ import (
 
 // DaemonCommand daemon process
 type DaemonCommand struct {
-	ConfigFile         string         `long:"config" description:"configuration file" default:"/etc/ofelia/config.ini"`
-	DockerFilters      []string       `short:"f" long:"docker-filter" description:"Filter for docker containers"`
-	DockerPollInterval *time.Duration `long:"docker-poll-interval" description:"Interval for docker polling and INI reload (0 disables)"`
-	DockerUseEvents    *bool          `long:"docker-events" description:"Use docker events instead of polling"`
-	DockerNoPoll       *bool          `long:"docker-no-poll" description:"Disable polling docker for labels"`
-	LogLevel           string         `long:"log-level" description:"Set log level (overrides config)"`
-	EnablePprof        bool           `long:"enable-pprof" description:"Enable the pprof HTTP server"`
-	PprofAddr          string         `long:"pprof-address" description:"Address for the pprof HTTP server to listen on" default:"127.0.0.1:8080"`
-	EnableWeb          bool           `long:"enable-web" description:"Enable the web UI"`
-	WebAddr            string         `long:"web-address" description:"Address for the web UI HTTP server to listen on" default:":8081"`
+	ConfigFile         string         `long:"config" env:"OFELIA_CONFIG" description:"configuration file" default:"/etc/ofelia/config.ini"`
+	DockerFilters      []string       `short:"f" long:"docker-filter" env:"OFELIA_DOCKER_FILTER" description:"Filter for docker containers"`
+	DockerPollInterval *time.Duration `long:"docker-poll-interval" env:"OFELIA_POLL_INTERVAL" description:"Interval for docker polling and INI reload (0 disables)"`
+	DockerUseEvents    *bool          `long:"docker-events" env:"OFELIA_DOCKER_EVENTS" description:"Use docker events instead of polling"`
+	DockerNoPoll       *bool          `long:"docker-no-poll" env:"OFELIA_DOCKER_NO_POLL" description:"Disable polling docker for labels"`
+	LogLevel           string         `long:"log-level" env:"OFELIA_LOG_LEVEL" description:"Set log level (overrides config)"`
+	EnablePprof        bool           `long:"enable-pprof" env:"OFELIA_ENABLE_PPROF" description:"Enable the pprof HTTP server"`
+	PprofAddr          string         `long:"pprof-address" env:"OFELIA_PPROF_ADDRESS" description:"Address for the pprof HTTP server to listen on" default:"127.0.0.1:8080"`
+	EnableWeb          bool           `long:"enable-web" env:"OFELIA_ENABLE_WEB" description:"Enable the web UI"`
+	WebAddr            string         `long:"web-address" env:"OFELIA_WEB_ADDRESS" description:"Address for the web UI HTTP server to listen on" default:":8081"`
 
 	scheduler   *core.Scheduler
 	signals     chan os.Signal
@@ -60,18 +60,7 @@ func (c *DaemonCommand) boot() (err error) {
 	if err != nil {
 		c.Logger.Warningf("Could not load config file %q: %v", c.ConfigFile, err)
 	}
-	if len(c.DockerFilters) > 0 {
-		config.Docker.Filters = c.DockerFilters
-	}
-	if c.DockerPollInterval != nil {
-		config.Docker.PollInterval = *c.DockerPollInterval
-	}
-	if c.DockerUseEvents != nil {
-		config.Docker.UseEvents = *c.DockerUseEvents
-	}
-	if c.DockerNoPoll != nil {
-		config.Docker.DisablePolling = *c.DockerNoPoll
-	}
+	c.applyOptions(config)
 
 	// Apply global settings from config if flags were not provided
 	if !c.EnableWeb {
@@ -97,6 +86,8 @@ func (c *DaemonCommand) boot() (err error) {
 	if err != nil {
 		c.Logger.Criticalf("Can't start the app: %v", err)
 	}
+	// Re-apply CLI/environment options so they override Docker labels
+	c.applyOptions(config)
 	c.scheduler = config.sh
 	if c.EnableWeb {
 		c.webServer = web.NewServer(c.WebAddr, c.scheduler)
@@ -174,4 +165,35 @@ func (c *DaemonCommand) shutdown() error {
 
 	c.Logger.Warningf("Waiting running jobs.")
 	return c.scheduler.Stop()
+}
+
+func (c *DaemonCommand) applyOptions(config *Config) {
+	if len(c.DockerFilters) > 0 {
+		config.Docker.Filters = c.DockerFilters
+	}
+	if c.DockerPollInterval != nil {
+		config.Docker.PollInterval = *c.DockerPollInterval
+	}
+	if c.DockerUseEvents != nil {
+		config.Docker.UseEvents = *c.DockerUseEvents
+	}
+	if c.DockerNoPoll != nil {
+		config.Docker.DisablePolling = *c.DockerNoPoll
+	}
+
+	if c.EnableWeb {
+		config.Global.EnableWeb = true
+	}
+	if c.WebAddr != ":8081" {
+		config.Global.WebAddr = c.WebAddr
+	}
+	if c.EnablePprof {
+		config.Global.EnablePprof = true
+	}
+	if c.PprofAddr != "127.0.0.1:8080" {
+		config.Global.PprofAddr = c.PprofAddr
+	}
+	if c.LogLevel != "" {
+		config.Global.LogLevel = c.LogLevel
+	}
 }

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -10,8 +10,8 @@ import (
 
 // ValidateCommand validates the config file
 type ValidateCommand struct {
-	ConfigFile string `long:"config" description:"configuration file" default:"/etc/ofelia/config.ini"`
-	LogLevel   string `long:"log-level" description:"Set log level (overrides config)"`
+	ConfigFile string `long:"config" env:"OFELIA_CONFIG" description:"configuration file" default:"/etc/ofelia/config.ini"`
+	LogLevel   string `long:"log-level" env:"OFELIA_LOG_LEVEL" description:"Set log level (overrides config)"`
 	Logger     core.Logger
 }
 


### PR DESCRIPTION
## Summary
- enable environment variables for CLI flags
- override config using environment variables after Docker labels are loaded
- document available variables in README

## Testing
- `go vet ./...`
- `go test ./...` *(fails: docker unavailable)*