### PR TITLE
Add job control endpoints to web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,12 @@ When `--enable-pprof` is specified, the daemon starts a Go pprof HTTP
 server for profiling. Use `--pprof-address` to set the listening address
 (default `127.0.0.1:8080`).
 When `--enable-web` is specified, the daemon serves a small web UI at
-`--web-address` (default `:8081`) to inspect job status. A second table lists
-jobs removed from the configuration via `/api/jobs/removed`. The endpoint
-`/api/jobs/{name}/history` exposes past runs including stdout, stderr and any
-error messages while `/api/config` returns the active configuration as JSON.
+`--web-address` (default `:8081`). Besides inspecting running and removed jobs,
+the UI allows starting jobs manually, disabling or enabling them and creating,
+updating or deleting local jobs. A second table lists jobs removed from the
+configuration via `/api/jobs/removed`. The endpoint `/api/jobs/{name}/history`
+exposes past runs including stdout, stderr and any error messages while
+`/api/config` returns the active configuration as JSON.
 
 ### Environment variables
 

--- a/static/ui/index.html
+++ b/static/ui/index.html
@@ -19,10 +19,33 @@
         <th>Last Status</th>
         <th>Run Time</th>
         <th>Duration</th>
+        <th>Actions</th>
       </tr>
     </thead>
     <tbody></tbody>
   </table>
+
+  <h1>Disabled Jobs</h1>
+  <table id="disabledJobs">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Schedule</th>
+        <th>Command</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+
+  <h2>Create/Update Job</h2>
+  <form id="jobForm">
+    <label>Name <input id="jobName" required></label>
+    <label>Schedule <input id="jobSchedule" required></label>
+    <label>Command <input id="jobCommand" required></label>
+    <button type="submit">Save</button>
+  </form>
+  <button id="deleteBtn">Delete Job</button>
 
   <h1>Job History for <span id="historyJob"></span></h1>
   <table id="history">
@@ -66,8 +89,23 @@
         const status = j.last_run ? (j.last_run.failed ? 'Failed' : 'Success') : 'never';
         const time = j.last_run ? new Date(j.last_run.date).toLocaleString() : '';
         const duration = j.last_run ? j.last_run.duration : '';
-        tr.innerHTML = `<td>${j.name}</td><td>${j.schedule}</td><td>${j.command}</td><td>${status}</td><td>${time}</td><td>${duration}</td>`;
+        tr.innerHTML = `<td>${j.name}</td><td>${j.schedule}</td><td>${j.command}</td><td>${status}</td><td>${time}</td><td>${duration}</td>` +
+          `<td><button onclick="runJob('${j.name}')">Run</button>` +
+          `<button onclick="disableJob('${j.name}')">Disable</button></td>`;
         tr.addEventListener('click', () => loadHistory(j.name));
+        tbody.appendChild(tr);
+      });
+    }
+
+    async function loadDisabled() {
+      const resp = await fetch('/api/jobs/disabled');
+      const jobs = await resp.json();
+      const tbody = document.querySelector('#disabledJobs tbody');
+      tbody.innerHTML = '';
+      jobs.forEach(j => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `<td>${j.name}</td><td>${j.schedule}</td><td>${j.command}</td>` +
+          `<td><button onclick="enableJob('${j.name}')">Enable</button></td>`;
         tbody.appendChild(tr);
       });
     }
@@ -109,8 +147,39 @@
       const cfg = await resp.json();
       document.getElementById('config').textContent = JSON.stringify(cfg, null, 2);
     }
+
+    async function runJob(name) {
+      await fetch('/api/jobs/run', {method: 'POST', body: JSON.stringify({name}), headers: {'Content-Type': 'application/json'}});
+      refresh();
+    }
+
+    async function disableJob(name) {
+      await fetch('/api/jobs/disable', {method: 'POST', body: JSON.stringify({name}), headers: {'Content-Type': 'application/json'}});
+      refresh();
+    }
+
+    async function enableJob(name) {
+      await fetch('/api/jobs/enable', {method: 'POST', body: JSON.stringify({name}), headers: {'Content-Type': 'application/json'}});
+      refresh();
+    }
+
+    document.getElementById('jobForm').addEventListener('submit', async e => {
+      e.preventDefault();
+      const name = document.getElementById('jobName').value;
+      const schedule = document.getElementById('jobSchedule').value;
+      const command = document.getElementById('jobCommand').value;
+      await fetch('/api/jobs/update', {method: 'POST', body: JSON.stringify({name, schedule, command}), headers: {'Content-Type': 'application/json'}});
+      refresh();
+    });
+
+    document.getElementById('deleteBtn').addEventListener('click', async () => {
+      const name = document.getElementById('jobName').value;
+      await fetch('/api/jobs/delete', {method: 'POST', body: JSON.stringify({name}), headers: {'Content-Type': 'application/json'}});
+      refresh();
+    });
     function refresh() {
       loadJobs();
+      loadDisabled();
       loadRemoved();
       loadConfig();
     }


### PR DESCRIPTION
## Summary
- extend Scheduler with disabled jobs and manual job runner
- add REST endpoints to manage jobs
- enhance HTML UI to run/disable/enable and CRUD jobs
- document web UI functionality

## Testing
- `go vet ./...`
- `go test ./...`
