### PR TITLE
Add context support to DockerHandler

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"os"
 	"time"
 
@@ -87,7 +88,7 @@ func (c *Config) InitializeApp() error {
 	c.buildSchedulerMiddlewares(c.sh)
 
 	var err error
-	c.dockerHandler, err = newDockerHandler(c, c.logger, &c.Docker, nil)
+	c.dockerHandler, err = newDockerHandler(context.Background(), c, c.logger, &c.Docker, nil)
 	if err != nil {
 		return err
 	}

--- a/cli/config_extra_test.go
+++ b/cli/config_extra_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"io/ioutil"
 	"os"
@@ -42,7 +43,7 @@ func (s *SuiteConfig) TestInitializeAppErrorDockerHandler(c *C) {
 	// Override newDockerHandler to simulate factory error
 	orig := newDockerHandler
 	defer func() { newDockerHandler = orig }()
-	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig, cli dockerClient) (*DockerHandler, error) {
+	newDockerHandler = func(ctx context.Context, notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig, cli dockerClient) (*DockerHandler, error) {
 		return nil, errors.New("factory error")
 	}
 

--- a/cli/config_initialize_test.go
+++ b/cli/config_initialize_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -33,12 +34,13 @@ func (s *ConfigInitSuite) TestInitializeAppSuccess(c *C) {
 	// Override newDockerHandler to use the test server
 	origFactory := newDockerHandler
 	defer func() { newDockerHandler = origFactory }()
-	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig, cli dockerClient) (*DockerHandler, error) {
+	newDockerHandler = func(ctx context.Context, notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig, cli dockerClient) (*DockerHandler, error) {
 		client, err := docker.NewClient(ts.URL)
 		if err != nil {
 			return nil, err
 		}
 		return &DockerHandler{
+			ctx:            ctx,
 			filters:        cfg.Filters,
 			notifier:       notifier,
 			logger:         logger,

--- a/cli/daemon_boot_test.go
+++ b/cli/daemon_boot_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"errors"
 	"os"
 	"strings"
@@ -40,7 +41,7 @@ func (s *DaemonBootSuite) TestBootLogsConfigError(c *C) {
 
 	orig := newDockerHandler
 	defer func() { newDockerHandler = orig }()
-	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig, cli dockerClient) (*DockerHandler, error) {
+	newDockerHandler = func(ctx context.Context, notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig, cli dockerClient) (*DockerHandler, error) {
 		return nil, errors.New("docker unavailable")
 	}
 
@@ -69,7 +70,7 @@ func (s *DaemonBootSuite) TestBootLogsConfigErrorSuppressed(c *C) {
 
 	orig := newDockerHandler
 	defer func() { newDockerHandler = orig }()
-	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig, cli dockerClient) (*DockerHandler, error) {
+	newDockerHandler = func(ctx context.Context, notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig, cli dockerClient) (*DockerHandler, error) {
 		return nil, errors.New("docker unavailable")
 	}
 
@@ -96,7 +97,7 @@ func (s *DaemonBootSuite) TestBootLogsMissingConfig(c *C) {
 
 	orig := newDockerHandler
 	defer func() { newDockerHandler = orig }()
-	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig, cli dockerClient) (*DockerHandler, error) {
+	newDockerHandler = func(ctx context.Context, notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig, cli dockerClient) (*DockerHandler, error) {
 		return nil, errors.New("docker unavailable")
 	}
 
@@ -123,7 +124,7 @@ func (s *DaemonBootSuite) TestBootLogsMissingConfigIncludesFilename(c *C) {
 
 	orig := newDockerHandler
 	defer func() { newDockerHandler = orig }()
-	newDockerHandler = func(notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig, cli dockerClient) (*DockerHandler, error) {
+	newDockerHandler = func(ctx context.Context, notifier dockerLabelsUpdate, logger core.Logger, cfg *DockerConfig, cli dockerClient) (*DockerHandler, error) {
 		return nil, errors.New("docker unavailable")
 	}
 


### PR DESCRIPTION
## Summary
- update `DockerHandler` to accept `context.Context`
- stop watcher goroutines when context is cancelled
- expose `Shutdown` to cancel Docker handler
- ensure daemon calls Docker handler shutdown
- adjust tests for new Docker handler constructor

## Testing
- `go vet ./...`
- `go test ./...`