### PR TITLE
Handle ID generation and hash errors

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -193,7 +193,17 @@ func (c *Config) dockerLabelsUpdate(labels map[string]map[string]string) {
 				defaults.Set(newJob)
 				newJob.Client = c.dockerHandler.GetInternalDockerClient()
 				newJob.Name = newJobsName
-				if newJob.Hash() != j.Hash() {
+				newHash, err1 := newJob.Hash()
+				if err1 != nil {
+					c.logger.Errorf("hash calculation failed: %v", err1)
+					break
+				}
+				oldHash, err2 := j.Hash()
+				if err2 != nil {
+					c.logger.Errorf("hash calculation failed: %v", err2)
+					break
+				}
+				if newHash != oldHash {
 					// Remove from the scheduler
 					c.sh.RemoveJob(j)
 					// Add the job back to the scheduler
@@ -257,7 +267,17 @@ func (c *Config) dockerLabelsUpdate(labels map[string]map[string]string) {
 				defaults.Set(newJob)
 				newJob.Client = c.dockerHandler.GetInternalDockerClient()
 				newJob.Name = newJobsName
-				if newJob.Hash() != j.Hash() {
+				newHash, err1 := newJob.Hash()
+				if err1 != nil {
+					c.logger.Errorf("hash calculation failed: %v", err1)
+					break
+				}
+				oldHash, err2 := j.Hash()
+				if err2 != nil {
+					c.logger.Errorf("hash calculation failed: %v", err2)
+					break
+				}
+				if newHash != oldHash {
 					// Remove from the scheduler
 					c.sh.RemoveJob(j)
 					// Add the job back to the scheduler
@@ -342,7 +362,15 @@ func (c *Config) iniConfigUpdate() error {
 		defaults.Set(newJob)
 		newJob.Client = c.dockerHandler.GetInternalDockerClient()
 		newJob.Name = name
-		if newJob.Hash() != j.Hash() {
+		newHash, err1 := newJob.Hash()
+		if err1 != nil {
+			return err1
+		}
+		oldHash, err2 := j.Hash()
+		if err2 != nil {
+			return err2
+		}
+		if newHash != oldHash {
 			c.sh.RemoveJob(j)
 			newJob.buildMiddlewares()
 			c.sh.AddJob(newJob)
@@ -372,7 +400,15 @@ func (c *Config) iniConfigUpdate() error {
 		defaults.Set(newJob)
 		newJob.Client = c.dockerHandler.GetInternalDockerClient()
 		newJob.Name = name
-		if newJob.Hash() != j.Hash() {
+		newHash, err1 := newJob.Hash()
+		if err1 != nil {
+			return err1
+		}
+		oldHash, err2 := j.Hash()
+		if err2 != nil {
+			return err2
+		}
+		if newHash != oldHash {
 			c.sh.RemoveJob(j)
 			newJob.buildMiddlewares()
 			c.sh.AddJob(newJob)
@@ -401,7 +437,15 @@ func (c *Config) iniConfigUpdate() error {
 		}
 		defaults.Set(newJob)
 		newJob.Name = name
-		if newJob.Hash() != j.Hash() {
+		newHash, err1 := newJob.Hash()
+		if err1 != nil {
+			return err1
+		}
+		oldHash, err2 := j.Hash()
+		if err2 != nil {
+			return err2
+		}
+		if newHash != oldHash {
 			c.sh.RemoveJob(j)
 			newJob.buildMiddlewares()
 			c.sh.AddJob(newJob)
@@ -430,7 +474,15 @@ func (c *Config) iniConfigUpdate() error {
 		defaults.Set(newJob)
 		newJob.Client = c.dockerHandler.GetInternalDockerClient()
 		newJob.Name = name
-		if newJob.Hash() != j.Hash() {
+		newHash, err1 := newJob.Hash()
+		if err1 != nil {
+			return err1
+		}
+		oldHash, err2 := j.Hash()
+		if err2 != nil {
+			return err2
+		}
+		if newHash != oldHash {
 			c.sh.RemoveJob(j)
 			newJob.buildMiddlewares()
 			c.sh.AddJob(newJob)

--- a/core/bare_job.go
+++ b/core/bare_job.go
@@ -53,10 +53,12 @@ func (j *BareJob) SetCronJobID(id int) {
 }
 
 // Returns a hash of all the job attributes. Used to detect changes
-func (j *BareJob) Hash() string {
+func (j *BareJob) Hash() (string, error) {
 	var hash string
-	getHash(reflect.TypeOf(j).Elem(), reflect.ValueOf(j).Elem(), &hash)
-	return hash
+	if err := getHash(reflect.TypeOf(j).Elem(), reflect.ValueOf(j).Elem(), &hash); err != nil {
+		return "", err
+	}
+	return hash, nil
 }
 
 // SetLastRun stores the last executed run for the job.

--- a/core/bare_job_extra_test.go
+++ b/core/bare_job_extra_test.go
@@ -21,8 +21,14 @@ func TestHash(t *testing.T) {
 	// Two jobs with identical fields should have identical hashes
 	job1 := &BareJob{Schedule: "sched", Name: "name", Command: "cmd"}
 	job2 := &BareJob{Schedule: "sched", Name: "name", Command: "cmd"}
-	h1 := job1.Hash()
-	h2 := job2.Hash()
+	h1, err := job1.Hash()
+	if err != nil {
+		t.Fatalf("hash error: %v", err)
+	}
+	h2, err := job2.Hash()
+	if err != nil {
+		t.Fatalf("hash error: %v", err)
+	}
 	if h1 == "" {
 		t.Errorf("expected non-empty hash, got empty string")
 	}
@@ -32,7 +38,10 @@ func TestHash(t *testing.T) {
 
 	// Changing one field should change the hash
 	job2.Command = "other"
-	h3 := job2.Hash()
+	h3, err := job2.Hash()
+	if err != nil {
+		t.Fatalf("hash error: %v", err)
+	}
 	if h3 == h1 {
 		t.Errorf("expected different hash after modifying Command, got %q", h3)
 	}

--- a/core/common_extra2_test.go
+++ b/core/common_extra2_test.go
@@ -67,7 +67,10 @@ func TestParseRegistryVarious(t *testing.T) {
 
 // TestExecutionLifecycle tests Execution.Start and Stop with no error.
 func TestExecutionLifecycle(t *testing.T) {
-	e := NewExecution()
+	e, err := NewExecution()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	// Ensure initial state
 	if e.IsRunning {
 		t.Error("expected IsRunning false before start")
@@ -99,7 +102,10 @@ func TestExecutionLifecycle(t *testing.T) {
 
 // TestExecutionStopError tests Execution.Stop with a regular error.
 func TestExecutionStopError(t *testing.T) {
-	e := NewExecution()
+	e, err := NewExecution()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	e.Start()
 	errIn := errors.New("fail")
 	e.Stop(errIn)
@@ -119,7 +125,10 @@ func TestExecutionStopError(t *testing.T) {
 
 // TestExecutionStopSkipped tests Execution.Stop with ErrSkippedExecution.
 func TestExecutionStopSkipped(t *testing.T) {
-	e := NewExecution()
+	e, err := NewExecution()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	e.Start()
 	e.Stop(ErrSkippedExecution)
 	if e.IsRunning {

--- a/core/common_extra3_test.go
+++ b/core/common_extra3_test.go
@@ -6,7 +6,10 @@ import (
 
 // TestRandomIDLength verifies that randomID produces a string of length 12.
 func TestRandomIDLength(t *testing.T) {
-	id := randomID()
+	id, err := randomID()
+	if err != nil {
+		t.Fatalf("randomID error: %v", err)
+	}
 	if len(id) != 12 {
 		t.Errorf("expected ID length 12, got %d", len(id))
 	}
@@ -16,7 +19,10 @@ func TestRandomIDLength(t *testing.T) {
 func TestRandomIDUniqueness(t *testing.T) {
 	ids := make(map[string]bool)
 	for i := 0; i < 100; i++ {
-		id := randomID()
+		id, err := randomID()
+		if err != nil {
+			t.Fatalf("randomID error: %v", err)
+		}
 		if ids[id] {
 			t.Errorf("duplicate ID found: %s", id)
 		}
@@ -33,7 +39,10 @@ func TestBareJobHashValue(t *testing.T) {
 	}
 	// Expect "schednamecmd"
 	want := "schednamecmd"
-	got := job.Hash()
+	got, err := job.Hash()
+	if err != nil {
+		t.Fatalf("hash error: %v", err)
+	}
 	if got != want {
 		t.Errorf("expected hash %q, got %q", want, got)
 	}
@@ -43,8 +52,16 @@ func TestBareJobHashValue(t *testing.T) {
 func TestBareJobHashConsistency(t *testing.T) {
 	job1 := &BareJob{Schedule: "s", Name: "n", Command: "c"}
 	job2 := &BareJob{Schedule: "s", Name: "n", Command: "c"}
-	if job1.Hash() != job2.Hash() {
-		t.Errorf("expected identical hashes, got %s and %s", job1.Hash(), job2.Hash())
+	h1, err := job1.Hash()
+	if err != nil {
+		t.Fatalf("hash error: %v", err)
+	}
+	h2, err := job2.Hash()
+	if err != nil {
+		t.Fatalf("hash error: %v", err)
+	}
+	if h1 != h2 {
+		t.Errorf("expected identical hashes, got %s and %s", h1, h2)
 	}
 }
 
@@ -52,7 +69,15 @@ func TestBareJobHashConsistency(t *testing.T) {
 func TestBareJobHashDifference(t *testing.T) {
 	job1 := &BareJob{Schedule: "s1", Name: "n", Command: "c"}
 	job2 := &BareJob{Schedule: "s2", Name: "n", Command: "c"}
-	if job1.Hash() == job2.Hash() {
-		t.Errorf("expected different hashes, both %s", job1.Hash())
+	h1, err := job1.Hash()
+	if err != nil {
+		t.Fatalf("hash error: %v", err)
+	}
+	h2, err := job2.Hash()
+	if err != nil {
+		t.Fatalf("hash error: %v", err)
+	}
+	if h1 == h2 {
+		t.Errorf("expected different hashes, both %s", h1)
 	}
 }

--- a/core/common_extra_test.go
+++ b/core/common_extra_test.go
@@ -7,7 +7,10 @@ import (
 
 // TestNewExecutionInitial tests the initial state of a new Execution.
 func TestNewExecutionInitial(t *testing.T) {
-	e := NewExecution()
+	e, err := NewExecution()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if e == nil {
 		t.Error("expected NewExecution to return non-nil")
 	}

--- a/core/common_test.go
+++ b/core/common_test.go
@@ -20,7 +20,8 @@ func (s *SuiteCommon) TestNewContext(c *C) {
 	j := &TestJob{}
 	j.Use(&TestMiddleware{})
 
-	e := NewExecution()
+	e, err := NewExecution()
+	c.Assert(err, IsNil)
 
 	ctx := NewContext(h, j, e)
 	c.Assert(ctx.Scheduler, DeepEquals, h)
@@ -38,13 +39,14 @@ func (s *SuiteCommon) TestContextNextError(c *C) {
 	j := &TestJob{}
 	j.Use(mA, mB, mC)
 
-	e := NewExecution()
+	e, err := NewExecution()
+	c.Assert(err, IsNil)
 
 	h := NewScheduler(&TestLogger{})
 	ctx := NewContext(h, j, e)
 	ctx.Start()
 
-	err := ctx.Next()
+	err = ctx.Next()
 	c.Assert(err, IsNil)
 	c.Assert(mA.Called, Equals, 1)
 	c.Assert(mB.Called, Equals, 0)
@@ -78,13 +80,14 @@ func (s *SuiteCommon) TestContextNextNested(c *C) {
 	j := &TestJob{}
 	j.Use(mA, mB, mC)
 
-	e := NewExecution()
+	e, err := NewExecution()
+	c.Assert(err, IsNil)
 
 	h := NewScheduler(&TestLogger{})
 	ctx := NewContext(h, j, e)
 	ctx.Start()
 
-	err := ctx.Next()
+	err = ctx.Next()
 	c.Assert(err, IsNil)
 	c.Assert(mA.Called, Equals, 1)
 	c.Assert(mB.Called, Equals, 1)
@@ -102,13 +105,14 @@ func (s *SuiteCommon) TestContextNextNestedError(c *C) {
 	j := &TestJob{}
 	j.Use(mA, mB, mC)
 
-	e := NewExecution()
+	e, err := NewExecution()
+	c.Assert(err, IsNil)
 
 	h := NewScheduler(&TestLogger{})
 	ctx := NewContext(h, j, e)
 	ctx.Start()
 
-	err := ctx.Next()
+	err = ctx.Next()
 	c.Assert(err, IsNil)
 	c.Assert(mA.Called, Equals, 1)
 	c.Assert(mB.Called, Equals, 0)
@@ -127,13 +131,14 @@ func (s *SuiteCommon) TestContextNextContinueOnStop(c *C) {
 	j := &TestJob{}
 	j.Use(mA, mB, mC)
 
-	e := NewExecution()
+	e, err := NewExecution()
+	c.Assert(err, IsNil)
 
 	h := NewScheduler(&TestLogger{})
 	ctx := NewContext(h, j, e)
 	ctx.Start()
 
-	err := ctx.Next()
+	err = ctx.Next()
 	c.Assert(err, IsNil)
 	c.Assert(mA.Called, Equals, 1)
 	c.Assert(mB.Called, Equals, 0)
@@ -149,13 +154,14 @@ func (s *SuiteCommon) TestContextNext(c *C) {
 	j := &TestJob{}
 	j.Use(mA, mB, mC)
 
-	e := NewExecution()
+	e, err := NewExecution()
+	c.Assert(err, IsNil)
 
 	h := NewScheduler(&TestLogger{})
 	ctx := NewContext(h, j, e)
 	ctx.Start()
 
-	err := ctx.Next()
+	err = ctx.Next()
 	c.Assert(err, IsNil)
 	c.Assert(mA.Called, Equals, 1)
 	c.Assert(mB.Called, Equals, 0)

--- a/core/execjob_test.go
+++ b/core/execjob_test.go
@@ -66,9 +66,10 @@ func (s *SuiteExecJob) TestRun(c *C) {
 	job.User = "foo"
 	job.TTY = true
 
-	e := NewExecution()
+	e, err := NewExecution()
+	c.Assert(err, IsNil)
 
-	err := job.Run(&Context{Execution: e})
+	err = job.Run(&Context{Execution: e})
 	c.Assert(err, IsNil)
 	c.Assert(executed, Equals, true)
 
@@ -93,11 +94,12 @@ func (s *SuiteExecJob) TestRunStartExecError(c *C) {
 	job.Container = ContainerFixture
 	job.Command = "echo foo"
 
-	e := NewExecution()
+	e, err := NewExecution()
+	c.Assert(err, IsNil)
 	ctx := &Context{Execution: e, Job: job}
 
 	ctx.Start()
-	err := job.Run(ctx)
+	err = job.Run(ctx)
 	ctx.Stop(err)
 
 	c.Assert(err, NotNil)

--- a/core/hash_test.go
+++ b/core/hash_test.go
@@ -14,7 +14,9 @@ func TestGetHashSimple(t *testing.T) {
 	}
 	val := S{A: "foo", B: 42, C: true}
 	var h string
-	getHash(reflect.TypeOf(val), reflect.ValueOf(val), &h)
+	if err := getHash(reflect.TypeOf(val), reflect.ValueOf(val), &h); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	want := "foo42true"
 	if h != want {
 		t.Errorf("expected hash %q, got %q", want, h)
@@ -31,7 +33,9 @@ func TestGetHashNested(t *testing.T) {
 	}
 	val := Outer{Inner: Inner{X: "bar"}}
 	var h string
-	getHash(reflect.TypeOf(val), reflect.ValueOf(val), &h)
+	if err := getHash(reflect.TypeOf(val), reflect.ValueOf(val), &h); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	want := "bar"
 	if h != want {
 		t.Errorf("expected nested hash %q, got %q", want, h)
@@ -39,17 +43,13 @@ func TestGetHashNested(t *testing.T) {
 }
 
 // TestGetHashPanicUnsupported tests that getHash panics on unsupported field types.
-func TestGetHashPanicUnsupported(t *testing.T) {
+func TestGetHashUnsupported(t *testing.T) {
 	type Bad struct {
 		F float64 `hash:"true"`
 	}
 	val := Bad{F: 3.14}
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("expected panic on unsupported type, but did not panic")
-		}
-	}()
-	// This should panic
 	var h string
-	getHash(reflect.TypeOf(val), reflect.ValueOf(val), &h)
+	if err := getHash(reflect.TypeOf(val), reflect.ValueOf(val), &h); err == nil {
+		t.Errorf("expected error on unsupported type")
+	}
 }

--- a/core/localjob_test.go
+++ b/core/localjob_test.go
@@ -17,10 +17,11 @@ func (s *SuiteLocalJob) TestRun(c *C) {
 	job.Command = `echo "foo bar"`
 
 	b, _ := circbuf.NewBuffer(1000)
-	e := NewExecution()
+	e, err := NewExecution()
+	c.Assert(err, IsNil)
 	e.OutputStream = b
 
-	err := job.Run(&Context{Execution: e})
+	err = job.Run(&Context{Execution: e})
 	c.Assert(err, IsNil)
 	c.Assert(b.String(), Equals, "foo bar\n")
 }
@@ -32,10 +33,11 @@ func (s *SuiteLocalJob) TestEnvironment(c *C) {
 	job.Environment = env
 
 	b, _ := circbuf.NewBuffer(1000)
-	e := NewExecution()
+	e, err := NewExecution()
+	c.Assert(err, IsNil)
 	e.OutputStream = b
 
-	err := job.Run(&Context{Execution: e})
+	err = job.Run(&Context{Execution: e})
 	c.Assert(err, IsNil)
 
 	// check that expected keys are present in the system env
@@ -55,11 +57,12 @@ func (s *SuiteLocalJob) TestRunFailed(c *C) {
 	job := &LocalJob{}
 	job.Command = "false"
 
-	e := NewExecution()
+	e, err := NewExecution()
+	c.Assert(err, IsNil)
 	ctx := &Context{Execution: e, Job: job}
 
 	ctx.Start()
-	err := job.Run(ctx)
+	err = job.Run(ctx)
 	ctx.Stop(err)
 
 	c.Assert(err, NotNil)

--- a/core/runjob_test.go
+++ b/core/runjob_test.go
@@ -45,7 +45,11 @@ func (s *SuiteRunJob) TestRun(c *C) {
 	job.Environment = []string{"test_Key1=value1", "test_Key2=value2"}
 	job.Volume = []string{"/test/tmp:/test/tmp:ro", "/test/tmp:/test/tmp:rw"}
 
-	ctx := &Context{Job: job, Execution: NewExecution()}
+	exec, err := NewExecution()
+	if err != nil {
+		c.Fatal(err)
+	}
+	ctx := &Context{Job: job, Execution: exec}
 	logger := logrus.New()
 	logger.Formatter = &logrus.TextFormatter{DisableTimestamp: true}
 	ctx.Logger = &LogrusAdapter{Logger: logger}
@@ -93,7 +97,11 @@ func (s *SuiteRunJob) TestRunFailed(c *C) {
 	job.Delete = "true"
 	job.Name = "fail"
 
-	ctx := &Context{Job: job, Execution: NewExecution()}
+	exec, err := NewExecution()
+	if err != nil {
+		c.Fatal(err)
+	}
+	ctx := &Context{Job: job, Execution: exec}
 	logger := logrus.New()
 	logger.Formatter = &logrus.TextFormatter{DisableTimestamp: true}
 	ctx.Logger = &LogrusAdapter{Logger: logger}
@@ -125,8 +133,12 @@ func (s *SuiteRunJob) TestRunWithEntrypoint(c *C) {
 	job.Name = "test-ep"
 	job.Delete = "true"
 
+	exec, err := NewExecution()
+	if err != nil {
+		c.Fatal(err)
+	}
 	ctx := &Context{}
-	ctx.Execution = NewExecution()
+	ctx.Execution = exec
 	logger := logrus.New()
 	logger.Formatter = &logrus.TextFormatter{DisableTimestamp: true}
 	ctx.Logger = &LogrusAdapter{Logger: logger}

--- a/core/runservice_test.go
+++ b/core/runservice_test.go
@@ -55,7 +55,10 @@ func (s *SuiteRunServiceJob) TestRun(c *C) {
 	job.Delete = "true"
 	job.Network = "foo"
 
-	e := NewExecution()
+	e, err := NewExecution()
+	if err != nil {
+		c.Fatal(err)
+	}
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -81,7 +84,7 @@ func (s *SuiteRunServiceJob) TestRun(c *C) {
 		wg.Done()
 	}()
 
-	err := job.Run(&Context{Execution: e, Logger: logger})
+	err = job.Run(&Context{Execution: e, Logger: logger})
 	c.Assert(err, IsNil)
 	wg.Wait()
 

--- a/core/scheduler.go
+++ b/core/scheduler.go
@@ -114,11 +114,15 @@ func (w *jobWrapper) Run() {
 		w.s.mu.Unlock()
 	}()
 
-	e := NewExecution()
+	e, err := NewExecution()
+	if err != nil {
+		w.s.Logger.Errorf("failed to create execution: %v", err)
+		return
+	}
 	ctx := NewContext(w.s, w.j, e)
 
 	w.start(ctx)
-	err := ctx.Next()
+	err = ctx.Next()
 	w.stop(ctx, err)
 }
 

--- a/middlewares/common_test.go
+++ b/middlewares/common_test.go
@@ -35,7 +35,8 @@ type BaseSuite struct {
 func (s *BaseSuite) SetUpTest(c *C) {
 	s.job = &TestJob{}
 	sh := core.NewScheduler(&TestLogger{})
-	e := core.NewExecution()
+	e, err := core.NewExecution()
+	c.Assert(err, IsNil)
 
 	s.ctx = core.NewContext(sh, s.job, e)
 }

--- a/middlewares/save_test.go
+++ b/middlewares/save_test.go
@@ -37,7 +37,8 @@ func (s *SuiteSave) SetUpTest(c *C) {
 	s.job = &job.TestJob
 
 	sh := core.NewScheduler(&TestLogger{})
-	e := core.NewExecution()
+	e, err := core.NewExecution()
+	c.Assert(err, IsNil)
 
 	s.ctx = core.NewContext(sh, job, e)
 }


### PR DESCRIPTION
## Summary
- return errors from `randomID` and `getHash`
- propagate error in `NewExecution`
- handle execution creation failure in scheduler
- update CLI job hash comparisons
- adjust tests for new error returns

## Testing
- `go vet ./...`
- `go test ./...`