### PR TITLE
fix(release): use SLSA builder env var syntax instead of goreleaser templates

### DIFF
--- a/.github/workflows/release-slsa.yml
+++ b/.github/workflows/release-slsa.yml
@@ -79,6 +79,7 @@ jobs:
     with:
       go-version-file: go.mod
       config-file: .slsa-goreleaser/${{ matrix.target }}.yml
+      evaluated-envs: "VERSION:${{ github.ref_name }},COMMIT:${{ github.sha }}"
       upload-assets: true
       draft-release: false
 
@@ -242,10 +243,10 @@ jobs:
           gh release edit "$RELEASE_TAG" \
             --notes-file CHANGELOG.md
 
-  # Container images (runs in parallel with binary builds)
+  # Container images (runs after binary builds succeed)
   docker:
     name: Build and Push Container Images
-    needs: resolve-tag
+    needs: [resolve-tag, build]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.slsa-goreleaser/darwin-amd64.yml
+++ b/.slsa-goreleaser/darwin-amd64.yml
@@ -2,6 +2,8 @@ version: 1
 env:
   - CGO_ENABLED=0
   - GO111MODULE=on
+  - VERSION
+  - COMMIT
 flags:
   - -trimpath
 goos: darwin
@@ -9,6 +11,4 @@ goarch: amd64
 main: .
 binary: ofelia-darwin-amd64
 ldflags:
-  - "-s -w"
-  - "-X main.version={{ .Tag }}"
-  - "-X main.build={{ .Commit }}"
+  - "-s -w -X main.version=$VERSION -X main.build=$COMMIT"

--- a/.slsa-goreleaser/darwin-arm64.yml
+++ b/.slsa-goreleaser/darwin-arm64.yml
@@ -2,6 +2,8 @@ version: 1
 env:
   - CGO_ENABLED=0
   - GO111MODULE=on
+  - VERSION
+  - COMMIT
 flags:
   - -trimpath
 goos: darwin
@@ -9,6 +11,4 @@ goarch: arm64
 main: .
 binary: ofelia-darwin-arm64
 ldflags:
-  - "-s -w"
-  - "-X main.version={{ .Tag }}"
-  - "-X main.build={{ .Commit }}"
+  - "-s -w -X main.version=$VERSION -X main.build=$COMMIT"

--- a/.slsa-goreleaser/linux-386.yml
+++ b/.slsa-goreleaser/linux-386.yml
@@ -2,6 +2,8 @@ version: 1
 env:
   - CGO_ENABLED=0
   - GO111MODULE=on
+  - VERSION
+  - COMMIT
 flags:
   - -trimpath
 goos: linux
@@ -9,6 +11,4 @@ goarch: 386
 main: .
 binary: ofelia-linux-386
 ldflags:
-  - "-s -w"
-  - "-X main.version={{ .Tag }}"
-  - "-X main.build={{ .Commit }}"
+  - "-s -w -X main.version=$VERSION -X main.build=$COMMIT"

--- a/.slsa-goreleaser/linux-amd64.yml
+++ b/.slsa-goreleaser/linux-amd64.yml
@@ -2,6 +2,8 @@ version: 1
 env:
   - CGO_ENABLED=0
   - GO111MODULE=on
+  - VERSION
+  - COMMIT
 flags:
   - -trimpath
 goos: linux
@@ -9,6 +11,4 @@ goarch: amd64
 main: .
 binary: ofelia-linux-amd64
 ldflags:
-  - "-s -w"
-  - "-X main.version={{ .Tag }}"
-  - "-X main.build={{ .Commit }}"
+  - "-s -w -X main.version=$VERSION -X main.build=$COMMIT"

--- a/.slsa-goreleaser/linux-arm64.yml
+++ b/.slsa-goreleaser/linux-arm64.yml
@@ -2,6 +2,8 @@ version: 1
 env:
   - CGO_ENABLED=0
   - GO111MODULE=on
+  - VERSION
+  - COMMIT
 flags:
   - -trimpath
 goos: linux
@@ -9,6 +11,4 @@ goarch: arm64
 main: .
 binary: ofelia-linux-arm64
 ldflags:
-  - "-s -w"
-  - "-X main.version={{ .Tag }}"
-  - "-X main.build={{ .Commit }}"
+  - "-s -w -X main.version=$VERSION -X main.build=$COMMIT"

--- a/.slsa-goreleaser/linux-armv6.yml
+++ b/.slsa-goreleaser/linux-armv6.yml
@@ -2,14 +2,14 @@ version: 1
 env:
   - CGO_ENABLED=0
   - GO111MODULE=on
-  - GOARM=6
+  - VERSION
+  - COMMIT
 flags:
   - -trimpath
 goos: linux
 goarch: arm
+goarm: 6
 main: .
 binary: ofelia-linux-armv6
 ldflags:
-  - "-s -w"
-  - "-X main.version={{ .Tag }}"
-  - "-X main.build={{ .Commit }}"
+  - "-s -w -X main.version=$VERSION -X main.build=$COMMIT"

--- a/.slsa-goreleaser/linux-armv7.yml
+++ b/.slsa-goreleaser/linux-armv7.yml
@@ -2,14 +2,14 @@ version: 1
 env:
   - CGO_ENABLED=0
   - GO111MODULE=on
-  - GOARM=7
+  - VERSION
+  - COMMIT
 flags:
   - -trimpath
 goos: linux
 goarch: arm
+goarm: 7
 main: .
 binary: ofelia-linux-armv7
 ldflags:
-  - "-s -w"
-  - "-X main.version={{ .Tag }}"
-  - "-X main.build={{ .Commit }}"
+  - "-s -w -X main.version=$VERSION -X main.build=$COMMIT"

--- a/.slsa-goreleaser/windows-amd64.yml
+++ b/.slsa-goreleaser/windows-amd64.yml
@@ -2,6 +2,8 @@ version: 1
 env:
   - CGO_ENABLED=0
   - GO111MODULE=on
+  - VERSION
+  - COMMIT
 flags:
   - -trimpath
 goos: windows
@@ -9,6 +11,4 @@ goarch: amd64
 main: .
 binary: ofelia-windows-amd64
 ldflags:
-  - "-s -w"
-  - "-X main.version={{ .Tag }}"
-  - "-X main.build={{ .Commit }}"
+  - "-s -w -X main.version=$VERSION -X main.build=$COMMIT"


### PR DESCRIPTION
## Summary

Fixes SLSA builder failure caused by using goreleaser template syntax that isn't supported by the SLSA Go builder v2.1.0.

## Changes

- Replace goreleaser template syntax with env vars in all 8 .slsa-goreleaser/*.yml configs
- Add evaluated-envs to pass VERSION and COMMIT to SLSA builder
- Fix Docker job dependency to prevent push if binary builds fail

## Root Cause

The SLSA Go builder doesn't support goreleaser's template syntax. It expects environment variables passed via the evaluated-envs workflow input.