### PR TITLE
Improve config reload logging

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -311,7 +311,9 @@ func (c *Config) iniConfigUpdate() error {
 		}
 	}
 
-	c.logger.Debugf("checking config file %s", c.configPath)
+	for _, f := range files {
+		c.logger.Debugf("checking config file %s", f)
+	}
 	if latest.Equal(c.configModTime) {
 		c.logger.Debugf("config not changed")
 		return nil
@@ -323,7 +325,7 @@ func (c *Config) iniConfigUpdate() error {
 	if err != nil {
 		return err
 	}
-	c.configFiles = parsed.configFiles
+	c.configFiles = files
 	c.configModTime = latest
 	c.logger.Debugf("applied config from %s", c.configPath)
 


### PR DESCRIPTION
## Summary
- log each config file path on reload instead of glob pattern
- include glob-based reload test for `iniConfigUpdate`

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6840866be4648333a94fe8c063116261