### PR TITLE
Warn about unknown docker labels

### DIFF
--- a/cli/docker_labels_test.go
+++ b/cli/docker_labels_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+func TestDockerLabels(t *testing.T) { TestingT(t) }
+
+type DockerLabelSuite struct{}
+
+var _ = Suite(&DockerLabelSuite{})
+
+type RecordingLogger struct {
+	warnings []string
+}
+
+func (l *RecordingLogger) Criticalf(format string, args ...interface{}) {}
+func (l *RecordingLogger) Debugf(format string, args ...interface{})    {}
+func (l *RecordingLogger) Errorf(format string, args ...interface{})    {}
+func (l *RecordingLogger) Noticef(format string, args ...interface{})   {}
+func (l *RecordingLogger) Warningf(format string, args ...interface{}) {
+	l.warnings = append(l.warnings, fmt.Sprintf(format, args...))
+}
+
+func (s *DockerLabelSuite) TestUnknownLabelWarning(c *C) {
+	logger := &RecordingLogger{}
+	cfg := Config{logger: logger}
+
+	labels := map[string]map[string]string{
+		"some": {
+			requiredLabel:                         "true",
+			serviceLabel:                          "true",
+			labelPrefix + ".invalid.job.schedule": "@daily",
+			labelPrefix + ".unknown":              "foo",
+		},
+	}
+
+	err := cfg.buildFromDockerLabels(labels)
+	c.Assert(err, IsNil)
+	c.Assert(len(logger.warnings), Equals, 2)
+	var invalid, unknown bool
+	for _, w := range logger.warnings {
+		if strings.Contains(w, "invalid.job.schedule") {
+			invalid = true
+		}
+		if strings.Contains(w, ".unknown") {
+			unknown = true
+		}
+	}
+	c.Assert(invalid, Equals, true)
+	c.Assert(unknown, Equals, true)
+}


### PR DESCRIPTION
## Summary
- emit warnings for unknown docker label keys
- track known global label keys
- add tests for warning logging
- fix test to be order independent

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68680fac0f688333b7094e8bbcfe7ad4