### PR TITLE
Fix timezone formatting in UI

### DIFF
--- a/static/ui/index.html
+++ b/static/ui/index.html
@@ -126,9 +126,12 @@
 
     function formatTime(dateStr) {
       const pref = localStorage.getItem('timezone') || 'local';
-      const dt = new Date(dateStr);
+      if (dateStr === null || dateStr === undefined) return 'Invalid Date';
+      const str = String(dateStr);
+      const dt = new Date(str);
+      if (isNaN(dt)) return 'Invalid Date';
       if (pref === 'utc') return dt.toISOString().replace('T',' ').replace('Z','');
-      if (pref === 'server') return dateStr.replace('T',' ');
+      if (pref === 'server') return str.replace('T',' ').replace('Z','');
       return dt.toLocaleString();
     }
 


### PR DESCRIPTION
## Summary
- fix edge cases in `formatTime` for server and UTC zones

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_686990c9399c83338398539fd9d8c33a