### PR TITLE
Fix error wrapping

### DIFF
--- a/core/common.go
+++ b/core/common.go
@@ -282,7 +282,7 @@ func buildPullOptions(image string) (docker.PullImageOptions, docker.AuthConfigu
 func pullImage(client *docker.Client, image string) error {
 	opts, auth := buildPullOptions(image)
 	if err := client.PullImage(opts, auth); err != nil {
-		return fmt.Errorf("error pulling image %q: %s", image, err)
+		return fmt.Errorf("error pulling image %q: %w", image, err)
 	}
 	return nil
 }

--- a/core/execjob.go
+++ b/core/execjob.go
@@ -64,7 +64,7 @@ func (j *ExecJob) buildExec() (*docker.Exec, error) {
 	})
 
 	if err != nil {
-		return exec, fmt.Errorf("error creating exec: %s", err)
+		return exec, fmt.Errorf("error creating exec: %w", err)
 	}
 
 	return exec, nil
@@ -79,7 +79,7 @@ func (j *ExecJob) startExec(e *Execution) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("error starting exec: %s", err)
+		return fmt.Errorf("error starting exec: %w", err)
 	}
 
 	return nil
@@ -89,7 +89,7 @@ func (j *ExecJob) inspectExec() (*docker.ExecInspect, error) {
 	i, err := j.Client.InspectExec(j.execID)
 
 	if err != nil {
-		return i, fmt.Errorf("error inspecting exec: %s", err)
+		return i, fmt.Errorf("error inspecting exec: %w", err)
 	}
 
 	return i, nil

--- a/core/runjob.go
+++ b/core/runjob.go
@@ -207,7 +207,7 @@ func (j *RunJob) buildContainer() (*docker.Container, error) {
 	})
 
 	if err != nil {
-		return c, fmt.Errorf("error creating exec: %s", err)
+		return c, fmt.Errorf("error creating exec: %w", err)
 	}
 
 	if j.Network != "" {
@@ -219,7 +219,7 @@ func (j *RunJob) buildContainer() (*docker.Container, error) {
 				if err := j.Client.ConnectNetwork(network.ID, docker.NetworkConnectionOptions{
 					Container: c.ID,
 				}); err != nil {
-					return c, fmt.Errorf("error connecting container to network: %s", err)
+					return c, fmt.Errorf("error connecting container to network: %w", err)
 				}
 			}
 		}

--- a/core/runservice.go
+++ b/core/runservice.go
@@ -106,7 +106,7 @@ func (j *RunServiceJob) watchContainer(ctx *Context, svcID string) error {
 
 	svc, err := j.Client.InspectService(svcID)
 	if err != nil {
-		return fmt.Errorf("Failed to inspect service %s: %s", svcID, err.Error())
+		return fmt.Errorf("failed to inspect service %s: %w", svcID, err)
 	}
 
 	startTime := time.Now()


### PR DESCRIPTION
## Summary
- wrap underlying errors using `%w`
- expose wrapped errors from `runservice`, `runjob`, `execjob`, and `common`

## Testing
- `go vet ./...`
- `go test ./...`
