### PR TITLE
feat(middleware): add notification deduplication for Slack and Mail

### DIFF
--- a/middlewares/dedup.go
+++ b/middlewares/dedup.go
@@ -1,0 +1,133 @@
+package middlewares
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sync"
+	"time"
+
+	"github.com/netresearch/ofelia/core"
+)
+
+// NotificationDedup provides deduplication of error notifications.
+// It tracks recent error notifications and suppresses duplicates within
+// a configurable cooldown period to prevent notification spam.
+type NotificationDedup struct {
+	cooldown time.Duration
+	entries  map[string]time.Time
+	mu       sync.RWMutex
+}
+
+// NewNotificationDedup creates a new notification deduplicator with the
+// specified cooldown period. If cooldown is 0, deduplication is disabled
+// and all notifications are allowed.
+func NewNotificationDedup(cooldown time.Duration) *NotificationDedup {
+	return &NotificationDedup{
+		cooldown: cooldown,
+		entries:  make(map[string]time.Time),
+	}
+}
+
+// ShouldNotify returns true if the notification should be sent, false if it
+// should be suppressed as a duplicate. Successful executions always return
+// true (no deduplication for success). Failed executions are deduplicated
+// based on job name, command, and error message.
+func (d *NotificationDedup) ShouldNotify(ctx *core.Context) bool {
+	// Disabled dedup - always notify
+	if d.cooldown == 0 {
+		return true
+	}
+
+	// Always notify for successful executions
+	if !ctx.Execution.Failed {
+		return true
+	}
+
+	key := d.generateKey(ctx)
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	lastNotified, exists := d.entries[key]
+	now := time.Now()
+
+	// First occurrence or cooldown expired
+	if !exists || now.Sub(lastNotified) >= d.cooldown {
+		d.entries[key] = now
+		return true
+	}
+
+	// Within cooldown period - suppress notification
+	return false
+}
+
+// generateKey creates a unique key for deduplication based on job name,
+// command, and error message. This ensures that different errors from
+// the same job or same errors from different jobs are tracked separately.
+func (d *NotificationDedup) generateKey(ctx *core.Context) string {
+	h := sha256.New()
+	h.Write([]byte(ctx.Job.GetName()))
+	h.Write([]byte(ctx.Job.GetCommand()))
+
+	if ctx.Execution.Error != nil {
+		h.Write([]byte(ctx.Execution.Error.Error()))
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Cleanup removes expired entries from the deduplication map.
+// This should be called periodically to prevent memory leaks for
+// jobs that no longer fail.
+func (d *NotificationDedup) Cleanup() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	now := time.Now()
+	for key, lastNotified := range d.entries {
+		if now.Sub(lastNotified) >= d.cooldown {
+			delete(d.entries, key)
+		}
+	}
+}
+
+// Len returns the number of entries in the deduplication map.
+// Useful for testing and monitoring.
+func (d *NotificationDedup) Len() int {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return len(d.entries)
+}
+
+// DefaultNotificationDedup is the global deduplicator instance used by
+// notification middlewares. It's initialized when configuration is loaded.
+var DefaultNotificationDedup *NotificationDedup
+
+// InitNotificationDedup initializes the global deduplicator with the
+// specified cooldown period. Call this during configuration loading.
+func InitNotificationDedup(cooldown time.Duration) {
+	DefaultNotificationDedup = NewNotificationDedup(cooldown)
+}
+
+// StartCleanupRoutine starts a background goroutine that periodically
+// cleans up expired entries. Returns a stop function to cancel the routine.
+func (d *NotificationDedup) StartCleanupRoutine(interval time.Duration) func() {
+	ticker := time.NewTicker(interval)
+	done := make(chan struct{})
+
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				d.Cleanup()
+			case <-done:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+
+	return func() {
+		close(done)
+	}
+}

--- a/middlewares/dedup_test.go
+++ b/middlewares/dedup_test.go
@@ -1,0 +1,276 @@
+package middlewares
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/netresearch/ofelia/core"
+)
+
+type SuiteDedup struct {
+	BaseSuite
+}
+
+var _ = Suite(&SuiteDedup{})
+
+func (s *SuiteDedup) TestNewNotificationDedup(c *C) {
+	dedup := NewNotificationDedup(time.Hour)
+	c.Assert(dedup, NotNil)
+	c.Assert(dedup.cooldown, Equals, time.Hour)
+	c.Assert(dedup.entries, NotNil)
+}
+
+func (s *SuiteDedup) TestGenerateKey(c *C) {
+	dedup := NewNotificationDedup(time.Hour)
+
+	// Set up job with name and command
+	s.job.Name = "test-job"
+	s.job.Command = "echo hello"
+
+	s.ctx.Start()
+	s.ctx.Stop(errors.New("connection refused"))
+
+	key := dedup.generateKey(s.ctx)
+	c.Assert(key, Not(Equals), "")
+
+	// Same error should produce same key
+	s.ctx.Start()
+	s.ctx.Stop(errors.New("connection refused"))
+	key2 := dedup.generateKey(s.ctx)
+	c.Assert(key, Equals, key2)
+
+	// Different error should produce different key
+	s.ctx.Start()
+	s.ctx.Stop(errors.New("timeout"))
+	key3 := dedup.generateKey(s.ctx)
+	c.Assert(key, Not(Equals), key3)
+}
+
+func (s *SuiteDedup) TestShouldNotify_FirstError(c *C) {
+	dedup := NewNotificationDedup(time.Hour)
+
+	s.job.Name = "test-job"
+	s.job.Command = "echo hello"
+
+	s.ctx.Start()
+	s.ctx.Stop(errors.New("first error"))
+
+	// First occurrence should always notify
+	c.Assert(dedup.ShouldNotify(s.ctx), Equals, true)
+}
+
+func (s *SuiteDedup) TestShouldNotify_DuplicateWithinCooldown(c *C) {
+	dedup := NewNotificationDedup(time.Hour)
+
+	s.job.Name = "test-job"
+	s.job.Command = "echo hello"
+
+	// First error - should notify
+	s.ctx.Start()
+	s.ctx.Stop(errors.New("same error"))
+	c.Assert(dedup.ShouldNotify(s.ctx), Equals, true)
+
+	// Same error again immediately - should NOT notify (within cooldown)
+	s.ctx.Start()
+	s.ctx.Stop(errors.New("same error"))
+	c.Assert(dedup.ShouldNotify(s.ctx), Equals, false)
+}
+
+func (s *SuiteDedup) TestShouldNotify_DifferentErrors(c *C) {
+	dedup := NewNotificationDedup(time.Hour)
+
+	s.job.Name = "test-job"
+	s.job.Command = "echo hello"
+
+	// First error
+	s.ctx.Start()
+	s.ctx.Stop(errors.New("error A"))
+	c.Assert(dedup.ShouldNotify(s.ctx), Equals, true)
+
+	// Different error - should notify
+	s.ctx.Start()
+	s.ctx.Stop(errors.New("error B"))
+	c.Assert(dedup.ShouldNotify(s.ctx), Equals, true)
+}
+
+func (s *SuiteDedup) TestShouldNotify_AfterCooldownExpires(c *C) {
+	// Use very short cooldown for testing
+	dedup := NewNotificationDedup(10 * time.Millisecond)
+
+	s.job.Name = "test-job"
+	s.job.Command = "echo hello"
+
+	// First error - should notify
+	s.ctx.Start()
+	s.ctx.Stop(errors.New("same error"))
+	c.Assert(dedup.ShouldNotify(s.ctx), Equals, true)
+
+	// Same error immediately - should NOT notify
+	s.ctx.Start()
+	s.ctx.Stop(errors.New("same error"))
+	c.Assert(dedup.ShouldNotify(s.ctx), Equals, false)
+
+	// Wait for cooldown to expire
+	time.Sleep(15 * time.Millisecond)
+
+	// Same error after cooldown - should notify again
+	s.ctx.Start()
+	s.ctx.Stop(errors.New("same error"))
+	c.Assert(dedup.ShouldNotify(s.ctx), Equals, true)
+}
+
+func (s *SuiteDedup) TestShouldNotify_SuccessAlwaysNotifies(c *C) {
+	dedup := NewNotificationDedup(time.Hour)
+
+	s.job.Name = "test-job"
+	s.job.Command = "echo hello"
+
+	// Success - should always notify (no dedup for success)
+	s.ctx.Start()
+	s.ctx.Stop(nil)
+	c.Assert(dedup.ShouldNotify(s.ctx), Equals, true)
+
+	// Another success - should also notify
+	s.ctx.Start()
+	s.ctx.Stop(nil)
+	c.Assert(dedup.ShouldNotify(s.ctx), Equals, true)
+}
+
+func (s *SuiteDedup) TestShouldNotify_DifferentJobs(c *C) {
+	dedup := NewNotificationDedup(time.Hour)
+
+	// Job 1 fails
+	s.job.Name = "job-1"
+	s.job.Command = "echo hello"
+	s.ctx.Start()
+	s.ctx.Stop(errors.New("same error"))
+	c.Assert(dedup.ShouldNotify(s.ctx), Equals, true)
+
+	// Job 2 fails with same error - should still notify (different job)
+	s.job.Name = "job-2"
+	s.ctx.Start()
+	s.ctx.Stop(errors.New("same error"))
+	c.Assert(dedup.ShouldNotify(s.ctx), Equals, true)
+}
+
+func (s *SuiteDedup) TestCleanup_RemovesExpiredEntries(c *C) {
+	dedup := NewNotificationDedup(10 * time.Millisecond)
+
+	s.job.Name = "test-job"
+	s.job.Command = "echo hello"
+
+	// Add some entries
+	s.ctx.Start()
+	s.ctx.Stop(errors.New("error 1"))
+	dedup.ShouldNotify(s.ctx)
+
+	s.ctx.Start()
+	s.ctx.Stop(errors.New("error 2"))
+	dedup.ShouldNotify(s.ctx)
+
+	c.Assert(len(dedup.entries), Equals, 2)
+
+	// Wait for cooldown to expire
+	time.Sleep(15 * time.Millisecond)
+
+	// Cleanup should remove expired entries
+	dedup.Cleanup()
+	c.Assert(len(dedup.entries), Equals, 0)
+}
+
+func (s *SuiteDedup) TestConcurrentAccess(c *C) {
+	dedup := NewNotificationDedup(time.Hour)
+
+	s.job.Name = "test-job"
+	s.job.Command = "echo hello"
+
+	// Simulate concurrent access
+	done := make(chan bool, 10)
+	for i := 0; i < 10; i++ {
+		go func(errNum int) {
+			ctx := s.createContext(c)
+			ctx.Start()
+			ctx.Stop(errors.New("error"))
+			dedup.ShouldNotify(ctx)
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// Should not panic and should have reasonable state
+	c.Assert(len(dedup.entries) >= 1, Equals, true)
+}
+
+func (s *SuiteDedup) createContext(c *C) *core.Context {
+	sh := core.NewScheduler(&TestLogger{})
+	e, err := core.NewExecution()
+	c.Assert(err, IsNil)
+	return core.NewContext(sh, s.job, e)
+}
+
+// Test disabled dedup (zero cooldown)
+func (s *SuiteDedup) TestZeroCooldown_AlwaysNotifies(c *C) {
+	dedup := NewNotificationDedup(0)
+
+	s.job.Name = "test-job"
+	s.job.Command = "echo hello"
+
+	// With zero cooldown, should always notify
+	s.ctx.Start()
+	s.ctx.Stop(errors.New("same error"))
+	c.Assert(dedup.ShouldNotify(s.ctx), Equals, true)
+
+	s.ctx.Start()
+	s.ctx.Stop(errors.New("same error"))
+	c.Assert(dedup.ShouldNotify(s.ctx), Equals, true)
+}
+
+// Integration test with standard Go testing for better IDE support
+func TestNotificationDedup_Integration(t *testing.T) {
+	dedup := NewNotificationDedup(100 * time.Millisecond)
+
+	// Create a mock context
+	job := &TestJob{}
+	job.Name = "integration-test-job"
+	job.Command = "test command"
+
+	sh := core.NewScheduler(&TestLogger{})
+	e, err := core.NewExecution()
+	if err != nil {
+		t.Fatalf("Failed to create execution: %v", err)
+	}
+
+	ctx := core.NewContext(sh, job, e)
+
+	// Test sequence: notify -> suppress -> notify after cooldown
+	ctx.Start()
+	ctx.Stop(errors.New("test error"))
+
+	if !dedup.ShouldNotify(ctx) {
+		t.Error("Expected first notification to be allowed")
+	}
+
+	ctx.Start()
+	ctx.Stop(errors.New("test error"))
+
+	if dedup.ShouldNotify(ctx) {
+		t.Error("Expected duplicate notification to be suppressed")
+	}
+
+	// Wait for cooldown
+	time.Sleep(150 * time.Millisecond)
+
+	ctx.Start()
+	ctx.Stop(errors.New("test error"))
+
+	if !dedup.ShouldNotify(ctx) {
+		t.Error("Expected notification after cooldown to be allowed")
+	}
+}

--- a/middlewares/slack_test.go
+++ b/middlewares/slack_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"time"
 
+	"github.com/netresearch/ofelia/core"
+
 	. "gopkg.in/check.v1"
 )
 
@@ -84,4 +86,109 @@ func (s *SuiteSlack) TestCustomHTTPClient(c *C) {
 	m.Client = custom
 
 	c.Assert(m.Run(s.ctx), IsNil)
+}
+
+func (s *SuiteSlack) TestDedupSuppressesDuplicateErrors(c *C) {
+	callCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+	}))
+	defer ts.Close()
+
+	// Create dedup with 1 hour cooldown
+	dedup := NewNotificationDedup(time.Hour)
+
+	// Create fresh context for this test
+	job := &TestJob{}
+	sh := core.NewScheduler(&TestLogger{})
+	e, err := core.NewExecution()
+	c.Assert(err, IsNil)
+	ctx := core.NewContext(sh, job, e)
+
+	// First error - should send notification
+	ctx.Start()
+	ctx.Stop(errors.New("test error"))
+
+	m := NewSlack(&SlackConfig{SlackWebhook: ts.URL, Dedup: dedup}).(*Slack)
+	c.Assert(m.Run(ctx), IsNil)
+	c.Assert(callCount, Equals, 1)
+
+	// Create new execution for second run
+	e2, _ := core.NewExecution()
+	ctx2 := core.NewContext(sh, job, e2)
+	ctx2.Start()
+	ctx2.Stop(errors.New("test error"))
+	c.Assert(m.Run(ctx2), IsNil)
+	c.Assert(callCount, Equals, 1) // Still 1, not 2 (suppressed)
+
+	// Different error - should send notification
+	e3, _ := core.NewExecution()
+	ctx3 := core.NewContext(sh, job, e3)
+	ctx3.Start()
+	ctx3.Stop(errors.New("different error"))
+	c.Assert(m.Run(ctx3), IsNil)
+	c.Assert(callCount, Equals, 2) // Now 2
+}
+
+func (s *SuiteSlack) TestDedupAllowsSuccessNotifications(c *C) {
+	callCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+	}))
+	defer ts.Close()
+
+	dedup := NewNotificationDedup(time.Hour)
+
+	// Create fresh context
+	job := &TestJob{}
+	sh := core.NewScheduler(&TestLogger{})
+	e, _ := core.NewExecution()
+	ctx := core.NewContext(sh, job, e)
+
+	// Success - should always send (dedup only applies to errors)
+	ctx.Start()
+	ctx.Stop(nil)
+
+	m := NewSlack(&SlackConfig{SlackWebhook: ts.URL, Dedup: dedup}).(*Slack)
+	c.Assert(m.Run(ctx), IsNil)
+	c.Assert(callCount, Equals, 1)
+
+	// Another success - should also send
+	e2, _ := core.NewExecution()
+	ctx2 := core.NewContext(sh, job, e2)
+	ctx2.Start()
+	ctx2.Stop(nil)
+	c.Assert(m.Run(ctx2), IsNil)
+	c.Assert(callCount, Equals, 2)
+}
+
+func (s *SuiteSlack) TestNoDedupWhenNotConfigured(c *C) {
+	callCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+	}))
+	defer ts.Close()
+
+	// Create fresh context
+	job := &TestJob{}
+	sh := core.NewScheduler(&TestLogger{})
+	e, _ := core.NewExecution()
+	ctx := core.NewContext(sh, job, e)
+
+	// No dedup configured
+	m := NewSlack(&SlackConfig{SlackWebhook: ts.URL}).(*Slack)
+
+	// First error
+	ctx.Start()
+	ctx.Stop(errors.New("test error"))
+	c.Assert(m.Run(ctx), IsNil)
+	c.Assert(callCount, Equals, 1)
+
+	// Same error again - should still send (no dedup)
+	e2, _ := core.NewExecution()
+	ctx2 := core.NewContext(sh, job, e2)
+	ctx2.Start()
+	ctx2.Stop(errors.New("test error"))
+	c.Assert(m.Run(ctx2), IsNil)
+	c.Assert(callCount, Equals, 2)
 }


### PR DESCRIPTION
## Summary
- Add rate-limiting for error notifications to prevent notification spam when jobs fail repeatedly with the same error
- New `notification-cooldown` global config option (e.g., `notification-cooldown = 1h`)
- Notifications for the same job+error are suppressed within the cooldown period
- Fix URL port handling bug in Slack middleware that was stripping ports from webhook URLs

## Changes
- Add `NotificationDedup` struct with SHA256-based key generation for identifying duplicate notifications
- Integrate dedup into Slack and Mail middlewares
- Add comprehensive tests for deduplication logic (unit tests + integration test)

## Test plan
- [x] All existing tests pass (31 middleware tests)
- [x] New dedup tests verify suppression behavior
- [x] Linter passes with 0 issues

Closes #371