### PR TITLE
Fix ComposeJob initialization in tests

### DIFF
--- a/core/composejob_test.go
+++ b/core/composejob_test.go
@@ -14,18 +14,18 @@ func TestComposeJobBuildCommand(t *testing.T) {
 		{
 			name: "Run command",
 			job: &ComposeJob{
+				BareJob: BareJob{Command: `echo "foo bar"`},
 				File:    "compose.yml",
 				Service: "svc",
-				Command: `echo "foo bar"`,
 			},
 			wantArgs: []string{"docker", "compose", "-f", "compose.yml", "run", "--rm", "svc", "echo", "foo bar"},
 		},
 		{
 			name: "Exec command",
 			job: &ComposeJob{
+				BareJob: BareJob{Command: `echo "foo bar"`},
 				File:    "compose.yml",
 				Service: "svc",
-				Command: `echo "foo bar"`,
 				Exec:    true,
 			},
 			wantArgs: []string{"docker", "compose", "-f", "compose.yml", "exec", "svc", "echo", "foo bar"},


### PR DESCRIPTION
## Summary
- initialize BareJob properly in compose job tests

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68696ff69c608333811c2cbe16e1d0db