### PR TITLE
chore: add CODEOWNERS for automated review assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# CODEOWNERS - Defines code ownership for pull request reviews
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+* @CybotTM @netresearch/netresearch
+
+# Security-sensitive files require security team review
+/.github/workflows/ @CybotTM @netresearch/sec
+/SECURITY.md @CybotTM @netresearch/sec


### PR DESCRIPTION
## Summary
Add CODEOWNERS file to define code ownership and enable automated review assignment.

## Ownership Structure
| Path | Owners |
|------|--------|
| `*` (default) | @CybotTM, @netresearch/netresearch |
| `/.github/workflows/` | @CybotTM, @netresearch/sec |
| `/SECURITY.md` | @CybotTM, @netresearch/sec |

## Why
- Enables "require CODEOWNERS review" branch protection
- Improves OpenSSF Scorecard Code-Review score
- Automates review assignment on PRs

## Next Steps
After merging, branch protection will be updated to require CODEOWNERS review.