### PR TITLE
Improve config reload logging and tests

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -319,7 +319,7 @@ func (c *Config) iniConfigUpdate() error {
 		return nil
 	}
 
-	c.logger.Debugf("reloading config from %s", strings.Join(files, ", "))
+	c.logger.Debugf("reloading config files from %s", strings.Join(files, ", "))
 
 	parsed, err := BuildFromFile(c.configPath, c.logger)
 	if err != nil {

--- a/cli/config.go
+++ b/cli/config.go
@@ -327,7 +327,7 @@ func (c *Config) iniConfigUpdate() error {
 	}
 	c.configFiles = files
 	c.configModTime = latest
-	c.logger.Debugf("applied config from %s", strings.Join(files, ", "))
+	c.logger.Debugf("applied config files from %s", strings.Join(files, ", "))
 
 	execPrep := func(name string, j *ExecJobConfig) {
 		defaults.Set(j)

--- a/cli/config.go
+++ b/cli/config.go
@@ -319,7 +319,7 @@ func (c *Config) iniConfigUpdate() error {
 		return nil
 	}
 
-	c.logger.Debugf("reloading config from %s", c.configPath)
+	c.logger.Debugf("reloading config from %s", strings.Join(files, ", "))
 
 	parsed, err := BuildFromFile(c.configPath, c.logger)
 	if err != nil {
@@ -327,7 +327,7 @@ func (c *Config) iniConfigUpdate() error {
 	}
 	c.configFiles = files
 	c.configModTime = latest
-	c.logger.Debugf("applied config from %s", c.configPath)
+	c.logger.Debugf("applied config from %s", strings.Join(files, ", "))
 
 	execPrep := func(name string, j *ExecJobConfig) {
 		defaults.Set(j)


### PR DESCRIPTION
## Summary
- log all resolved config files when reloading
- remove sleeps from config reload tests and bump file mtime instead

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68408cb0b12c83339c6b3a08f36fc554