### PR TITLE
Expose active config via web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Label your Docker containers and let this Go-powered daemon handle the schedule.
 - **Optional pprof server** enabled with `--enable-pprof` and bound via
   `--pprof-address` for profiling and debugging.
 - **Optional web UI** enabled with `--enable-web` and bound via
-  `--web-address` to view job status.
+  `--web-address` to view job status and configuration.
 
 This fork is based off of [mcuadros/ofelia](https://github.com/mcuadros/ofelia).
 
@@ -76,7 +76,9 @@ When `--enable-pprof` is specified, the daemon starts a Go pprof HTTP
 server for profiling. Use `--pprof-address` to set the listening address
 (default `127.0.0.1:8080`).
 When `--enable-web` is specified, the daemon serves a small web UI at
-`--web-address` (default `:8081`) to inspect job status.
+`--web-address` (default `:8081`) to inspect job status and view the
+active configuration. The UI fetches JSON from `/api/jobs` and
+`/api/config` periodically.
 
 ### Environment variables
 

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -33,6 +33,7 @@ type DaemonCommand struct {
 	dockerHandler *DockerHandler
 	done          chan struct{}
 	Logger        core.Logger
+	config        *Config
 }
 
 // Execute runs the daemon
@@ -93,8 +94,9 @@ func (c *DaemonCommand) boot() (err error) {
 	c.applyOptions(config)
 	c.scheduler = config.sh
 	c.dockerHandler = config.dockerHandler
+	c.config = config
 	if c.EnableWeb {
-		c.webServer = web.NewServer(c.WebAddr, c.scheduler)
+		c.webServer = web.NewServer(c.WebAddr, c.scheduler, c.config)
 	}
 
 	return err
@@ -174,6 +176,11 @@ func (c *DaemonCommand) shutdown() error {
 
 	c.Logger.Warningf("Waiting running jobs.")
 	return c.scheduler.Stop()
+}
+
+// Config returns the currently active configuration.
+func (c *DaemonCommand) Config() *Config {
+	return c.config
 }
 
 func (c *DaemonCommand) applyOptions(config *Config) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,3 +36,11 @@ pprof-address = 127.0.0.1:8080
 The equivalent labels are `ofelia.enable-web`, `ofelia.web-address`,
 `ofelia.enable-pprof` and `ofelia.pprof-address`.
 
+When the web UI is enabled, the daemon exposes two JSON endpoints:
+
+- `/api/jobs` – list of all scheduled jobs and their last execution.
+- `/api/config` – the currently active configuration.
+
+The static interface polls these endpoints periodically to display live
+information.
+

--- a/static/ui/index.html
+++ b/static/ui/index.html
@@ -23,6 +23,8 @@
     </thead>
     <tbody></tbody>
   </table>
+  <h2>Configuration</h2>
+  <pre id="config"></pre>
   <script>
     async function loadJobs() {
       const resp = await fetch('/api/jobs');
@@ -38,8 +40,15 @@
         tbody.appendChild(tr);
       });
     }
+    async function loadConfig() {
+      const resp = await fetch('/api/config');
+      const cfg = await resp.json();
+      document.getElementById('config').textContent = JSON.stringify(cfg, null, 2);
+    }
     loadJobs();
+    loadConfig();
     setInterval(loadJobs, 5000);
+    setInterval(loadConfig, 5000);
   </script>
 </body>
 </html>

--- a/web/server.go
+++ b/web/server.go
@@ -12,13 +12,15 @@ import (
 type Server struct {
 	addr      string
 	scheduler *core.Scheduler
+	config    interface{}
 	srv       *http.Server
 }
 
-func NewServer(addr string, s *core.Scheduler) *Server {
-	server := &Server{addr: addr, scheduler: s}
+func NewServer(addr string, s *core.Scheduler, cfg interface{}) *Server {
+	server := &Server{addr: addr, scheduler: s, config: cfg}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/jobs", server.jobsHandler)
+	mux.HandleFunc("/api/config", server.configHandler)
 	mux.Handle("/", http.FileServer(http.Dir("static/ui")))
 	server.srv = &http.Server{Addr: addr, Handler: mux}
 	return server
@@ -79,4 +81,9 @@ func (s *Server) jobsHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(jobs)
+}
+
+func (s *Server) configHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(s.config)
 }


### PR DESCRIPTION
## Summary
- add daemon accessor for current config
- publish config through new `/api/config` endpoint
- display configuration in the web UI
- document the API and UI updates

## Testing
- `go vet ./...`
- `go test ./...`
