### PR TITLE
fix(docker): update Go image to 1.25.5 to match go.mod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Pin base images by digest for supply chain security
 # Renovate will automatically update these digests
-FROM golang:1.25.0-alpine@sha256:f18a072054848d87a8077455f0ac8a25886f2397f88bfdd222d6fafbb5bba440 AS builder
+FROM golang:1.25.5-alpine@sha256:26111811bc967321e7b6f852e914d14bede324cd1accb7f81811929a6a57fea9 AS builder
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache gcc musl-dev git


### PR DESCRIPTION
## Summary
- Update Dockerfile base image from golang:1.25.0-alpine to golang:1.25.5-alpine

## Problem
The Docker build fails with:
```
go: go.mod requires go >= 1.25.5 (running go 1.25.0; GOTOOLCHAIN=local)
```

The go.mod was updated to require Go 1.25.5 in v0.13.1, but the Dockerfile still uses golang:1.25.0-alpine.

## Fix
Update the Dockerfile to use golang:1.25.5-alpine with the proper digest for supply chain security.

## Test plan
- [ ] CI Docker build passes
- [ ] Multi-arch builds complete successfully