### PR TITLE
fix(docs): remove broken link to deleted investigation doc

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -151,9 +151,6 @@ v0.11.0 introduced OptimizedDockerClient that incorrectly enabled HTTP/2 on all 
    export DOCKER_CERT_PATH=/path/to/certs
    ```
 
-**Technical Details**:
-See `docs/http2_investigation_findings.md` for complete technical analysis.
-
 **References**:
 - Issue: #266
 - Fix: #267


### PR DESCRIPTION
## Summary
- Remove reference to `docs/http2_investigation_findings.md` which was deleted in PR #293
- The issue/PR references (#266, #267) remain for historical tracking

## Context
Copilot review on #293 flagged this broken link. PR #293 was merged before the fix could be applied, so this follow-up PR addresses it.