### PR TITLE
feat(core): centralize Docker image pulling

### DIFF
--- a/core/common.go
+++ b/core/common.go
@@ -271,6 +271,17 @@ func buildPullOptions(image string) (docker.PullImageOptions, docker.AuthConfigu
 	}, buildAuthConfiguration(registry)
 }
 
+// pullImage downloads a Docker image if it is not available locally.
+// It uses the provided client to fetch the image with authentication
+// details from the Docker configuration file.
+func pullImage(client *docker.Client, image string) error {
+	opts, auth := buildPullOptions(image)
+	if err := client.PullImage(opts, auth); err != nil {
+		return fmt.Errorf("error pulling image %q: %s", image, err)
+	}
+	return nil
+}
+
 func parseRegistry(repository string) string {
 	parts := strings.Split(repository, "/")
 	if len(parts) < 2 {

--- a/core/runjob.go
+++ b/core/runjob.go
@@ -83,7 +83,7 @@ func (j *RunJob) Run(ctx *Context) error {
 			// if Pull option "true"
 			// try pulling image first
 			if pull {
-				if pullError = j.pullImage(); pullError == nil {
+				if pullError = pullImage(j.Client, j.Image); pullError == nil {
 					ctx.Log("Pulled image " + j.Image)
 					return nil
 				}
@@ -99,7 +99,7 @@ func (j *RunJob) Run(ctx *Context) error {
 
 			// if couldn't find image locally, still try to pull
 			if !pull && searchErr == ErrLocalImageNotFound {
-				if pullError = j.pullImage(); pullError == nil {
+				if pullError = pullImage(j.Client, j.Image); pullError == nil {
 					ctx.Log("Pulled image " + j.Image)
 					return nil
 				}
@@ -175,15 +175,6 @@ func (j *RunJob) searchLocalImage() error {
 
 	if len(imgs) != 1 {
 		return ErrLocalImageNotFound
-	}
-
-	return nil
-}
-
-func (j *RunJob) pullImage() error {
-	o, a := buildPullOptions(j.Image)
-	if err := j.Client.PullImage(o, a); err != nil {
-		return fmt.Errorf("error pulling image %q: %s", j.Image, err)
 	}
 
 	return nil

--- a/core/runservice.go
+++ b/core/runservice.go
@@ -32,7 +32,7 @@ func NewRunServiceJob(c *docker.Client) *RunServiceJob {
 }
 
 func (j *RunServiceJob) Run(ctx *Context) error {
-	if err := j.pullImage(); err != nil {
+	if err := pullImage(j.Client, j.Image); err != nil {
 		return err
 	}
 
@@ -49,15 +49,6 @@ func (j *RunServiceJob) Run(ctx *Context) error {
 	}
 
 	return j.deleteService(ctx, svc.ID)
-}
-
-func (j *RunServiceJob) pullImage() error {
-	o, a := buildPullOptions(j.Image)
-	if err := j.Client.PullImage(o, a); err != nil {
-		return fmt.Errorf("error pulling image %q: %s", j.Image, err)
-	}
-
-	return nil
 }
 
 func (j *RunServiceJob) buildService() (*swarm.Service, error) {


### PR DESCRIPTION
## Summary
- add a helper for Docker image pulling
- use it in RunJob and RunServiceJob

## Testing
- `go vet ./...`
- `go test ./...` *(fails: docker unavailable)*