### PR TITLE
fix: update container image badge to use GHCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub release](https://img.shields.io/github/v/release/netresearch/ofelia)](https://github.com/netresearch/ofelia/releases/latest)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/netresearch/ofelia)](go.mod)
 [![License](https://img.shields.io/github/license/netresearch/ofelia)](LICENSE)
-[![Docker Pulls](https://img.shields.io/docker/pulls/netresearch/ofelia)](https://hub.docker.com/r/netresearch/ofelia)
+[![Container Image](https://img.shields.io/badge/ghcr.io-netresearch%2Fofelia-blue)](https://github.com/netresearch/ofelia/pkgs/container/ofelia)
 [![Go Report Card](https://goreportcard.com/badge/github.com/netresearch/ofelia)](https://goreportcard.com/report/github.com/netresearch/ofelia)
 
 <img src="https://weirdspace.dk/FranciscoIbanez/Graphics/Ofelia.gif" align="right" width="180px" height="300px" vspace="20" />


### PR DESCRIPTION
Ofelia publishes container images to GitHub Container Registry (ghcr.io), not Docker Hub.

This PR fixes the incorrect Docker Hub badge added in PR #256 to point to the correct GHCR package.

**Changes:**
- Replace Docker Hub pulls badge with GHCR container image badge
- Update link to point to https://github.com/netresearch/ofelia/pkgs/container/ofelia

**Related:** PR #256