### PR TITLE
fix: use docker metadata version output for platform tagging

### DIFF
--- a/.github/workflows/release-slsa.yml
+++ b/.github/workflows/release-slsa.yml
@@ -328,7 +328,7 @@ jobs:
         run: |
           set -euo pipefail
           IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
-          VERSION="${{ env.VERSION }}"
+          VERSION="${{ steps.meta.outputs.version }}"
 
           # Get the manifest and extract platform digests, then tag each platform
           for platform in linux/386 linux/amd64 linux/arm/v6 linux/arm/v7 linux/arm64; do
@@ -352,4 +352,4 @@ jobs:
         run: |
           set -euo pipefail
           cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest@${{ steps.push.outputs.digest }}
-          cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}@${{ steps.push.outputs.digest }}
+          cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}@${{ steps.push.outputs.digest }}


### PR DESCRIPTION
## Summary
- Fixed version mismatch in release workflow that caused `MANIFEST_UNKNOWN` error
- The docker/metadata-action with `semver` pattern strips the `v` prefix from git tags
- Platform tagging step was using `env.VERSION` (e.g., `v0.14.0`) but should use `steps.meta.outputs.version` (e.g., `0.14.0`)

## Root Cause
When creating release v0.14.0, the image was pushed with tag `0.14.0` (semver strips `v`), but the platform tagging step tried to fetch `ghcr.io/netresearch/ofelia:v0.14.0`, causing:
```
Error: fetching manifest ghcr.io/netresearch/ofelia:v0.14.0: MANIFEST_UNKNOWN
```

## Fix
Use `${{ steps.meta.outputs.version }}` instead of `${{ env.VERSION }}` for:
- Platform-specific image tagging (line 331)
- Cosign signing (line 355) - for consistency

## Test Plan
- [ ] Merge this PR
- [ ] Re-run the release workflow for v0.14.0