### PR TITLE
Expose removed jobs in web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Label your Docker containers and let this Go-powered daemon handle the schedule.
   `--pprof-address` for profiling and debugging.
 - **Optional web UI** enabled with `--enable-web` and bound via
   `--web-address` to view job status.
+- **Removed job history** keeps deregistered jobs in memory and shows them in the web UI.
 
 This fork is based off of [mcuadros/ofelia](https://github.com/mcuadros/ofelia).
 
@@ -76,7 +77,8 @@ When `--enable-pprof` is specified, the daemon starts a Go pprof HTTP
 server for profiling. Use `--pprof-address` to set the listening address
 (default `127.0.0.1:8080`).
 When `--enable-web` is specified, the daemon serves a small web UI at
-`--web-address` (default `:8081`) to inspect job status.
+`--web-address` (default `:8081`) to inspect job status. A second table lists
+jobs removed from the configuration via `/api/jobs/removed`.
 
 ### Environment variables
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,3 +36,6 @@ pprof-address = 127.0.0.1:8080
 The equivalent labels are `ofelia.enable-web`, `ofelia.web-address`,
 `ofelia.enable-pprof` and `ofelia.pprof-address`.
 
+The web UI exposes `/api/jobs` for active jobs and `/api/jobs/removed` for
+those that have been deregistered.
+

--- a/static/ui/index.html
+++ b/static/ui/index.html
@@ -23,6 +23,21 @@
     </thead>
     <tbody></tbody>
   </table>
+
+  <h1>Removed Jobs</h1>
+  <table id="removedJobs">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Schedule</th>
+        <th>Command</th>
+        <th>Last Status</th>
+        <th>Run Time</th>
+        <th>Duration</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
   <script>
     async function loadJobs() {
       const resp = await fetch('/api/jobs');
@@ -35,11 +50,29 @@
         const time = j.last_run ? new Date(j.last_run.date).toLocaleString() : '';
         const duration = j.last_run ? j.last_run.duration : '';
         tr.innerHTML = `<td>${j.name}</td><td>${j.schedule}</td><td>${j.command}</td><td>${status}</td><td>${time}</td><td>${duration}</td>`;
+      tbody.appendChild(tr);
+    });
+    }
+    async function loadRemoved() {
+      const resp = await fetch('/api/jobs/removed');
+      const jobs = await resp.json();
+      const tbody = document.querySelector('#removedJobs tbody');
+      tbody.innerHTML = '';
+      jobs.forEach(j => {
+        const tr = document.createElement('tr');
+        const status = j.last_run ? (j.last_run.failed ? 'Failed' : 'Success') : 'never';
+        const time = j.last_run ? new Date(j.last_run.date).toLocaleString() : '';
+        const duration = j.last_run ? j.last_run.duration : '';
+        tr.innerHTML = `<td>${j.name}</td><td>${j.schedule}</td><td>${j.command}</td><td>${status}</td><td>${time}</td><td>${duration}</td>`;
         tbody.appendChild(tr);
       });
     }
-    loadJobs();
-    setInterval(loadJobs, 5000);
+    function refresh() {
+      loadJobs();
+      loadRemoved();
+    }
+    refresh();
+    setInterval(refresh, 5000);
   </script>
 </body>
 </html>

--- a/web/server.go
+++ b/web/server.go
@@ -19,6 +19,7 @@ func NewServer(addr string, s *core.Scheduler) *Server {
 	server := &Server{addr: addr, scheduler: s}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/jobs", server.jobsHandler)
+	mux.HandleFunc("/api/jobs/removed", server.removedJobsHandler)
 	mux.Handle("/", http.FileServer(http.Dir("static/ui")))
 	server.srv = &http.Server{Addr: addr, Handler: mux}
 	return server
@@ -53,6 +54,38 @@ type apiJob struct {
 func (s *Server) jobsHandler(w http.ResponseWriter, r *http.Request) {
 	jobs := make([]apiJob, 0, len(s.scheduler.Jobs))
 	for _, job := range s.scheduler.Jobs {
+		var execInfo *apiExecution
+		if lrGetter, ok := job.(interface{ GetLastRun() *core.Execution }); ok {
+			if lr := lrGetter.GetLastRun(); lr != nil {
+				errStr := ""
+				if lr.Error != nil {
+					errStr = lr.Error.Error()
+				}
+				execInfo = &apiExecution{
+					Date:     lr.Date,
+					Duration: lr.Duration,
+					Failed:   lr.Failed,
+					Skipped:  lr.Skipped,
+					Error:    errStr,
+				}
+			}
+		}
+		jobs = append(jobs, apiJob{
+			Name:     job.GetName(),
+			Schedule: job.GetSchedule(),
+			Command:  job.GetCommand(),
+			LastRun:  execInfo,
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(jobs)
+}
+
+func (s *Server) removedJobsHandler(w http.ResponseWriter, r *http.Request) {
+	removed := s.scheduler.GetRemovedJobs()
+	jobs := make([]apiJob, 0, len(removed))
+	for _, job := range removed {
 		var execInfo *apiExecution
 		if lrGetter, ok := job.(interface{ GetLastRun() *core.Execution }); ok {
 			if lr := lrGetter.GetLastRun(); lr != nil {


### PR DESCRIPTION
## Summary
- keep track of jobs removed from the scheduler
- expose removed jobs through `/api/jobs/removed`
- display removed jobs in the web UI
- document removed job retention in README and architecture docs

## Testing
- `go vet ./...`
- `go test ./...`
