### PR TITLE
Expose active config via API and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ server for profiling. Use `--pprof-address` to set the listening address
 (default `127.0.0.1:8080`).
 When `--enable-web` is specified, the daemon serves a small web UI at
 `--web-address` (default `:8081`) to inspect job status. A second table lists
-jobs removed from the configuration via `/api/jobs/removed`.
+jobs removed from the configuration via `/api/jobs/removed`. The endpoint
+`/api/config` returns the active configuration as JSON.
 
 ### Environment variables
 

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -31,6 +31,7 @@ type DaemonCommand struct {
 	pprofServer   *http.Server
 	webServer     *web.Server
 	dockerHandler *DockerHandler
+	config        *Config
 	done          chan struct{}
 	Logger        core.Logger
 }
@@ -93,8 +94,9 @@ func (c *DaemonCommand) boot() (err error) {
 	c.applyOptions(config)
 	c.scheduler = config.sh
 	c.dockerHandler = config.dockerHandler
+	c.config = config
 	if c.EnableWeb {
-		c.webServer = web.NewServer(c.WebAddr, c.scheduler)
+		c.webServer = web.NewServer(c.WebAddr, c.scheduler, c.config)
 	}
 
 	return err
@@ -208,4 +210,9 @@ func (c *DaemonCommand) applyOptions(config *Config) {
 	if c.LogLevel != "" {
 		config.Global.LogLevel = c.LogLevel
 	}
+}
+
+// Config returns the active configuration used by the daemon.
+func (c *DaemonCommand) Config() *Config {
+	return c.config
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -36,6 +36,7 @@ pprof-address = 127.0.0.1:8080
 The equivalent labels are `ofelia.enable-web`, `ofelia.web-address`,
 `ofelia.enable-pprof` and `ofelia.pprof-address`.
 
-The web UI exposes `/api/jobs` for active jobs and `/api/jobs/removed` for
-those that have been deregistered.
+The web UI exposes `/api/jobs` for active jobs, `/api/jobs/removed` for those
+that have been deregistered and `/api/config` with the currently active
+configuration.
 

--- a/static/ui/index.html
+++ b/static/ui/index.html
@@ -38,6 +38,8 @@
     </thead>
     <tbody></tbody>
   </table>
+  <h1>Configuration</h1>
+  <pre id="config"></pre>
   <script>
     async function loadJobs() {
       const resp = await fetch('/api/jobs');
@@ -67,9 +69,15 @@
         tbody.appendChild(tr);
       });
     }
+    async function loadConfig() {
+      const resp = await fetch('/api/config');
+      const cfg = await resp.json();
+      document.getElementById('config').textContent = JSON.stringify(cfg, null, 2);
+    }
     function refresh() {
       loadJobs();
       loadRemoved();
+      loadConfig();
     }
     refresh();
     setInterval(refresh, 5000);

--- a/web/server.go
+++ b/web/server.go
@@ -12,14 +12,16 @@ import (
 type Server struct {
 	addr      string
 	scheduler *core.Scheduler
+	config    interface{}
 	srv       *http.Server
 }
 
-func NewServer(addr string, s *core.Scheduler) *Server {
-	server := &Server{addr: addr, scheduler: s}
+func NewServer(addr string, s *core.Scheduler, cfg interface{}) *Server {
+	server := &Server{addr: addr, scheduler: s, config: cfg}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/jobs", server.jobsHandler)
 	mux.HandleFunc("/api/jobs/removed", server.removedJobsHandler)
+	mux.HandleFunc("/api/config", server.configHandler)
 	mux.Handle("/", http.FileServer(http.Dir("static/ui")))
 	server.srv = &http.Server{Addr: addr, Handler: mux}
 	return server
@@ -112,4 +114,9 @@ func (s *Server) removedJobsHandler(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(jobs)
+}
+
+func (s *Server) configHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(s.config)
 }


### PR DESCRIPTION
## Summary
- provide daemon access to the active configuration via `Config()`
- send the config to the web server and expose `/api/config`
- show configuration info in the UI and refresh periodically
- document the endpoint in README and architecture docs

## Testing
- `go vet ./...`
- `go test ./...`

---
Addresses:
- https://github.com/mcuadros/ofelia/issues/122
- https://github.com/mcuadros/ofelia/issues/169