### PR TITLE
fix(release): use correct SLSA builder template syntax

### DIFF
--- a/.github/workflows/release-slsa.yml
+++ b/.github/workflows/release-slsa.yml
@@ -79,7 +79,7 @@ jobs:
     with:
       go-version-file: go.mod
       config-file: .slsa-goreleaser/${{ matrix.target }}.yml
-      evaluated-envs: "VERSION:${{ github.ref_name }},COMMIT:${{ github.sha }}"
+      evaluated-envs: "VERSION:${{ github.ref_name }}, COMMIT:${{ github.sha }}"
       upload-assets: true
       draft-release: false
 

--- a/.slsa-goreleaser/darwin-amd64.yml
+++ b/.slsa-goreleaser/darwin-amd64.yml
@@ -2,13 +2,11 @@ version: 1
 env:
   - CGO_ENABLED=0
   - GO111MODULE=on
-  - VERSION
-  - COMMIT
 flags:
   - -trimpath
 goos: darwin
 goarch: amd64
 main: .
-binary: ofelia-darwin-amd64
+binary: ofelia-{{ .Os }}-{{ .Arch }}
 ldflags:
-  - "-s -w -X main.version=$VERSION -X main.build=$COMMIT"
+  - "-s -w -X main.version={{ .Env.VERSION }} -X main.build={{ .Env.COMMIT }}"

--- a/.slsa-goreleaser/darwin-arm64.yml
+++ b/.slsa-goreleaser/darwin-arm64.yml
@@ -2,13 +2,11 @@ version: 1
 env:
   - CGO_ENABLED=0
   - GO111MODULE=on
-  - VERSION
-  - COMMIT
 flags:
   - -trimpath
 goos: darwin
 goarch: arm64
 main: .
-binary: ofelia-darwin-arm64
+binary: ofelia-{{ .Os }}-{{ .Arch }}
 ldflags:
-  - "-s -w -X main.version=$VERSION -X main.build=$COMMIT"
+  - "-s -w -X main.version={{ .Env.VERSION }} -X main.build={{ .Env.COMMIT }}"

--- a/.slsa-goreleaser/linux-386.yml
+++ b/.slsa-goreleaser/linux-386.yml
@@ -2,13 +2,11 @@ version: 1
 env:
   - CGO_ENABLED=0
   - GO111MODULE=on
-  - VERSION
-  - COMMIT
 flags:
   - -trimpath
 goos: linux
 goarch: 386
 main: .
-binary: ofelia-linux-386
+binary: ofelia-{{ .Os }}-{{ .Arch }}
 ldflags:
-  - "-s -w -X main.version=$VERSION -X main.build=$COMMIT"
+  - "-s -w -X main.version={{ .Env.VERSION }} -X main.build={{ .Env.COMMIT }}"

--- a/.slsa-goreleaser/linux-amd64.yml
+++ b/.slsa-goreleaser/linux-amd64.yml
@@ -2,13 +2,11 @@ version: 1
 env:
   - CGO_ENABLED=0
   - GO111MODULE=on
-  - VERSION
-  - COMMIT
 flags:
   - -trimpath
 goos: linux
 goarch: amd64
 main: .
-binary: ofelia-linux-amd64
+binary: ofelia-{{ .Os }}-{{ .Arch }}
 ldflags:
-  - "-s -w -X main.version=$VERSION -X main.build=$COMMIT"
+  - "-s -w -X main.version={{ .Env.VERSION }} -X main.build={{ .Env.COMMIT }}"

--- a/.slsa-goreleaser/linux-arm64.yml
+++ b/.slsa-goreleaser/linux-arm64.yml
@@ -2,13 +2,11 @@ version: 1
 env:
   - CGO_ENABLED=0
   - GO111MODULE=on
-  - VERSION
-  - COMMIT
 flags:
   - -trimpath
 goos: linux
 goarch: arm64
 main: .
-binary: ofelia-linux-arm64
+binary: ofelia-{{ .Os }}-{{ .Arch }}
 ldflags:
-  - "-s -w -X main.version=$VERSION -X main.build=$COMMIT"
+  - "-s -w -X main.version={{ .Env.VERSION }} -X main.build={{ .Env.COMMIT }}"

--- a/.slsa-goreleaser/linux-armv6.yml
+++ b/.slsa-goreleaser/linux-armv6.yml
@@ -2,8 +2,6 @@ version: 1
 env:
   - CGO_ENABLED=0
   - GO111MODULE=on
-  - VERSION
-  - COMMIT
 flags:
   - -trimpath
 goos: linux
@@ -12,4 +10,4 @@ goarm: 6
 main: .
 binary: ofelia-linux-armv6
 ldflags:
-  - "-s -w -X main.version=$VERSION -X main.build=$COMMIT"
+  - "-s -w -X main.version={{ .Env.VERSION }} -X main.build={{ .Env.COMMIT }}"

--- a/.slsa-goreleaser/linux-armv7.yml
+++ b/.slsa-goreleaser/linux-armv7.yml
@@ -2,8 +2,6 @@ version: 1
 env:
   - CGO_ENABLED=0
   - GO111MODULE=on
-  - VERSION
-  - COMMIT
 flags:
   - -trimpath
 goos: linux
@@ -12,4 +10,4 @@ goarm: 7
 main: .
 binary: ofelia-linux-armv7
 ldflags:
-  - "-s -w -X main.version=$VERSION -X main.build=$COMMIT"
+  - "-s -w -X main.version={{ .Env.VERSION }} -X main.build={{ .Env.COMMIT }}"

--- a/.slsa-goreleaser/windows-amd64.yml
+++ b/.slsa-goreleaser/windows-amd64.yml
@@ -2,13 +2,11 @@ version: 1
 env:
   - CGO_ENABLED=0
   - GO111MODULE=on
-  - VERSION
-  - COMMIT
 flags:
   - -trimpath
 goos: windows
 goarch: amd64
 main: .
-binary: ofelia-windows-amd64
+binary: ofelia-{{ .Os }}-{{ .Arch }}
 ldflags:
-  - "-s -w -X main.version=$VERSION -X main.build=$COMMIT"
+  - "-s -w -X main.version={{ .Env.VERSION }} -X main.build={{ .Env.COMMIT }}"


### PR DESCRIPTION
## Summary

Fixes SLSA build failures by using the correct template syntax for the SLSA Go builder.

## Changes

- Use `{{ .Env.VERSION }}` and `{{ .Env.COMMIT }}` in ldflags (not $VERSION)
- Add space after comma in evaluated-envs format
- Remove VERSION/COMMIT from env section
- Use explicit binary names for armv6/armv7 configs

## Root Cause

The SLSA builder uses a different template syntax than expected. It requires:
- `{{ .Env.VAR }}` to reference environment variables
- Space after comma in evaluated-envs: `VAR1:val, VAR2:val`