### PR TITLE
fix: correct inverted Go version check logic in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -27,7 +27,7 @@ fi
 GO_VERSION=$(go version | grep -o 'go[0-9]\+\.[0-9]\+' | sed 's/go//')
 REQUIRED_VERSION="1.25"
 
-if ! echo "$GO_VERSION $REQUIRED_VERSION" | awk '{exit ($1 < $2)}'; then
+if echo "$GO_VERSION $REQUIRED_VERSION" | awk '{exit ($1 < $2)}'; then
     echo -e "${GREEN}✅ Go $GO_VERSION detected${NC}"
 else
     echo -e "${YELLOW}⚠️  Go $GO_VERSION found, but Go $REQUIRED_VERSION+ is recommended for this project${NC}"


### PR DESCRIPTION
## Problem
The Go version check in `.envrc` was showing a warning for Go 1.25.4 even though it meets the requirement of Go 1.25+.

## Root Cause
The version comparison condition was inverted due to an incorrect negation operator (`!`).

```bash
# Before (incorrect)
if ! echo "$GO_VERSION $REQUIRED_VERSION" | awk '{exit ($1 < $2)}'; then
    # This executed when version was TOO OLD (incorrect)
    echo "✅ Go $GO_VERSION detected"
else
    # This executed when version was OK (incorrect) 
    echo "⚠️  Warning message"
fi
```

## Fix
Removed the negation operator to fix the logic:

```bash
# After (correct)
if echo "$GO_VERSION $REQUIRED_VERSION" | awk '{exit ($1 < $2)}'; then
    # Now executes when version is OK
    echo "✅ Go $GO_VERSION detected"
else
    # Now executes when version is TOO OLD
    echo "⚠️  Warning message"
fi
```

## Testing
- ✅ Go 1.25.4 now correctly shows: `✅ Go 1.25 detected`
- ✅ Would show warning for Go < 1.25

## Impact
- No functional changes to the project
- Purely cosmetic fix for developer experience
- Single line change in `.envrc`