### PR TITLE
Add timezone selector for web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Label your Docker containers and let this Go-powered daemon handle the schedule.
   the binary.
 - **Removed job history** keeps deregistered jobs in memory and shows them in the web UI.
 - **Enhanced web UI** allows editing and deleting jobs, shows job origin and type, displays each job's configuration and renders the scheduler configuration in a table with empty job sections hidden. Action buttons now use clear icons.
+- **Timezone selector** in the web UI lets you view timestamps in local, server or UTC time and remembers your choice.
 
 This fork is based off of [mcuadros/ofelia](https://github.com/mcuadros/ofelia).
 
@@ -93,7 +94,9 @@ the UI allows starting jobs manually, disabling or enabling them and creating,
 updating or deleting jobs of all types. A second table lists jobs removed from
 the configuration via `/api/jobs/removed`. The endpoint `/api/jobs/{name}/history`
 exposes past runs including stdout, stderr and any error messages while
-`/api/config` returns the active configuration as JSON.
+`/api/config` returns the active configuration as JSON. The UI includes a
+timezone selector so you can view times in your local zone, the server zone or
+UTC and have that preference saved locally.
 Creating `run` or `exec` jobs requires Ofelia to run with Docker access; the
 server rejects such requests if no Docker client is available.
 

--- a/static/ui/index.html
+++ b/static/ui/index.html
@@ -126,9 +126,12 @@
 
     function formatTime(dateStr) {
       const pref = localStorage.getItem('timezone') || 'local';
-      const dt = new Date(dateStr);
+      if (dateStr === null || dateStr === undefined) return 'Invalid Date';
+      const str = String(dateStr);
+      const dt = new Date(str);
+      if (isNaN(dt)) return 'Invalid Date';
       if (pref === 'utc') return dt.toISOString().replace('T',' ').replace('Z','');
-      if (pref === 'server') return dateStr.replace('T',' ');
+      if (pref === 'server') return str.replace('T',' ').replace('Z','');
       return dt.toLocaleString();
     }
 

--- a/static/ui/index.html
+++ b/static/ui/index.html
@@ -12,6 +12,13 @@
   </style>
 </head>
 <body>
+  <label>Time zone
+    <select id="timezoneSelect">
+      <option value="local">local</option>
+      <option value="server">server</option>
+      <option value="utc">utc</option>
+    </select>
+  </label>
   <h1>Scheduled Jobs</h1>
   <table id="jobs">
     <thead>
@@ -117,8 +124,22 @@
       return `${ns}ns`;
     }
 
+    function formatTime(dateStr) {
+      const pref = localStorage.getItem('timezone') || 'local';
+      const dt = new Date(dateStr);
+      if (pref === 'utc') return dt.toISOString().replace('T',' ').replace('Z','');
+      if (pref === 'server') return dateStr.replace('T',' ');
+      return dt.toLocaleString();
+    }
+
     let jobsData = {};
     let editing = null;
+    const tzSelect = document.getElementById('timezoneSelect');
+    tzSelect.value = localStorage.getItem('timezone') || 'local';
+    tzSelect.addEventListener('change', () => {
+      localStorage.setItem('timezone', tzSelect.value);
+      refresh();
+    });
     async function loadJobs() {
       const resp = await fetch('/api/jobs');
       const jobs = await resp.json();
@@ -131,7 +152,7 @@
         const statusText = j.last_run ? (j.last_run.failed ? 'Failed' : (j.last_run.skipped ? 'Skipped' : 'Success')) : 'never';
         const symbol = statusText === 'Failed' ? '❌' : statusText === 'Skipped' ? '⏭' : statusText === 'Success' ? '✅' : '–';
         const status = `${symbol} ${statusText}`;
-        const time = j.last_run ? new Date(j.last_run.date).toISOString().replace('T',' ').replace('Z','') : '';
+        const time = j.last_run ? formatTime(j.last_run.date) : '';
         const duration = j.last_run ? j.last_run.duration : '';
         const cfg = `<details><summary>⚙</summary><pre>${JSON.stringify(j.config, null, 2)}</pre></details>`;
         tr.innerHTML = `<td>${j.name}</td><td>${j.type}</td><td class="fixed">${j.schedule}</td><td class="fixed">${j.command}</td>` +
@@ -170,7 +191,7 @@
         const statusText = e.failed ? 'Failed' : (e.skipped ? 'Skipped' : 'Success');
         const symbol = statusText === 'Failed' ? '❌' : statusText === 'Skipped' ? '⏭' : '✅';
         const status = `${symbol} ${statusText}`;
-        const time = new Date(e.date).toISOString().replace('T',' ').replace('Z','');
+        const time = formatTime(e.date);
         const err = e.error ? e.error : '';
         row.innerHTML = `<td>${time}</td><td>${formatDuration(e.duration)}</td><td>${status}</td>` +
           `<td>${err}</td>` +
@@ -189,7 +210,7 @@
         const statusText = j.last_run ? (j.last_run.failed ? 'Failed' : (j.last_run.skipped ? 'Skipped' : 'Success')) : 'never';
         const symbol = statusText === 'Failed' ? '❌' : statusText === 'Skipped' ? '⏭' : statusText === 'Success' ? '✅' : '–';
         const status = `${symbol} ${statusText}`;
-        const time = j.last_run ? new Date(j.last_run.date).toISOString().replace('T',' ').replace('Z','') : '';
+        const time = j.last_run ? formatTime(j.last_run.date) : '';
         const duration = j.last_run ? j.last_run.duration : '';
         const cfg = `<details><summary>⚙</summary><pre>${JSON.stringify(j.config, null, 2)}</pre></details>`;
         tr.innerHTML = `<td>${j.name}</td><td>${j.type}</td><td class="fixed">${j.schedule}</td><td class="fixed">${j.command}</td><td>${j.origin}</td><td>${status}</td><td>${time}</td><td>${formatDuration(duration)}</td><td>${cfg}</td>`;


### PR DESCRIPTION
## Summary
- add timezone selection to web UI with persistence
- update time formatting helper
- refresh tables when timezone changes
- document timezone option

## Testing
- `go vet ./...` *(fails: unknown field Command in ComposeJob)*
- `go test ./...` *(fails: unknown field Command in ComposeJob)*

------
https://chatgpt.com/codex/tasks/task_b_68696ff6856483339a2ab5340832ebf1