### PR TITLE
Isolate integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,39 @@ on:
       - master
 
 jobs:
-  test:
+  unit:
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [1.24.x]
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Format check
+        run: |
+          unformatted=$(gofmt -l $(git ls-files '*.go'))
+          if [ -n "$unformatted" ]; then
+            echo "The following files are not formatted:" >&2
+            echo "$unformatted" >&2
+            exit 1
+          fi
+
+      - name: Unit tests
+        run: go test ./...
+
+  integration:
+    needs: unit
     strategy:
       fail-fast: false
       matrix:
@@ -34,17 +66,5 @@ jobs:
       - name: Confirm Docker
         run: docker info
 
-      - name: Vet
-        run: go vet ./...
-
-      - name: Format check
-        run: |
-          unformatted=$(gofmt -l $(git ls-files '*.go'))
-          if [ -n "$unformatted" ]; then
-            echo "The following files are not formatted:" >&2
-            echo "$unformatted" >&2
-            exit 1
-          fi
-
-      - name: Test
-        run: go test ./...
+      - name: Integration tests
+        run: go test -tags=integration ./...

--- a/cli/docker_handler_integration_test.go
+++ b/cli/docker_handler_integration_test.go
@@ -1,0 +1,43 @@
+//go:build integration
+// +build integration
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/fsouza/go-dockerclient/testing"
+	. "gopkg.in/check.v1"
+)
+
+func (s *DockerHandlerSuite) TestPollingDisabled(c *C) {
+	ch := make(chan struct{}, 1)
+	notifier := &chanNotifier{ch: ch}
+
+	server, err := testing.NewServer("127.0.0.1:0", nil, nil)
+	c.Assert(err, IsNil)
+	defer server.Stop()
+	server.CustomHandler("/containers/json", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintln(w, `[{"Names":["/cont"],"Labels":{"ofelia.enabled":"true"}}]`)
+	}))
+	tsURL := server.URL()
+
+	os.Setenv("DOCKER_HOST", "tcp://"+strings.TrimPrefix(tsURL, "http://"))
+	defer os.Unsetenv("DOCKER_HOST")
+
+	cfg := &DockerConfig{Filters: []string{}, PollInterval: time.Millisecond * 50, UseEvents: false, DisablePolling: true}
+	_, err = NewDockerHandler(context.Background(), notifier, &TestLogger{}, cfg, nil)
+	c.Assert(err, IsNil)
+
+	select {
+	case <-ch:
+		c.Error("unexpected update")
+	case <-time.After(time.Millisecond * 150):
+	}
+}

--- a/cli/docker_handler_test.go
+++ b/cli/docker_handler_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
-	"github.com/fsouza/go-dockerclient/testing"
 	. "gopkg.in/check.v1"
 )
 
@@ -126,34 +125,6 @@ func (s *DockerHandlerSuite) TestGetDockerLabelsValid(c *C) {
 		},
 	}
 	c.Assert(labels, DeepEquals, expected)
-}
-
-// TestPollingDisabled ensures no updates are triggered when polling is disabled and no events occur
-func (s *DockerHandlerSuite) TestPollingDisabled(c *C) {
-	ch := make(chan struct{}, 1)
-	notifier := &chanNotifier{ch: ch}
-
-	server, err := testing.NewServer("127.0.0.1:0", nil, nil)
-	c.Assert(err, IsNil)
-	defer server.Stop()
-	server.CustomHandler("/containers/json", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintln(w, `[{"Names":["/cont"],"Labels":{"ofelia.enabled":"true"}}]`)
-	}))
-	tsURL := server.URL()
-
-	os.Setenv("DOCKER_HOST", "tcp://"+strings.TrimPrefix(tsURL, "http://"))
-	defer os.Unsetenv("DOCKER_HOST")
-
-	cfg := &DockerConfig{Filters: []string{}, PollInterval: time.Millisecond * 50, UseEvents: false, DisablePolling: true}
-	_, err = NewDockerHandler(context.Background(), notifier, &TestLogger{}, cfg, nil)
-	c.Assert(err, IsNil)
-
-	select {
-	case <-ch:
-		c.Error("unexpected update")
-	case <-time.After(time.Millisecond * 150):
-	}
 }
 
 // TestWatchInvalidInterval verifies that watch exits immediately when

--- a/core/execjob_integration_test.go
+++ b/core/execjob_integration_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package core
 
 import (

--- a/core/runjob_integration_test.go
+++ b/core/runjob_integration_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package core
 
 import (

--- a/core/runservice_integration_test.go
+++ b/core/runservice_integration_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package core
 
 import (

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,12 +1,21 @@
 # Running Tests
 
-The unit tests expect Go to be installed and a Docker daemon available. The CI pipeline starts Docker before running the test suite.
+Unit tests can be run without Docker. Integration tests require either a running
+Docker daemon or the Docker test server.
 
-1. Install Docker and make sure the daemon is running.
-2. Fetch dependencies and run the tests:
+## Unit tests
 
 ```sh
 go test ./...
 ```
 
-Some tests start a mocked Docker server and do not require network access, but Docker must be present so the client library works correctly.
+## Integration tests
+
+Start Docker and run the suite with the `integration` build tag:
+
+```sh
+go test -tags=integration ./...
+```
+
+The CI workflow executes unit tests first and runs the integration tests in a
+separate step.


### PR DESCRIPTION
## Summary
- tag docker-dependent tests with `integration`
- run unit tests and integration tests separately in CI
- document new testing workflow

## Testing
- `go vet ./...`
- `go test ./...`
- `go test -tags=integration ./...`
