### PR TITLE
fix: set GHCR package description via GitHub API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,12 +430,20 @@ jobs:
           OWNER: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
-          curl -sS -X PATCH \
+          # Try organization endpoint first, fall back to user endpoint if it fails
+          if ! curl -sSf -X PATCH \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/orgs/${OWNER}/packages/container/ofelia" \
-            -d '{"description":"A docker job scheduler (based on mcuadros/ofelia)"}'
+            -d '{"description":"A docker job scheduler (based on mcuadros/ofelia)"}'; then
+            curl -sSf -X PATCH \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/users/${OWNER}/packages/container/ofelia" \
+              -d '{"description":"A docker job scheduler (based on mcuadros/ofelia)"}'
+          fi
 
   hadolint:
     name: hadolint

--- a/.github/workflows/release-slsa.yml
+++ b/.github/workflows/release-slsa.yml
@@ -359,9 +359,17 @@ jobs:
           OWNER: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
-          curl -sS -X PATCH \
+          # Try organization endpoint first, fall back to user endpoint if it fails
+          if ! curl -sSf -X PATCH \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/orgs/${OWNER}/packages/container/ofelia" \
-            -d '{"description":"A docker job scheduler (based on mcuadros/ofelia)"}'
+            -d '{"description":"A docker job scheduler (based on mcuadros/ofelia)"}'; then
+            curl -sSf -X PATCH \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/users/${OWNER}/packages/container/ofelia" \
+              -d '{"description":"A docker job scheduler (based on mcuadros/ofelia)"}'
+          fi


### PR DESCRIPTION
## Summary

- Add workflow step to set GHCR package description via GitHub REST API
- Runs after container image signing in both CI and release workflows

## Problem

The GHCR package page shows "no description" even though OCI image labels are correctly set. This is because:

1. **OCI image labels** (`org.opencontainers.image.description`) are stored in the image manifest
2. **GHCR package description** is separate metadata managed by GitHub Packages

The `org.opencontainers.image.source` label links the image to the repository but doesn't populate the package page description.

## Solution

Use the GitHub Packages API to explicitly set the package description after pushing container images:

```bash
curl -X PATCH \
  -H "Authorization: Bearer $GITHUB_TOKEN" \
  "https://api.github.com/orgs/{owner}/packages/container/ofelia" \
  -d '{"description":"A docker job scheduler (based on mcuadros/ofelia)"}'
```

## Test plan

- [ ] Merge and wait for CI workflow to run on main
- [ ] Verify GHCR package page shows description: https://github.com/netresearch/ofelia/pkgs/container/ofelia