### PR TITLE
fix(ci): use correct commit SHA for codeql-action v3.28.19

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -38,6 +38,6 @@ jobs:
           publish_results: true
 
       - name: Upload Scorecard results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@66b39da20ccc656acc90dd27ea30f5d458ec33ce # v3.28.19
+        uses: github/codeql-action/upload-sarif@fca7ace96b7d713c7035871441bd52efbe39e27e # v3.28.19
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Fixes OpenSSF Scorecard workflow failure caused by using the annotated tag object SHA instead of the actual commit SHA for codeql-action.

### Problem
The v3.28.19 tag is an annotated tag, so:
- Tag object SHA: `66b39da20ccc656acc90dd27ea30f5d458ec33ce`
- **Commit SHA**: `fca7ace96b7d713c7035871441bd52efbe39e27e` ✅

### Error Fixed
```
imposter commit: 66b39da20ccc656acc90dd27ea30f5d458ec33ce does not belong to github/codeql-action/upload-sarif
```

## Test plan
- [ ] Verify scorecard workflow passes after merge