### PR TITLE
fix(cli): eliminate silent failure on invalid log levels

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -455,7 +455,9 @@ func (c *Config) iniConfigUpdate() error {
 				j.Use(c.sh.Middlewares()...)
 			}
 		}
-		ApplyLogLevel(c.Global.LogLevel)
+		if err := ApplyLogLevel(c.Global.LogLevel); err != nil {
+			c.logger.Warningf("Failed to apply global log level (using default): %v", err)
+		}
 	}
 
 	execPrep := func(name string, j *ExecJobConfig) {

--- a/cli/config_extra_test.go
+++ b/cli/config_extra_test.go
@@ -424,7 +424,7 @@ func (s *SuiteConfig) TestIniConfigUpdateGlobalChange(c *C) {
 	cfg.sh = core.NewScheduler(test.NewTestLogger())
 	cfg.buildSchedulerMiddlewares(cfg.sh)
 
-	ApplyLogLevel(cfg.Global.LogLevel)
+	_ = ApplyLogLevel(cfg.Global.LogLevel) // Ignore error in test
 	ms := cfg.sh.Middlewares()
 	c.Assert(ms, HasLen, 1)
 	saveMw := ms[0].(*middlewares.Save)

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -53,7 +53,10 @@ func (c *DaemonCommand) boot() (err error) {
 	c.done = make(chan struct{})
 
 	// Apply CLI log level before reading config
-	ApplyLogLevel(c.LogLevel)
+	if err := ApplyLogLevel(c.LogLevel); err != nil {
+		c.Logger.Errorf("Failed to apply log level: %v", err)
+		return fmt.Errorf("invalid log level configuration: %w", err)
+	}
 
 	// Initialize shutdown manager
 	c.shutdownManager = core.NewShutdownManager(c.Logger, 30*time.Second)
@@ -89,7 +92,9 @@ func (c *DaemonCommand) boot() (err error) {
 	}
 
 	if c.LogLevel == "" {
-		ApplyLogLevel(config.Global.LogLevel)
+		if err := ApplyLogLevel(config.Global.LogLevel); err != nil {
+			c.Logger.Warningf("Failed to apply config log level (using default): %v", err)
+		}
 	}
 
 	err = config.InitializeApp()

--- a/cli/logging.go
+++ b/cli/logging.go
@@ -1,19 +1,35 @@
 package cli
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/sirupsen/logrus"
 )
 
 // ApplyLogLevel sets the global logging level if level is valid.
-func ApplyLogLevel(level string) {
+// Returns an error if the level is invalid, with a list of valid options.
+func ApplyLogLevel(level string) error {
 	if level == "" {
-		return
+		return nil
 	}
+
 	lvl, err := logrus.ParseLevel(strings.ToLower(level))
 	if err != nil {
-		return
+		// Dynamically generate list of valid levels
+		var validLevels []string
+		for _, l := range logrus.AllLevels {
+			validLevels = append(validLevels, l.String())
+		}
+
+		// Log warning for immediate visibility
+		logrus.Warnf("Invalid log level %q. Valid levels: %s",
+			level, strings.Join(validLevels, ", "))
+
+		// Return error for programmatic handling
+		return fmt.Errorf("invalid log level %q: %w", level, err)
 	}
+
 	logrus.SetLevel(lvl)
+	return nil
 }

--- a/cli/logging_test.go
+++ b/cli/logging_test.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestApplyLogLevel(t *testing.T) {
+	tests := []struct {
+		name      string
+		level     string
+		expectErr bool
+		expected  logrus.Level
+	}{
+		{
+			name:      "valid debug level",
+			level:     "debug",
+			expectErr: false,
+			expected:  logrus.DebugLevel,
+		},
+		{
+			name:      "valid info level",
+			level:     "info",
+			expectErr: false,
+			expected:  logrus.InfoLevel,
+		},
+		{
+			name:      "valid warning level",
+			level:     "warning",
+			expectErr: false,
+			expected:  logrus.WarnLevel,
+		},
+		{
+			name:      "valid error level",
+			level:     "error",
+			expectErr: false,
+			expected:  logrus.ErrorLevel,
+		},
+		{
+			name:      "empty level",
+			level:     "",
+			expectErr: false,
+			expected:  logrus.InfoLevel, // Should not change current level
+		},
+		{
+			name:      "invalid level",
+			level:     "invalid",
+			expectErr: true,
+			expected:  logrus.InfoLevel, // Should not change current level
+		},
+		{
+			name:      "typo in debug",
+			level:     "degub",
+			expectErr: true,
+			expected:  logrus.InfoLevel,
+		},
+		{
+			name:      "case insensitive",
+			level:     "DEBUG",
+			expectErr: false,
+			expected:  logrus.DebugLevel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset to info level before each test
+			logrus.SetLevel(logrus.InfoLevel)
+
+			err := ApplyLogLevel(tt.level)
+
+			if tt.expectErr && err == nil {
+				t.Errorf("Expected error for level %q, but got none", tt.level)
+			}
+
+			if !tt.expectErr && err != nil {
+				t.Errorf("Unexpected error for level %q: %v", tt.level, err)
+			}
+
+			if !tt.expectErr {
+				currentLevel := logrus.GetLevel()
+				if currentLevel != tt.expected {
+					t.Errorf("Expected level %v, got %v", tt.expected, currentLevel)
+				}
+			}
+		})
+	}
+}

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -19,7 +19,11 @@ type ValidateCommand struct {
 
 // Execute runs the validation command
 func (c *ValidateCommand) Execute(_ []string) error {
-	ApplyLogLevel(c.LogLevel)
+	if err := ApplyLogLevel(c.LogLevel); err != nil {
+		c.Logger.Errorf("Failed to apply log level: %v", err)
+		return fmt.Errorf("invalid log level configuration: %w", err)
+	}
+
 	c.Logger.Debugf("Validating %q ... ", c.ConfigFile)
 	conf, err := BuildFromFile(c.ConfigFile, c.Logger)
 	if err != nil {
@@ -27,7 +31,9 @@ func (c *ValidateCommand) Execute(_ []string) error {
 		return err
 	}
 	if c.LogLevel == "" {
-		ApplyLogLevel(conf.Global.LogLevel)
+		if err := ApplyLogLevel(conf.Global.LogLevel); err != nil {
+			c.Logger.Warningf("Failed to apply config log level (using default): %v", err)
+		}
 	}
 
 	applyConfigDefaults(conf)


### PR DESCRIPTION
## Summary
Fixes critical UX issue (#P1.1) where invalid log levels fail silently, leaving operators confused when debugging.

## Problem
The `ApplyLogLevel()` function silently swallowed errors when parsing invalid log levels. Operators attempting to debug with `--log-level=debug` (or misspelling it) received NO feedback, leading to wasted troubleshooting time during production incidents.

## Solution
- ApplyLogLevel() now returns error with actionable message
- Dynamically generates valid levels from `logrus.AllLevels` 
- Logs warning for immediate visibility
- Returns error for programmatic handling (fail-fast)
- Updated all 6 call sites with proper error handling

## Error Message Example
```
Invalid log level "degub". Valid levels: panic, fatal, error, warning, info, debug, trace
```

## Changes
### Modified Files:
- `cli/logging.go`: Added error return with dynamic validation
- `cli/daemon.go`: Fail fast on CLI errors, warn on config errors
- `cli/validate.go`: Fail fast on CLI errors, warn on config errors
- `cli/config.go`: Warn on config errors during updates
- `cli/config_extra_test.go`: Handle errors in tests

### New Files:
- `cli/logging_test.go`: Comprehensive test suite with 8 test cases

## Testing
```bash
go test ./cli -run TestApplyLogLevel -v
# All 8 test cases pass
# Tests cover: valid levels, invalid levels, typos, case sensitivity, empty input
```

## Benefits
✅ Eliminates operator confusion during debugging  
✅ Clear, actionable error messages with valid options  
✅ Follows Go idioms and industry standards (docker, git, kubectl)  
✅ Fail-fast on CLI flags, graceful degradation on config files  

## Part of UX Improvement Initiative
This is task P1.1 of a 12-task UX improvement initiative based on comprehensive UX analysis. See full analysis in docs.

Closes #258

---
Addresses:
- https://github.com/mcuadros/ofelia/issues/84
- https://github.com/mcuadros/ofelia/issues/131
- https://github.com/mcuadros/ofelia/pull/301