### PR TITLE
Add runtime reload for global settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ Ofelia merges options from multiple sources in the following order. Values from 
 
 The daemon watches `config.ini` and reloads it automatically when the file changes.
 
+Job definitions and most `[global]` middleware options (`slack-*`, `save-*`,
+`mail-*`, `log-level`, `max-runtime`) are applied on reload. Options that start
+servers (`enable-web`, `web-address`, `enable-pprof`, `pprof-address`) and all
+`[docker]` settings require restarting the daemon.
+
 ## Configuration
 
 ### Jobs

--- a/core/common.go
+++ b/core/common.go
@@ -221,6 +221,12 @@ func (c *middlewareContainer) Use(ms ...Middleware) {
 	}
 }
 
+func (c *middlewareContainer) ResetMiddlewares(ms ...Middleware) {
+	c.m = nil
+	c.order = nil
+	c.Use(ms...)
+}
+
 func (c *middlewareContainer) Middlewares() []Middleware {
 	var ms []Middleware
 	for _, t := range c.order {

--- a/core/common_test.go
+++ b/core/common_test.go
@@ -273,6 +273,19 @@ func (s *SuiteCommon) TestMiddlewareContainerUseOder(c *C) {
 	c.Assert(ms[1], Equals, mA)
 }
 
+func (s *SuiteCommon) TestMiddlewareContainerReset(c *C) {
+	mA := &TestMiddleware{}
+	mB := &TestMiddlewareAltA{}
+
+	container := &middlewareContainer{}
+	container.Use(mA)
+	container.ResetMiddlewares(mB)
+
+	ms := container.Middlewares()
+	c.Assert(ms, HasLen, 1)
+	c.Assert(ms[0], Equals, mB)
+}
+
 type TestMiddleware struct {
 	Called int
 	Nested bool


### PR DESCRIPTION
## Summary
- compare global options when reloading config
- rebuild scheduler and job middlewares on global change
- add `ResetMiddlewares` to core
- test global reload of log-level and save settings
- document which settings are hot-reloaded

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_686961668de88333ad17ed6741cfb032