### PR TITLE
Enhance UI job controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Label your Docker containers and let this Go-powered daemon handle the schedule.
 - **Optional web UI** enabled with `--enable-web` and bound via
   `--web-address` to view job status.
 - **Removed job history** keeps deregistered jobs in memory and shows them in the web UI.
+- **Enhanced web UI** allows editing and deleting jobs, shows job origin and type and displays each job's configuration.
 
 This fork is based off of [mcuadros/ofelia](https://github.com/mcuadros/ofelia).
 

--- a/static/ui/index.html
+++ b/static/ui/index.html
@@ -6,6 +6,8 @@
   <style>
     table { border-collapse: collapse; }
     th, td { border: 1px solid #ccc; padding: 4px; }
+    .fixed { font-family: monospace; }
+    #config { font-family: monospace; max-height: 300px; overflow: auto; }
   </style>
 </head>
 <body>
@@ -14,12 +16,14 @@
     <thead>
       <tr>
         <th>Name</th>
+        <th>Type</th>
         <th>Schedule</th>
         <th>Command</th>
         <th>Origin</th>
         <th>Last Status</th>
         <th>Run Time</th>
         <th>Duration</th>
+        <th>Config</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -31,9 +35,11 @@
     <thead>
       <tr>
         <th>Name</th>
+        <th>Type</th>
         <th>Schedule</th>
         <th>Command</th>
         <th>Origin</th>
+        <th>Config</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -47,7 +53,6 @@
     <label>Command <input id="jobCommand" required></label>
     <button type="submit">Save</button>
   </form>
-  <button id="deleteBtn">Delete Job</button>
 
   <h1>Job History for <span id="historyJob"></span></h1>
   <table id="history">
@@ -69,12 +74,14 @@
     <thead>
       <tr>
         <th>Name</th>
+        <th>Type</th>
         <th>Schedule</th>
         <th>Command</th>
         <th>Origin</th>
         <th>Last Status</th>
         <th>Run Time</th>
         <th>Duration</th>
+        <th>Config</th>
       </tr>
     </thead>
     <tbody></tbody>
@@ -82,19 +89,28 @@
   <h1>Configuration</h1>
   <pre id="config"></pre>
   <script>
+    let jobsData = {};
     async function loadJobs() {
       const resp = await fetch('/api/jobs');
       const jobs = await resp.json();
       const tbody = document.querySelector('#jobs tbody');
       tbody.innerHTML = '';
+      jobsData = {};
       jobs.forEach(j => {
+        jobsData[j.name] = j;
         const tr = document.createElement('tr');
-        const status = j.last_run ? (j.last_run.failed ? 'Failed' : 'Success') : 'never';
-        const time = j.last_run ? new Date(j.last_run.date).toLocaleString() : '';
+        const statusText = j.last_run ? (j.last_run.failed ? 'Failed' : (j.last_run.skipped ? 'Skipped' : 'Success')) : 'never';
+        const symbol = statusText === 'Failed' ? '❌' : statusText === 'Skipped' ? '⏭' : statusText === 'Success' ? '✅' : '–';
+        const status = `${symbol} ${statusText}`;
+        const time = j.last_run ? new Date(j.last_run.date).toISOString().replace('T',' ').replace('Z','') : '';
         const duration = j.last_run ? j.last_run.duration : '';
-        tr.innerHTML = `<td>${j.name}</td><td>${j.schedule}</td><td>${j.command}</td><td>${j.origin}</td><td>${status}</td><td>${time}</td><td>${duration}</td>` +
-          `<td><button onclick="runJob('${j.name}')">Run</button>` +
-          `<button onclick="disableJob('${j.name}')">Disable</button></td>`;
+        const cfg = `<details><summary>config</summary><pre>${JSON.stringify(j.config, null, 2)}</pre></details>`;
+        tr.innerHTML = `<td>${j.name}</td><td>${j.type}</td><td class="fixed">${j.schedule}</td><td class="fixed">${j.command}</td>` +
+          `<td>${j.origin}</td><td>${status}</td><td>${time}</td><td>${duration}</td><td>${cfg}</td>` +
+          `<td><button onclick="runJob('${j.name}')">▶</button>` +
+          `<button onclick="editJob('${j.name}')">✎</button>` +
+          `<button onclick="deleteJob('${j.name}')">🗑</button>` +
+          `<button onclick="disableJob('${j.name}')">✖</button></td>`;
         tr.addEventListener('click', () => loadHistory(j.name));
         tbody.appendChild(tr);
       });
@@ -107,8 +123,9 @@
       tbody.innerHTML = '';
       jobs.forEach(j => {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${j.name}</td><td>${j.schedule}</td><td>${j.command}</td><td>${j.origin}</td>` +
-          `<td><button onclick="enableJob('${j.name}')">Enable</button></td>`;
+        const cfg = `<details><summary>config</summary><pre>${JSON.stringify(j.config, null, 2)}</pre></details>`;
+        tr.innerHTML = `<td>${j.name}</td><td>${j.type}</td><td class="fixed">${j.schedule}</td><td class="fixed">${j.command}</td><td>${j.origin}</td><td>${cfg}</td>` +
+          `<td><button onclick="enableJob('${j.name}')">✔</button></td>`;
         tbody.appendChild(tr);
       });
     }
@@ -121,8 +138,10 @@
       tbody.innerHTML = '';
       hist.forEach(e => {
         const row = document.createElement('tr');
-        const status = e.failed ? 'Failed' : (e.skipped ? 'Skipped' : 'Success');
-        const time = new Date(e.date).toLocaleString();
+        const statusText = e.failed ? 'Failed' : (e.skipped ? 'Skipped' : 'Success');
+        const symbol = statusText === 'Failed' ? '❌' : statusText === 'Skipped' ? '⏭' : '✅';
+        const status = `${symbol} ${statusText}`;
+        const time = new Date(e.date).toISOString().replace('T',' ').replace('Z','');
         const err = e.error ? e.error : '';
         row.innerHTML = `<td>${time}</td><td>${e.duration}</td><td>${status}</td>` +
           `<td>${err}</td>` +
@@ -138,10 +157,13 @@
       tbody.innerHTML = '';
       jobs.forEach(j => {
         const tr = document.createElement('tr');
-        const status = j.last_run ? (j.last_run.failed ? 'Failed' : 'Success') : 'never';
-        const time = j.last_run ? new Date(j.last_run.date).toLocaleString() : '';
+        const statusText = j.last_run ? (j.last_run.failed ? 'Failed' : (j.last_run.skipped ? 'Skipped' : 'Success')) : 'never';
+        const symbol = statusText === 'Failed' ? '❌' : statusText === 'Skipped' ? '⏭' : statusText === 'Success' ? '✅' : '–';
+        const status = `${symbol} ${statusText}`;
+        const time = j.last_run ? new Date(j.last_run.date).toISOString().replace('T',' ').replace('Z','') : '';
         const duration = j.last_run ? j.last_run.duration : '';
-        tr.innerHTML = `<td>${j.name}</td><td>${j.schedule}</td><td>${j.command}</td><td>${j.origin}</td><td>${status}</td><td>${time}</td><td>${duration}</td>`;
+        const cfg = `<details><summary>config</summary><pre>${JSON.stringify(j.config, null, 2)}</pre></details>`;
+        tr.innerHTML = `<td>${j.name}</td><td>${j.type}</td><td class="fixed">${j.schedule}</td><td class="fixed">${j.command}</td><td>${j.origin}</td><td>${status}</td><td>${time}</td><td>${duration}</td><td>${cfg}</td>`;
         tbody.appendChild(tr);
       });
     }
@@ -171,15 +193,23 @@
       const name = document.getElementById('jobName').value;
       const schedule = document.getElementById('jobSchedule').value;
       const command = document.getElementById('jobCommand').value;
-      await fetch('/api/jobs/update', {method: 'POST', body: JSON.stringify({name, schedule, command}), headers: {'Content-Type': 'application/json'}});
+      await fetch('/api/jobs/update', {method: 'POST', body: JSON.stringify({name, schedule, command}), headers: {'Content-Type': 'application/json','X-Origin':'web'}});
       refresh();
     });
 
-    document.getElementById('deleteBtn').addEventListener('click', async () => {
-      const name = document.getElementById('jobName').value;
-      await fetch('/api/jobs/delete', {method: 'POST', body: JSON.stringify({name}), headers: {'Content-Type': 'application/json'}});
+    function editJob(name) {
+      const j = jobsData[name];
+      if (!j) return;
+      document.getElementById('jobName').value = j.name;
+      document.getElementById('jobSchedule').value = j.schedule;
+      document.getElementById('jobCommand').value = j.command;
+    }
+
+    async function deleteJob(name) {
+      await fetch('/api/jobs/delete', {method: 'POST', body: JSON.stringify({name}), headers: {'Content-Type': 'application/json','X-Origin':'web'}});
       refresh();
-    });
+    }
+
     function refresh() {
       loadJobs();
       loadDisabled();

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -37,11 +37,13 @@ type apiExecution struct {
 }
 
 type apiJob struct {
-	Name     string        `json:"name"`
-	Schedule string        `json:"schedule"`
-	Command  string        `json:"command"`
-	LastRun  *apiExecution `json:"last_run"`
-	Origin   string        `json:"origin"`
+	Name     string          `json:"name"`
+	Type     string          `json:"type"`
+	Schedule string          `json:"schedule"`
+	Command  string          `json:"command"`
+	LastRun  *apiExecution   `json:"last_run"`
+	Origin   string          `json:"origin"`
+	Config   json.RawMessage `json:"config"`
 }
 
 func TestHistoryEndpoint(t *testing.T) {


### PR DESCRIPTION
## Summary
- show job type and config in the web UI
- add edit/delete buttons and mark jobs created from web
- improve API by exposing job type and config
- hide job lists from config endpoint
- document new web UI features

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_683db84f508c8333a8dd4aada3e06671