### PR TITLE
Add compose job type

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ You can configure four different kinds of jobs:
 - `job-run`: runs a command inside of a new container, using a specific image.
 - `job-local`: runs the command inside of the host running ofelia.
 - `job-service-run`: runs the command inside a new "run-once" service, for running inside a swarm
+- `job-compose`: runs a command using `docker compose run` or `docker compose exec` based on a compose file
 
 See [Jobs reference documentation](docs/jobs.md) for all available parameters.
 See [Architecture overview](docs/architecture.md) for details about the scheduler, job types and middleware.
@@ -257,8 +258,16 @@ docker run -it --rm \
 
 See the [example](example/) directory for a ready-made `compose.yml` that
 demonstrates the different job types. It starts an `nginx` container with an
-`exec` job label and configures additional `run`, `local` and `service-run` jobs
-via `ofelia.ini`.
+`exec` job label and configures additional `run`, `local`, `service-run` and
+`compose` jobs via `ofelia.ini`.
+
+Compose jobs help address feature requests such as
+[#359](https://github.com/mcuadros/ofelia/issues/359),
+[#358](https://github.com/mcuadros/ofelia/issues/358),
+[#333](https://github.com/mcuadros/ofelia/issues/333),
+[#318](https://github.com/mcuadros/ofelia/issues/318),
+[#290](https://github.com/mcuadros/ofelia/issues/290) and
+[#247](https://github.com/mcuadros/ofelia/issues/247).
 
 The Docker image expects a configuration file at `/etc/ofelia/config.ini` and
 runs `daemon --config /etc/ofelia/config.ini` by default. You can also mount a

--- a/cli/docker-labels.go
+++ b/cli/docker-labels.go
@@ -20,6 +20,7 @@ func (c *Config) buildFromDockerLabels(labels map[string]map[string]string) erro
 	localJobs := make(map[string]map[string]interface{})
 	runJobs := make(map[string]map[string]interface{})
 	serviceJobs := make(map[string]map[string]interface{})
+	composeJobs := make(map[string]map[string]interface{})
 	globalConfigs := make(map[string]interface{})
 
 	for c, l := range labels {
@@ -74,6 +75,11 @@ func (c *Config) buildFromDockerLabels(labels map[string]map[string]string) erro
 					runJobs[jobName] = make(map[string]interface{})
 				}
 				setJobParam(runJobs[jobName], jobParam, v)
+			case jobType == jobCompose:
+				if _, ok := composeJobs[jobName]; !ok {
+					composeJobs[jobName] = make(map[string]interface{})
+				}
+				setJobParam(composeJobs[jobName], jobParam, v)
 			default:
 				// TODO: warn about unknown parameter
 			}
@@ -106,6 +112,12 @@ func (c *Config) buildFromDockerLabels(labels map[string]map[string]string) erro
 
 	if len(runJobs) > 0 {
 		if err := mapstructure.WeakDecode(runJobs, &c.RunJobs); err != nil {
+			return err
+		}
+	}
+
+	if len(composeJobs) > 0 {
+		if err := mapstructure.WeakDecode(composeJobs, &c.ComposeJobs); err != nil {
 			return err
 		}
 	}

--- a/core/composejob.go
+++ b/core/composejob.go
@@ -1,0 +1,42 @@
+package core
+
+import (
+	"github.com/gobs/args"
+	"os"
+	"os/exec"
+)
+
+type ComposeJob struct {
+	BareJob `mapstructure:",squash"`
+	File    string `default:"compose.yml" gcfg:"file" mapstructure:"file" hash:"true"`
+	Service string `gcfg:"service" mapstructure:"service" hash:"true"`
+	Exec    bool   `default:"false" gcfg:"exec" mapstructure:"exec" hash:"true"`
+}
+
+func NewComposeJob() *ComposeJob { return &ComposeJob{} }
+
+func (j *ComposeJob) Run(ctx *Context) error {
+	cmd, err := j.buildCommand(ctx)
+	if err != nil {
+		return err
+	}
+	return cmd.Run()
+}
+
+func (j *ComposeJob) buildCommand(ctx *Context) (*exec.Cmd, error) {
+	var argsSlice []string
+	argsSlice = append(argsSlice, "compose", "-f", j.File)
+	if j.Exec {
+		argsSlice = append(argsSlice, "exec", j.Service)
+	} else {
+		argsSlice = append(argsSlice, "run", "--rm", j.Service)
+	}
+	if j.Command != "" {
+		argsSlice = append(argsSlice, args.GetArgs(j.Command)...)
+	}
+	cmd := exec.Command("docker", argsSlice...)
+	cmd.Stdout = ctx.Execution.OutputStream
+	cmd.Stderr = ctx.Execution.ErrorStream
+	cmd.Env = os.Environ()
+	return cmd, nil
+}

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -4,6 +4,7 @@
 - [`run`](#run)
 - [`local`](#local)
 - [`service-run`](#service-run)
+- [`compose`](#compose)
 
 ## `exec`
 
@@ -202,4 +203,33 @@ schedule = 0,20,40 * * * *
 image = ubuntu
 network = swarm_network
 command =  touch /tmp/example
+```
+
+## `compose`
+
+This job triggers commands via Docker Compose. Set `exec = true` to run commands
+in an existing service container using `docker compose exec`. By default, a new
+container is started with `docker compose run --rm`.
+
+### Parameters
+
+- **`schedule`: string**
+  - When the job should be executed. E.g. every 10 seconds or every night at 1 AM.
+- **`file`: string**
+  - Path to the compose file, defaults to `compose.yml`.
+- **`service`: string**
+  - Service name to run or exec.
+- `exec`: boolean = `false`
+  - Use `docker compose exec` instead of `run`.
+- `command`: string
+  - Command passed to the service (optional).
+
+### INI-file example
+
+```ini
+[job-compose "backup"]
+schedule = @daily
+file = docker-compose.yml
+service = db
+command = pg_dumpall -U postgres
 ```

--- a/example/README.md
+++ b/example/README.md
@@ -21,5 +21,6 @@ Ofelia reads the jobs defined in `ofelia.ini` and also uses Docker labels to con
 - `job-run` defined in `ofelia.ini` to start an Alpine container printing the date
 - `job-local` defined in `ofelia.ini` executing a command inside the Ofelia container
 - `job-service-run` defined in `ofelia.ini` (requires Docker Swarm)
+- `job-compose` defined in `ofelia.ini` triggering a Compose service
 
 The `data/` directory is mounted so you can inspect the output of the run job.

--- a/example/ofelia.ini
+++ b/example/ofelia.ini
@@ -16,3 +16,9 @@ command = echo "Hello from local job"
 schedule = 0,20,40 * * * *
 image = alpine
 command = touch /tmp/swarm-example
+
+[job-compose "pg-dump"]
+schedule = @daily
+file = compose.yml
+service = db
+command = pg_dumpall -U postgres > /tmp/dump.sql


### PR DESCRIPTION
## Summary
- implement `ComposeJob` for executing docker compose run or exec commands
- support `job-compose` in configuration and labels
- document compose job parameters and example usage
- showcase compose job in example project
- link related issues in the README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6840a0d637d083339190b0f42977efd1