### PR TITLE
fix(ci): skip gitleaks on merge_group events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,6 +283,8 @@ jobs:
 
   gitleaks:
     name: gitleaks
+    # gitleaks-action doesn't support merge_group events
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Fixes merge queue failures caused by gitleaks-action not supporting the `merge_group` event.

### Error Fixed
```
Error: ERROR: The [merge_group] event is not yet supported
```

### Solution
Skip gitleaks job on merge_group events. This is safe because:
- Gitleaks already ran during the PR's pull_request event
- The merge queue doesn't introduce new commits that would need scanning

## Test plan
- [ ] Verify merge queue passes without gitleaks error