### PR TITLE
fix(ci): add checkout step to release notes job for gh CLI context

### DIFF
--- a/.github/workflows/release-slsa.yml
+++ b/.github/workflows/release-slsa.yml
@@ -208,6 +208,9 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Download changelog
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:


### PR DESCRIPTION
## Summary
- Add checkout step to release notes job so gh CLI has repository context

## Problem
The `gh release edit` command in the release notes job fails with:
```
fatal: not a git repository (or any of the parent directories): .git
```

## Solution
Add `actions/checkout` step before using gh CLI commands that require repository context.

Same fix as PRs #281 and #282 for SBOM and checksums jobs.