### PR TITLE
Add execution history API

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ server for profiling. Use `--pprof-address` to set the listening address
 When `--enable-web` is specified, the daemon serves a small web UI at
 `--web-address` (default `:8081`) to inspect job status. A second table lists
 jobs removed from the configuration via `/api/jobs/removed`. The endpoint
+`/api/jobs/{name}/history` exposes past runs including stdout and stderr while
 `/api/config` returns the active configuration as JSON.
 
 ### Environment variables

--- a/core/bare_job.go
+++ b/core/bare_job.go
@@ -78,3 +78,12 @@ func (j *BareJob) GetLastRun() *Execution {
 	defer j.lock.Unlock()
 	return j.lastRun
 }
+
+// GetHistory returns a copy of the job's execution history.
+func (j *BareJob) GetHistory() []*Execution {
+	j.lock.Lock()
+	defer j.lock.Unlock()
+	hist := make([]*Execution, len(j.history))
+	copy(hist, j.history)
+	return hist
+}

--- a/core/bare_job_test.go
+++ b/core/bare_job_test.go
@@ -45,3 +45,16 @@ func (s *SuiteBareJob) TestHistoryUnlimited(c *C) {
 	job.SetLastRun(&Execution{})
 	c.Assert(len(job.history), Equals, 2)
 }
+
+func (s *SuiteBareJob) TestGetHistory(c *C) {
+	job := &BareJob{}
+	e1, e2 := &Execution{ID: "1"}, &Execution{ID: "2"}
+	job.SetLastRun(e1)
+	job.SetLastRun(e2)
+	hist := job.GetHistory()
+	c.Assert(hist, HasLen, 2)
+	c.Assert(hist[0], Equals, e1)
+	c.Assert(hist[1], Equals, e2)
+	hist[0] = nil
+	c.Assert(job.history[0], Equals, e1)
+}

--- a/core/common.go
+++ b/core/common.go
@@ -40,6 +40,7 @@ type Job interface {
 	NotifyStop()
 	GetCronJobID() int
 	SetCronJobID(int)
+	GetHistory() []*Execution
 }
 
 type Context struct {

--- a/core/context_log_test.go
+++ b/core/context_log_test.go
@@ -49,6 +49,7 @@ func (j *stubJob) NotifyStart()              {}
 func (j *stubJob) NotifyStop()               {}
 func (j *stubJob) GetCronJobID() int         { return 0 }
 func (j *stubJob) SetCronJobID(id int)       {}
+func (j *stubJob) GetHistory() []*Execution  { return nil }
 
 // TestContextLogDefault verifies that Context.Log uses Noticef when no error or skip.
 func TestContextLogDefault(t *testing.T) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,6 +37,7 @@ The equivalent labels are `ofelia.enable-web`, `ofelia.web-address`,
 `ofelia.enable-pprof` and `ofelia.pprof-address`.
 
 The web UI exposes `/api/jobs` for active jobs, `/api/jobs/removed` for those
-that have been deregistered and `/api/config` with the currently active
-configuration.
+that have been deregistered and `/api/jobs/{name}/history` with the execution
+history of a specific job, including stdout and stderr for each run.
+`/api/config` returns the currently active configuration.
 

--- a/static/ui/index.html
+++ b/static/ui/index.html
@@ -24,6 +24,20 @@
     <tbody></tbody>
   </table>
 
+  <h1>Job History for <span id="historyJob"></span></h1>
+  <table id="history">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Duration</th>
+        <th>Status</th>
+        <th>Stdout</th>
+        <th>Stderr</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+
   <h1>Removed Jobs</h1>
   <table id="removedJobs">
     <thead>
@@ -52,8 +66,26 @@
         const time = j.last_run ? new Date(j.last_run.date).toLocaleString() : '';
         const duration = j.last_run ? j.last_run.duration : '';
         tr.innerHTML = `<td>${j.name}</td><td>${j.schedule}</td><td>${j.command}</td><td>${status}</td><td>${time}</td><td>${duration}</td>`;
-      tbody.appendChild(tr);
-    });
+        tr.addEventListener('click', () => loadHistory(j.name));
+        tbody.appendChild(tr);
+      });
+    }
+
+    async function loadHistory(name) {
+      document.getElementById('historyJob').textContent = name;
+      const resp = await fetch(`/api/jobs/${name}/history`);
+      const hist = await resp.json();
+      const tbody = document.querySelector('#history tbody');
+      tbody.innerHTML = '';
+      hist.forEach(e => {
+        const row = document.createElement('tr');
+        const status = e.failed ? 'Failed' : (e.skipped ? 'Skipped' : 'Success');
+        const time = new Date(e.date).toLocaleString();
+        row.innerHTML = `<td>${time}</td><td>${e.duration}</td><td>${status}</td>` +
+          `<td><details><summary>stdout</summary><pre>${e.stdout}</pre></details></td>` +
+          `<td><details><summary>stderr</summary><pre>${e.stderr}</pre></details></td>`;
+        tbody.appendChild(row);
+      });
     }
     async function loadRemoved() {
       const resp = await fetch('/api/jobs/removed');

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -1,0 +1,81 @@
+package web
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/netresearch/ofelia/core"
+)
+
+type stubLogger struct{}
+
+func (stubLogger) Criticalf(string, ...interface{}) {}
+func (stubLogger) Debugf(string, ...interface{})    {}
+func (stubLogger) Errorf(string, ...interface{})    {}
+func (stubLogger) Noticef(string, ...interface{})   {}
+func (stubLogger) Warningf(string, ...interface{})  {}
+
+type testJob struct{ core.BareJob }
+
+func (j *testJob) Run(*core.Context) error { return nil }
+
+func TestHistoryEndpoint(t *testing.T) {
+	job := &testJob{}
+	job.Name = "job1"
+	job.Schedule = "@daily"
+	job.Command = "echo"
+	e, _ := core.NewExecution()
+	e.OutputStream.Write([]byte("out"))
+	e.ErrorStream.Write([]byte("err"))
+	job.SetLastRun(e)
+	sched := &core.Scheduler{Jobs: []core.Job{job}, Logger: &stubLogger{}}
+	srv := NewServer("", sched, nil)
+
+	req := httptest.NewRequest("GET", "/api/jobs/job1/history", nil)
+	w := httptest.NewRecorder()
+	srv.srv.Handler.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("unexpected status %d", w.Code)
+	}
+	var data []apiExecution
+	if err := json.NewDecoder(w.Body).Decode(&data); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(data) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(data))
+	}
+	if data[0].Stdout != "out" || data[0].Stderr != "err" {
+		t.Fatalf("unexpected output %v", data[0])
+	}
+}
+
+func TestJobsHandlerIncludesOutput(t *testing.T) {
+	job := &testJob{}
+	job.Name = "job1"
+	job.Schedule = "@daily"
+	job.Command = "echo"
+	e, _ := core.NewExecution()
+	e.OutputStream.Write([]byte("out"))
+	e.ErrorStream.Write([]byte("err"))
+	job.SetLastRun(e)
+	sched := &core.Scheduler{Jobs: []core.Job{job}, Logger: &stubLogger{}}
+	srv := NewServer("", sched, nil)
+
+	req := httptest.NewRequest("GET", "/api/jobs", nil)
+	w := httptest.NewRecorder()
+	srv.srv.Handler.ServeHTTP(w, req)
+	if w.Code != 200 {
+		t.Fatalf("unexpected status %d", w.Code)
+	}
+	var jobs []apiJob
+	if err := json.NewDecoder(w.Body).Decode(&jobs); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(jobs) != 1 || jobs[0].LastRun == nil {
+		t.Fatalf("unexpected jobs %v", jobs)
+	}
+	if jobs[0].LastRun.Stdout != "out" || jobs[0].LastRun.Stderr != "err" {
+		t.Fatalf("stdout/stderr not included")
+	}
+}


### PR DESCRIPTION
## Summary
- expose GetHistory on BareJob and Job interface
- include stdout/stderr in API execution data
- add /api/jobs/{name}/history endpoint
- display run history in the web UI
- document new API and UI features
- cover new code with unit tests

## Testing
- `go vet ./...`
- `go test ./...`
