### PR TITLE
Add job history API and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Label your Docker containers and let this Go-powered daemon handle the schedule.
   `--pprof-address` for profiling and debugging.
 - **Optional web UI** enabled with `--enable-web` and bound via
   `--web-address` to view job status.
+- **HTTP API** exposing `/api/jobs` and `/api/jobs/{name}/history` for inspecting
+  job metadata and execution logs.
 
 This fork is based off of [mcuadros/ofelia](https://github.com/mcuadros/ofelia).
 
@@ -76,7 +78,8 @@ When `--enable-pprof` is specified, the daemon starts a Go pprof HTTP
 server for profiling. Use `--pprof-address` to set the listening address
 (default `127.0.0.1:8080`).
 When `--enable-web` is specified, the daemon serves a small web UI at
-`--web-address` (default `:8081`) to inspect job status.
+`--web-address` (default `:8081`) to inspect job status. The UI relies on the
+JSON API endpoints mentioned above to list jobs and show execution history.
 
 ### Environment variables
 

--- a/core/bare_job.go
+++ b/core/bare_job.go
@@ -78,3 +78,11 @@ func (j *BareJob) GetLastRun() *Execution {
 	defer j.lock.Unlock()
 	return j.lastRun
 }
+
+// GetHistory returns the slice containing past executions of the job.
+// The returned slice is not a copy; callers should not modify it.
+func (j *BareJob) GetHistory() []*Execution {
+	j.lock.Lock()
+	defer j.lock.Unlock()
+	return j.history
+}

--- a/core/bare_job_test.go
+++ b/core/bare_job_test.go
@@ -45,3 +45,16 @@ func (s *SuiteBareJob) TestHistoryUnlimited(c *C) {
 	job.SetLastRun(&Execution{})
 	c.Assert(len(job.history), Equals, 2)
 }
+
+func (s *SuiteBareJob) TestGetHistory(c *C) {
+	job := &BareJob{}
+	e1 := &Execution{}
+	e2 := &Execution{}
+	job.SetLastRun(e1)
+	job.SetLastRun(e2)
+
+	hist := job.GetHistory()
+	c.Assert(len(hist), Equals, 2)
+	c.Assert(hist[0], Equals, e1)
+	c.Assert(hist[1], Equals, e2)
+}

--- a/core/common.go
+++ b/core/common.go
@@ -40,6 +40,8 @@ type Job interface {
 	NotifyStop()
 	GetCronJobID() int
 	SetCronJobID(int)
+	// GetHistory returns all past executions retained for the job.
+	GetHistory() []*Execution
 }
 
 type Context struct {

--- a/core/context_log_test.go
+++ b/core/context_log_test.go
@@ -49,6 +49,7 @@ func (j *stubJob) NotifyStart()              {}
 func (j *stubJob) NotifyStop()               {}
 func (j *stubJob) GetCronJobID() int         { return 0 }
 func (j *stubJob) SetCronJobID(id int)       {}
+func (j *stubJob) GetHistory() []*Execution  { return nil }
 
 // TestContextLogDefault verifies that Context.Log uses Noticef when no error or skip.
 func TestContextLogDefault(t *testing.T) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,3 +36,14 @@ pprof-address = 127.0.0.1:8080
 The equivalent labels are `ofelia.enable-web`, `ofelia.web-address`,
 `ofelia.enable-pprof` and `ofelia.pprof-address`.
 
+When the web server is enabled, Ofelia exposes a small HTTP API used by the UI.
+Two endpoints are currently available:
+
+* `/api/jobs` returns all configured jobs including metadata and the last
+  execution.
+* `/api/jobs/{name}/history` returns the full execution history for the given
+  job, including captured stdout and stderr streams.
+
+The static pages under `static/ui/` consume this API to present job status and
+previous runs.
+

--- a/static/ui/history.html
+++ b/static/ui/history.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Job History</title>
+  <style>
+    table { border-collapse: collapse; }
+    th, td { border: 1px solid #ccc; padding: 4px; }
+    pre { margin: 0; }
+  </style>
+</head>
+<body>
+  <h1>History for <span id="job-name"></span></h1>
+  <table id="history">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Duration</th>
+        <th>Status</th>
+        <th>Stdout</th>
+        <th>Stderr</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+<script>
+  const params = new URLSearchParams(location.search);
+  const job = params.get('job');
+  document.getElementById('job-name').textContent = job;
+
+  async function loadHistory() {
+    const resp = await fetch(`/api/jobs/${encodeURIComponent(job)}/history`);
+    const entries = await resp.json();
+    const tbody = document.querySelector('#history tbody');
+    tbody.innerHTML = '';
+    entries.forEach(e => {
+      const tr = document.createElement('tr');
+      const status = e.failed ? 'Failed' : (e.skipped ? 'Skipped' : 'Success');
+      const date = new Date(e.date).toLocaleString();
+      tr.innerHTML = `<td>${date}</td><td>${e.duration}</td><td>${status}</td>` +
+        `<td><details><summary>stdout</summary><pre>${e.stdout}</pre></details></td>` +
+        `<td><details><summary>stderr</summary><pre>${e.stderr}</pre></details></td>`;
+      tbody.appendChild(tr);
+    });
+  }
+  loadHistory();
+</script>
+</body>
+</html>

--- a/static/ui/index.html
+++ b/static/ui/index.html
@@ -19,6 +19,7 @@
         <th>Last Status</th>
         <th>Run Time</th>
         <th>Duration</th>
+        <th>History</th>
       </tr>
     </thead>
     <tbody></tbody>
@@ -34,7 +35,8 @@
         const status = j.last_run ? (j.last_run.failed ? 'Failed' : 'Success') : 'never';
         const time = j.last_run ? new Date(j.last_run.date).toLocaleString() : '';
         const duration = j.last_run ? j.last_run.duration : '';
-        tr.innerHTML = `<td>${j.name}</td><td>${j.schedule}</td><td>${j.command}</td><td>${status}</td><td>${time}</td><td>${duration}</td>`;
+        const link = `<a href="history.html?job=${encodeURIComponent(j.name)}">view</a>`;
+        tr.innerHTML = `<td>${j.name}</td><td>${j.schedule}</td><td>${j.command}</td><td>${status}</td><td>${time}</td><td>${duration}</td><td>${link}</td>`;
         tbody.appendChild(tr);
       });
     }

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -1,0 +1,65 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/netresearch/ofelia/core"
+	. "gopkg.in/check.v1"
+)
+
+type SuiteServer struct{}
+
+var _ = Suite(&SuiteServer{})
+
+func Test(t *testing.T) { TestingT(t) }
+
+// minimal job used for server tests
+type testJob struct{ core.BareJob }
+
+func (j *testJob) Run(ctx *core.Context) error { return nil }
+
+type testLogger struct{}
+
+func (*testLogger) Criticalf(string, ...interface{}) {}
+func (*testLogger) Debugf(string, ...interface{})    {}
+func (*testLogger) Errorf(string, ...interface{})    {}
+func (*testLogger) Noticef(string, ...interface{})   {}
+func (*testLogger) Warningf(string, ...interface{})  {}
+
+func (s *SuiteServer) TestJobHistoryHandler(c *C) {
+	sc := core.NewScheduler(&testLogger{})
+	job := &testJob{core.BareJob{Name: "foo", Schedule: "@hourly", Command: "echo"}}
+	c.Assert(sc.AddJob(job), IsNil)
+
+	e, err := core.NewExecution()
+	c.Assert(err, IsNil)
+	e.Start()
+	e.OutputStream.Write([]byte("out"))
+	e.ErrorStream.Write([]byte("err"))
+	e.Stop(nil)
+	job.SetLastRun(e)
+
+	srv := NewServer(":0", sc)
+	req := httptest.NewRequest("GET", "/api/jobs/foo/history", nil)
+	w := httptest.NewRecorder()
+	srv.jobHistoryHandler(w, req)
+
+	c.Assert(w.Code, Equals, http.StatusOK)
+	var hist []apiExecution
+	c.Assert(json.Unmarshal(w.Body.Bytes(), &hist), IsNil)
+	c.Assert(len(hist), Equals, 1)
+	c.Assert(hist[0].Stdout, Equals, "out")
+	c.Assert(hist[0].Stderr, Equals, "err")
+}
+
+func (s *SuiteServer) TestJobHistoryHandlerNotFound(c *C) {
+	sc := core.NewScheduler(&testLogger{})
+	srv := NewServer(":0", sc)
+	req := httptest.NewRequest("GET", "/api/jobs/unknown/history", nil)
+	w := httptest.NewRecorder()
+	srv.jobHistoryHandler(w, req)
+	c.Assert(w.Code, Equals, http.StatusNotFound)
+}


### PR DESCRIPTION
## Summary
- expose job history via Job interface
- implement history retrieval in BareJob
- serve `/api/jobs/{name}/history` endpoint
- include stdout/stderr in API responses
- show history links in the UI and add a new history page
- document new features
- cover server and BareJob history with tests

## Testing
- `go vet ./...`
- `go test ./...`
