### PR TITLE
fix(ci): add checkout step to checksums job for gh CLI context

### DIFF
--- a/.github/workflows/release-slsa.yml
+++ b/.github/workflows/release-slsa.yml
@@ -148,6 +148,9 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Download all release assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add checkout step to checksums generation job so gh CLI has repository context

## Problem
The `gh release download` command in the checksums job fails with:
```
fatal: not a git repository (or any of the parent directories): .git
```

## Solution
Add `actions/checkout` step before using gh CLI commands that require repository context.

Same fix as PR #281 for SBOM job.