### PR TITLE
Fix CodeQL error on merge queue branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
 
   codeql:
     # skip merge queue branches as they disappear before the upload step
-    if: github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/gh-readonly-queue/')
+    if: (github.event_name != 'push') || (!startsWith(github.ref, 'refs/heads/gh-readonly-queue/'))
     name: CodeQL Analysis
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,8 @@ jobs:
         run: go test -tags=integration ./...
 
   codeql:
+    # skip merge queue branches as they disappear before the upload step
+    if: github.event_name != 'push' || !startsWith(github.ref, 'refs/heads/gh-readonly-queue/')
     name: CodeQL Analysis
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- avoid CodeQL upload errors by skipping the job when triggered by the merge queue

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_683d97b0a4448333977e4c5e2f2429a2