### PR TITLE
fix(ci): use correct commit SHA for scorecard-action v2.4.0

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@ff5dd8929f96a8a4dc67d13f32b8c75057829621 # v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

Fixes OpenSSF Scorecard workflow failure caused by using the annotated tag object SHA instead of the actual commit SHA.

### Problem
The v2.4.0 tag is an annotated tag, so:
- Tag object SHA: `ff5dd8929f96a8a4dc67d13f32b8c75057829621`
- **Commit SHA**: `62b2cac7ed8198b15735ed49ab1e5cf35480ba46` ✅

The OpenSSF webapp verification requires the commit SHA, not the tag object SHA.

### Error Fixed
```
imposter commit: ff5dd8929f96a8a4dc67d13f32b8c75057829621 does not belong to ossf/scorecard-action
```

## Test plan
- [ ] Verify scorecard workflow passes after merge