### PR TITLE
Add ComposeJob buildCommand tests

### DIFF
--- a/core/composejob_test.go
+++ b/core/composejob_test.go
@@ -5,50 +5,55 @@ import (
 	"testing"
 )
 
-func TestComposeJobBuildCommandRun(t *testing.T) {
-	job := &ComposeJob{File: "compose.yml", Service: "svc"}
-	job.Command = `echo "foo bar"`
-	exec, err := NewExecution()
-	if err != nil {
-		t.Fatalf("NewExecution error: %v", err)
+func TestComposeJobBuildCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		job      *ComposeJob
+		wantArgs []string
+	}{
+		{
+			name: "Run command",
+			job: &ComposeJob{
+				File:    "compose.yml",
+				Service: "svc",
+				Command: `echo "foo bar"`,
+			},
+			wantArgs: []string{"docker", "compose", "-f", "compose.yml", "run", "--rm", "svc", "echo", "foo bar"},
+		},
+		{
+			name: "Exec command",
+			job: &ComposeJob{
+				File:    "compose.yml",
+				Service: "svc",
+				Command: `echo "foo bar"`,
+				Exec:    true,
+			},
+			wantArgs: []string{"docker", "compose", "-f", "compose.yml", "exec", "svc", "echo", "foo bar"},
+		},
 	}
-	ctx := &Context{Execution: exec}
-	cmd, err := job.buildCommand(ctx)
-	if err != nil {
-		t.Fatalf("buildCommand error: %v", err)
-	}
-	wantArgs := []string{"docker", "compose", "-f", "compose.yml", "run", "--rm", "svc", "echo", "foo bar"}
-	if !reflect.DeepEqual(cmd.Args, wantArgs) {
-		t.Errorf("unexpected args: %v, want %v", cmd.Args, wantArgs)
-	}
-	if cmd.Stdout != exec.OutputStream {
-		t.Errorf("expected stdout to be execution output buffer")
-	}
-	if cmd.Stderr != exec.ErrorStream {
-		t.Errorf("expected stderr to be execution error buffer")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exec, err := NewExecution()
+			if err != nil {
+				t.Fatalf("NewExecution error: %v", err)
+			}
+			ctx := &Context{Execution: exec}
+			cmd, err := tt.job.buildCommand(ctx)
+			if err != nil {
+				t.Fatalf("buildCommand error: %v", err)
+			}
+			if !reflect.DeepEqual(cmd.Args, tt.wantArgs) {
+				t.Errorf("unexpected args: %v, want %v", cmd.Args, tt.wantArgs)
+			}
+			if cmd.Stdout != exec.OutputStream {
+				t.Errorf("expected stdout to be execution output buffer")
+			}
+			if cmd.Stderr != exec.ErrorStream {
+				t.Errorf("expected stderr to be execution error buffer")
+			}
+		})
 	}
 }
 
-func TestComposeJobBuildCommandExec(t *testing.T) {
-	job := &ComposeJob{File: "compose.yml", Service: "svc", Exec: true}
-	job.Command = `echo "foo bar"`
-	exec, err := NewExecution()
-	if err != nil {
-		t.Fatalf("NewExecution error: %v", err)
-	}
-	ctx := &Context{Execution: exec}
-	cmd, err := job.buildCommand(ctx)
-	if err != nil {
-		t.Fatalf("buildCommand error: %v", err)
-	}
-	wantArgs := []string{"docker", "compose", "-f", "compose.yml", "exec", "svc", "echo", "foo bar"}
-	if !reflect.DeepEqual(cmd.Args, wantArgs) {
-		t.Errorf("unexpected args: %v, want %v", cmd.Args, wantArgs)
-	}
-	if cmd.Stdout != exec.OutputStream {
-		t.Errorf("expected stdout to be execution output buffer")
-	}
-	if cmd.Stderr != exec.ErrorStream {
-		t.Errorf("expected stderr to be execution error buffer")
-	}
-}
+// Removed as part of refactoring into table-driven test.

--- a/core/composejob_test.go
+++ b/core/composejob_test.go
@@ -1,0 +1,54 @@
+package core
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestComposeJobBuildCommandRun(t *testing.T) {
+	job := &ComposeJob{File: "compose.yml", Service: "svc"}
+	job.Command = `echo "foo bar"`
+	exec, err := NewExecution()
+	if err != nil {
+		t.Fatalf("NewExecution error: %v", err)
+	}
+	ctx := &Context{Execution: exec}
+	cmd, err := job.buildCommand(ctx)
+	if err != nil {
+		t.Fatalf("buildCommand error: %v", err)
+	}
+	wantArgs := []string{"docker", "compose", "-f", "compose.yml", "run", "--rm", "svc", "echo", "foo bar"}
+	if !reflect.DeepEqual(cmd.Args, wantArgs) {
+		t.Errorf("unexpected args: %v, want %v", cmd.Args, wantArgs)
+	}
+	if cmd.Stdout != exec.OutputStream {
+		t.Errorf("expected stdout to be execution output buffer")
+	}
+	if cmd.Stderr != exec.ErrorStream {
+		t.Errorf("expected stderr to be execution error buffer")
+	}
+}
+
+func TestComposeJobBuildCommandExec(t *testing.T) {
+	job := &ComposeJob{File: "compose.yml", Service: "svc", Exec: true}
+	job.Command = `echo "foo bar"`
+	exec, err := NewExecution()
+	if err != nil {
+		t.Fatalf("NewExecution error: %v", err)
+	}
+	ctx := &Context{Execution: exec}
+	cmd, err := job.buildCommand(ctx)
+	if err != nil {
+		t.Fatalf("buildCommand error: %v", err)
+	}
+	wantArgs := []string{"docker", "compose", "-f", "compose.yml", "exec", "svc", "echo", "foo bar"}
+	if !reflect.DeepEqual(cmd.Args, wantArgs) {
+		t.Errorf("unexpected args: %v, want %v", cmd.Args, wantArgs)
+	}
+	if cmd.Stdout != exec.OutputStream {
+		t.Errorf("expected stdout to be execution output buffer")
+	}
+	if cmd.Stderr != exec.ErrorStream {
+		t.Errorf("expected stderr to be execution error buffer")
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for ComposeJob.buildCommand
- verify exec vs run arguments and stdout/stderr wiring

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_68680fc057948333a19beca05804581f