### PR TITLE
fix(ci): add checkout step to SBOM job for gh CLI context

### DIFF
--- a/.github/workflows/release-slsa.yml
+++ b/.github/workflows/release-slsa.yml
@@ -96,6 +96,9 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@55dc4ee22412511ee8c3142cbea40418e6cec693 # v0.17.8
 


### PR DESCRIPTION
## Summary
- Add checkout step to SBOM generation job so gh CLI has repository context

## Problem
The `gh release download` command in the SBOM job fails with:
```
fatal: not a git repository (or any of the parent directories): .git
```

## Solution
Add `actions/checkout` step before using gh CLI commands that require repository context.