### PR TITLE
Fix INI exec jobs removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ In order to achieve this, you simply have to use Docker containers with the labe
 ### Hybrid configuration (INI files + Docker)
 
 You can specify part of the configuration on the INI files, such as globals for the middlewares or even declare tasks in there but also merge them with Docker.
-The Docker labels will be parsed, added and removed on the fly but the config file can also be used. Run jobs defined in the INI file remain active even when no labeled containers are found. Jobs detected via Docker labels are managed separately and can disappear when the corresponding container is removed.
+The Docker labels will be parsed, added and removed on the fly but the config file can also be used. Run and exec jobs defined in the INI file remain active even when no labeled containers are found. Jobs detected via Docker labels are managed separately and can disappear when the corresponding container is removed.
 
 Use the INI file to:
 

--- a/cli/config_extra_test.go
+++ b/cli/config_extra_test.go
@@ -62,6 +62,7 @@ func (s *SuiteConfig) TestDockerLabelsUpdateExecJobs(c *C) {
 	cfg.sh = core.NewScheduler(&TestLogger{})
 	cfg.buildSchedulerMiddlewares(cfg.sh)
 	cfg.ExecJobs = make(map[string]*ExecJobConfig)
+	cfg.LabelExecJobs = make(map[string]*ExecJobConfig)
 
 	// 1) Addition of new job
 	labelsAdd := map[string]map[string]string{
@@ -71,8 +72,8 @@ func (s *SuiteConfig) TestDockerLabelsUpdateExecJobs(c *C) {
 		},
 	}
 	cfg.dockerLabelsUpdate(labelsAdd)
-	c.Assert(len(cfg.ExecJobs), Equals, 1)
-	j := cfg.ExecJobs["container1.foo"]
+	c.Assert(len(cfg.LabelExecJobs), Equals, 1)
+	j := cfg.LabelExecJobs["container1.foo"]
 	// Verify schedule and command set
 	c.Assert(j.GetSchedule(), Equals, "@every 5s")
 	c.Assert(j.GetCommand(), Equals, "echo foo")
@@ -89,15 +90,15 @@ func (s *SuiteConfig) TestDockerLabelsUpdateExecJobs(c *C) {
 		},
 	}
 	cfg.dockerLabelsUpdate(labelsChange)
-	c.Assert(len(cfg.ExecJobs), Equals, 1)
-	j2 := cfg.ExecJobs["container1.foo"]
+	c.Assert(len(cfg.LabelExecJobs), Equals, 1)
+	j2 := cfg.LabelExecJobs["container1.foo"]
 	c.Assert(j2.GetSchedule(), Equals, "@every 10s")
 	entries = cfg.sh.Entries()
 	c.Assert(len(entries), Equals, 1)
 
 	// 3) Removal of job
 	cfg.dockerLabelsUpdate(map[string]map[string]string{})
-	c.Assert(len(cfg.ExecJobs), Equals, 0)
+	c.Assert(len(cfg.LabelExecJobs), Equals, 0)
 	entries = cfg.sh.Entries()
 	c.Assert(len(entries), Equals, 0)
 }

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -43,7 +43,13 @@ func applyConfigDefaults(conf *Config) {
 	for _, j := range conf.ExecJobs {
 		defaults.Set(j)
 	}
+	for _, j := range conf.LabelExecJobs {
+		defaults.Set(j)
+	}
 	for _, j := range conf.RunJobs {
+		defaults.Set(j)
+	}
+	for _, j := range conf.LabelRunJobs {
 		defaults.Set(j)
 	}
 	for _, j := range conf.LocalJobs {

--- a/web/server.go
+++ b/web/server.go
@@ -98,6 +98,12 @@ func jobOrigin(cfg interface{}, name string) string {
 			return "label"
 		}
 	}
+	labelExecJobs := v.FieldByName("LabelExecJobs")
+	if labelExecJobs.IsValid() && labelExecJobs.Kind() == reflect.Map {
+		if labelExecJobs.MapIndex(reflect.ValueOf(name)).IsValid() {
+			return "label"
+		}
+	}
 	return ""
 }
 
@@ -344,7 +350,7 @@ func stripJobs(cfg interface{}) interface{} {
 	}
 	out := reflect.New(v.Type()).Elem()
 	out.Set(v)
-	fields := []string{"RunJobs", "LabelRunJobs", "ExecJobs", "ServiceJobs", "LocalJobs"}
+	fields := []string{"RunJobs", "LabelRunJobs", "LabelExecJobs", "ExecJobs", "ServiceJobs", "LocalJobs"}
 	for _, f := range fields {
 		if fv := out.FieldByName(f); fv.IsValid() && fv.CanSet() {
 			fv.Set(reflect.Zero(fv.Type()))


### PR DESCRIPTION
## Summary
- keep exec jobs defined in INI when docker polling occurs
- track label based exec jobs in a separate map
- update web UI helpers for new map
- adjust docs for INI exec job behaviour
- update tests for new map

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_684073a1fbf083338a924269fe660dd0