### PR TITLE
Handle label run jobs separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ In order to achieve this, you simply have to use Docker containers with the labe
 ### Hybrid configuration (INI files + Docker)
 
 You can specify part of the configuration on the INI files, such as globals for the middlewares or even declare tasks in there but also merge them with Docker.
-The Docker labels will be parsed, added and removed on the fly but the config file can also be used.
+The Docker labels will be parsed, added and removed on the fly but the config file can also be used. Run jobs defined in the INI file remain active even when no labeled containers are found. Jobs detected via Docker labels are managed separately and can disappear when the corresponding container is removed.
 
 Use the INI file to:
 

--- a/static/ui/index.html
+++ b/static/ui/index.html
@@ -16,6 +16,7 @@
         <th>Name</th>
         <th>Schedule</th>
         <th>Command</th>
+        <th>Origin</th>
         <th>Last Status</th>
         <th>Run Time</th>
         <th>Duration</th>
@@ -32,6 +33,7 @@
         <th>Name</th>
         <th>Schedule</th>
         <th>Command</th>
+        <th>Origin</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -69,6 +71,7 @@
         <th>Name</th>
         <th>Schedule</th>
         <th>Command</th>
+        <th>Origin</th>
         <th>Last Status</th>
         <th>Run Time</th>
         <th>Duration</th>
@@ -89,7 +92,7 @@
         const status = j.last_run ? (j.last_run.failed ? 'Failed' : 'Success') : 'never';
         const time = j.last_run ? new Date(j.last_run.date).toLocaleString() : '';
         const duration = j.last_run ? j.last_run.duration : '';
-        tr.innerHTML = `<td>${j.name}</td><td>${j.schedule}</td><td>${j.command}</td><td>${status}</td><td>${time}</td><td>${duration}</td>` +
+        tr.innerHTML = `<td>${j.name}</td><td>${j.schedule}</td><td>${j.command}</td><td>${j.origin}</td><td>${status}</td><td>${time}</td><td>${duration}</td>` +
           `<td><button onclick="runJob('${j.name}')">Run</button>` +
           `<button onclick="disableJob('${j.name}')">Disable</button></td>`;
         tr.addEventListener('click', () => loadHistory(j.name));
@@ -104,7 +107,7 @@
       tbody.innerHTML = '';
       jobs.forEach(j => {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${j.name}</td><td>${j.schedule}</td><td>${j.command}</td>` +
+        tr.innerHTML = `<td>${j.name}</td><td>${j.schedule}</td><td>${j.command}</td><td>${j.origin}</td>` +
           `<td><button onclick="enableJob('${j.name}')">Enable</button></td>`;
         tbody.appendChild(tr);
       });
@@ -138,7 +141,7 @@
         const status = j.last_run ? (j.last_run.failed ? 'Failed' : 'Success') : 'never';
         const time = j.last_run ? new Date(j.last_run.date).toLocaleString() : '';
         const duration = j.last_run ? j.last_run.duration : '';
-        tr.innerHTML = `<td>${j.name}</td><td>${j.schedule}</td><td>${j.command}</td><td>${status}</td><td>${time}</td><td>${duration}</td>`;
+        tr.innerHTML = `<td>${j.name}</td><td>${j.schedule}</td><td>${j.command}</td><td>${j.origin}</td><td>${status}</td><td>${time}</td><td>${duration}</td>`;
         tbody.appendChild(tr);
       });
     }


### PR DESCRIPTION
## Summary
- add `LabelRunJobs` to keep label based run jobs
- keep INI jobs on Docker updates
- expose job origin via API and UI
- test label polling and API origin output
- document hybrid behaviour

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_683d3869f0e88333a65c0c4d6dcc26bb