### PR TITLE
docs: add comprehensive badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # Ofelia - a job scheduler
+
 [![CI](https://github.com/netresearch/ofelia/actions/workflows/ci.yml/badge.svg)](https://github.com/netresearch/ofelia/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/netresearch/ofelia/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/netresearch/ofelia/actions/workflows/github-code-scanning/codeql)
+[![GitHub release](https://img.shields.io/github/v/release/netresearch/ofelia)](https://github.com/netresearch/ofelia/releases/latest)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/netresearch/ofelia)](go.mod)
+[![License](https://img.shields.io/github/license/netresearch/ofelia)](LICENSE)
+[![Docker Pulls](https://img.shields.io/docker/pulls/netresearch/ofelia)](https://hub.docker.com/r/netresearch/ofelia)
+[![Go Report Card](https://goreportcard.com/badge/github.com/netresearch/ofelia)](https://goreportcard.com/report/github.com/netresearch/ofelia)
 
 <img src="https://weirdspace.dk/FranciscoIbanez/Graphics/Ofelia.gif" align="right" width="180px" height="300px" vspace="20" />
 


### PR DESCRIPTION
## Summary

Enhances README with professional badges to improve project visibility and discoverability.

## Badges Added

✅ **GitHub release** - Shows latest version (v0.11.0)  
✅ **Go version** - Displays Go 1.25 from go.mod  
✅ **License** - MIT license badge  
✅ **Docker pulls** - Shows Docker Hub popularity  
✅ **Go Report Card** - Code quality score  

## Before

Only had CI and CodeQL badges.

## After

Comprehensive badge set showing:
- Build status
- Security scanning
- Latest release
- Go version
- License
- Docker usage
- Code quality

## Preview

The badges will display in a clean horizontal row at the top of the README, providing quick insights about the project's status and quality.