### PR TITLE
fix(security): pin go install commands by commit hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,8 @@ jobs:
           go-version-file: go.mod
 
       - name: Install go-licenses
-        run: go install github.com/google/go-licenses@v1.6.0
+        # Pin by hash for OpenSSF Scorecard compliance
+        run: go install github.com/google/go-licenses@5348b744d0983d85713295ea08a20cca1654a45e # v1.6.0
 
       - name: Check licenses
         run: |
@@ -296,7 +297,8 @@ jobs:
           go-version-file: go.mod
 
       - name: Install gosec
-        run: go install github.com/securego/gosec/v2/cmd/gosec@v2.22.0
+        # Pin by hash for OpenSSF Scorecard compliance
+        run: go install github.com/securego/gosec/v2/cmd/gosec@5d1a18b12ab7a9858baf9b7cffa903028792ed17 # v2.22.0
 
       - name: Run gosec
         run: |

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -15,7 +15,8 @@ echo ""
 # Check if lefthook is installed
 if ! command -v lefthook >/dev/null 2>&1; then
     echo "📦 Installing lefthook..."
-    go install github.com/evilmartians/lefthook@latest
+    # Pin to commit hash for OpenSSF Scorecard compliance (v2.0.4)
+    go install github.com/evilmartians/lefthook@a92b0191f01bd54306f069c371878eeee39611f7
     echo "✅ lefthook installed"
 fi
 


### PR DESCRIPTION
## Summary
- Pin all `go install` commands by commit hash instead of version tags
- Improves OpenSSF Scorecard Pinned-Dependencies score from 9/10 to 10/10

## Changes
| File | Tool | Before | After (hash) |
|------|------|--------|--------------|
| `scripts/install-hooks.sh` | lefthook | `@latest` | `@a92b0191f01bd54306f069c371878eeee39611f7` (v2.0.4) |
| `.github/workflows/ci.yml` | go-licenses | `@v1.6.0` | `@5348b744d0983d85713295ea08a20cca1654a45e` |
| `.github/workflows/ci.yml` | gosec | `@v2.22.0` | `@5d1a18b12ab7a9858baf9b7cffa903028792ed17` |

## Why
OpenSSF Scorecard's `Pinned-Dependencies` check requires dependencies to be pinned by **commit hash** for maximum supply chain security. Version tags can be moved or deleted, but commit hashes are immutable.

## Test plan
- [x] CI passes with hash-pinned dependencies
- [x] `go install` commands resolve correctly to expected versions