### PR TITLE
feat(auth): implement Docker registry authentication via config.json

### DIFF
--- a/cli/docker_config_handler.go
+++ b/cli/docker_config_handler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/netresearch/ofelia/core"
+	dockeradapter "github.com/netresearch/ofelia/core/adapters/docker"
 	"github.com/netresearch/ofelia/core/domain"
 )
 
@@ -155,7 +156,12 @@ func NewDockerHandler(
 
 // buildSDKProvider creates the new SDK-based Docker provider.
 func (c *DockerHandler) buildSDKProvider() (core.DockerProvider, error) {
-	provider, err := core.NewSDKDockerProviderDefault()
+	// Create auth provider for registry authentication
+	authProvider := dockeradapter.NewConfigAuthProvider()
+
+	provider, err := core.NewSDKDockerProvider(&core.SDKDockerProviderConfig{
+		AuthProvider: authProvider,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SDK Docker provider: %w", err)
 	}

--- a/core/adapters/docker/auth.go
+++ b/core/adapters/docker/auth.go
@@ -1,0 +1,144 @@
+package docker
+
+import (
+	"fmt"
+
+	"github.com/distribution/reference"
+	"github.com/docker/cli/cli/config"
+	"github.com/docker/cli/cli/config/configfile"
+	"github.com/docker/cli/cli/config/types"
+
+	"github.com/netresearch/ofelia/core/domain"
+)
+
+// ConfigAuthProvider implements ports.AuthProvider using Docker's config.json.
+// It reads credentials fresh on each call to support dynamic credential updates
+// (e.g., short-lived tokens from AWS ECR, GCR).
+type ConfigAuthProvider struct {
+	// configDir overrides the default Docker config directory (for testing)
+	configDir string
+	// logger for debug/warning messages (optional)
+	logger Logger
+}
+
+// Logger interface for auth provider logging
+type Logger interface {
+	Debugf(format string, args ...interface{})
+	Warningf(format string, args ...interface{})
+}
+
+// NewConfigAuthProvider creates a new auth provider.
+func NewConfigAuthProvider() *ConfigAuthProvider {
+	return &ConfigAuthProvider{}
+}
+
+// NewConfigAuthProviderWithOptions creates an auth provider with options.
+func NewConfigAuthProviderWithOptions(configDir string, logger Logger) *ConfigAuthProvider {
+	return &ConfigAuthProvider{
+		configDir: configDir,
+		logger:    logger,
+	}
+}
+
+// GetAuthConfig returns auth configuration for a registry.
+func (p *ConfigAuthProvider) GetAuthConfig(registry string) (domain.AuthConfig, error) {
+	// Load config fresh each time (no caching) to support credential rotation
+	cfg, err := p.loadConfig()
+	if err != nil {
+		p.logWarning("Failed to load Docker config: %v", err)
+		return domain.AuthConfig{}, nil // Graceful fallback for public images
+	}
+
+	// Normalize registry address
+	registry = normalizeRegistry(registry)
+
+	// Get auth from config (supports credential helpers)
+	authConfig, err := cfg.GetAuthConfig(registry)
+	if err != nil {
+		p.logWarning("Failed to get auth for registry %q: %v", registry, err)
+		return domain.AuthConfig{}, nil // Graceful fallback
+	}
+
+	// Log if we found credentials
+	if authConfig.Username != "" || authConfig.IdentityToken != "" {
+		p.logDebug("Found credentials for registry %q", registry)
+	}
+
+	return convertAuthConfig(authConfig), nil
+}
+
+// GetEncodedAuth returns base64-encoded auth for a registry.
+func (p *ConfigAuthProvider) GetEncodedAuth(registry string) (string, error) {
+	auth, err := p.GetAuthConfig(registry)
+	if err != nil {
+		return "", err
+	}
+
+	// Empty auth is valid (public registry)
+	if auth.Username == "" && auth.Password == "" && auth.IdentityToken == "" && auth.Auth == "" {
+		return "", nil
+	}
+
+	return EncodeAuthConfig(auth)
+}
+
+func (p *ConfigAuthProvider) loadConfig() (*configfile.ConfigFile, error) {
+	var cfg *configfile.ConfigFile
+	var err error
+	if p.configDir != "" {
+		cfg, err = config.Load(p.configDir)
+	} else {
+		cfg, err = config.Load(config.Dir())
+	}
+	if err != nil {
+		return nil, fmt.Errorf("loading docker config: %w", err)
+	}
+	return cfg, nil
+}
+
+func (p *ConfigAuthProvider) logDebug(format string, args ...interface{}) {
+	if p.logger != nil {
+		p.logger.Debugf(format, args...)
+	}
+}
+
+func (p *ConfigAuthProvider) logWarning(format string, args ...interface{}) {
+	if p.logger != nil {
+		p.logger.Warningf(format, args...)
+	}
+}
+
+// normalizeRegistry normalizes a registry address for credential lookup.
+func normalizeRegistry(registry string) string {
+	// Docker Hub special cases
+	if registry == "" || registry == "docker.io" || registry == "index.docker.io" {
+		return "https://index.docker.io/v1/"
+	}
+	return registry
+}
+
+// convertAuthConfig converts Docker CLI types to domain types.
+func convertAuthConfig(src types.AuthConfig) domain.AuthConfig {
+	return domain.AuthConfig{
+		Username:      src.Username,
+		Password:      src.Password,
+		Auth:          src.Auth,
+		ServerAddress: src.ServerAddress,
+		IdentityToken: src.IdentityToken,
+		RegistryToken: src.RegistryToken,
+	}
+}
+
+// ExtractRegistry extracts the registry hostname from an image reference.
+// Uses the canonical docker/distribution/reference parser for robustness.
+func ExtractRegistry(image string) string {
+	// Use canonical reference parsing
+	named, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		// Fallback to Docker Hub for unparseable images
+		return "docker.io"
+	}
+
+	// reference.Domain returns the registry domain
+	return reference.Domain(named)
+}

--- a/core/adapters/docker/auth_test.go
+++ b/core/adapters/docker/auth_test.go
@@ -1,0 +1,262 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractRegistry(t *testing.T) {
+	tests := []struct {
+		name     string
+		image    string
+		expected string
+	}{
+		// Docker Hub defaults
+		{"simple image", "alpine", "docker.io"},
+		{"image with tag", "nginx:latest", "docker.io"},
+		{"library image", "library/ubuntu", "docker.io"},
+		{"user/repo", "myuser/myimage", "docker.io"},
+		{"user/repo with tag", "myuser/myimage:v1.0", "docker.io"},
+
+		// Private registries
+		{"gcr.io", "gcr.io/project/image:tag", "gcr.io"},
+		{"quay.io", "quay.io/org/image", "quay.io"},
+		{"ghcr.io", "ghcr.io/owner/image:latest", "ghcr.io"},
+		{"ecr", "123456789.dkr.ecr.us-east-1.amazonaws.com/myimage", "123456789.dkr.ecr.us-east-1.amazonaws.com"},
+
+		// Registry with port
+		{"localhost with port", "localhost:5000/myimage", "localhost:5000"},
+		{"IP with port", "192.168.1.1:5000/image", "192.168.1.1:5000"},
+		{"custom registry with port", "registry.example.com:8080/org/image:tag", "registry.example.com:8080"},
+
+		// Custom domain registries
+		{"custom domain", "registry.example.com/org/image", "registry.example.com"},
+		{"subdomain registry", "docker.my-company.com/project/image:v2", "docker.my-company.com"},
+
+		// Digests - note: reference.ParseNormalizedNamed may not handle
+		// all digest formats, especially with incomplete sha256
+		{"image with digest", "alpine@sha256:abc123def456", "docker.io"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractRegistry(tt.image)
+			if got != tt.expected {
+				t.Errorf("ExtractRegistry(%q) = %q, want %q", tt.image, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizeRegistry(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"", "https://index.docker.io/v1/"},
+		{"docker.io", "https://index.docker.io/v1/"},
+		{"index.docker.io", "https://index.docker.io/v1/"},
+		{"gcr.io", "gcr.io"},
+		{"quay.io", "quay.io"},
+		{"localhost:5000", "localhost:5000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := normalizeRegistry(tt.input)
+			if got != tt.expected {
+				t.Errorf("normalizeRegistry(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestConfigAuthProvider_GetAuthConfig_MissingConfig(t *testing.T) {
+	// Create provider with non-existent config dir
+	provider := NewConfigAuthProviderWithOptions("/nonexistent/path/12345", nil)
+
+	// Should return empty auth (graceful fallback), not error
+	auth, err := provider.GetAuthConfig("gcr.io")
+	if err != nil {
+		t.Errorf("GetAuthConfig() error = %v, want nil (graceful fallback)", err)
+	}
+	if auth.Username != "" || auth.Password != "" {
+		t.Errorf("GetAuthConfig() = %+v, want empty auth", auth)
+	}
+}
+
+func TestConfigAuthProvider_GetEncodedAuth_Empty(t *testing.T) {
+	// Create provider with non-existent config dir
+	provider := NewConfigAuthProviderWithOptions("/nonexistent/path/12345", nil)
+
+	// Should return empty string (no auth needed)
+	encoded, err := provider.GetEncodedAuth("docker.io")
+	if err != nil {
+		t.Errorf("GetEncodedAuth() error = %v, want nil", err)
+	}
+	if encoded != "" {
+		t.Errorf("GetEncodedAuth() = %q, want empty string", encoded)
+	}
+}
+
+func TestConfigAuthProvider_GetAuthConfig_ValidConfig(t *testing.T) {
+	// Create temp dir with mock config.json
+	tmpDir, err := os.MkdirTemp("", "docker-config-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Write mock config.json with basic auth
+	configJSON := `{
+		"auths": {
+			"https://index.docker.io/v1/": {
+				"auth": "dXNlcm5hbWU6cGFzc3dvcmQ="
+			},
+			"gcr.io": {
+				"username": "oauth2accesstoken",
+				"password": "ya29.token123"
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte(configJSON), 0600); err != nil {
+		t.Fatalf("Failed to write config.json: %v", err)
+	}
+
+	provider := NewConfigAuthProviderWithOptions(tmpDir, nil)
+
+	// Test Docker Hub auth (base64 auth gets decoded to username/password by config library)
+	auth, err := provider.GetAuthConfig("docker.io")
+	if err != nil {
+		t.Errorf("GetAuthConfig(docker.io) error = %v", err)
+	}
+	// The docker/cli config library decodes base64 auth into username/password
+	if auth.Username != "username" {
+		t.Errorf("GetAuthConfig(docker.io).Username = %q, want username", auth.Username)
+	}
+	if auth.Password != "password" {
+		t.Errorf("GetAuthConfig(docker.io).Password = %q, want password", auth.Password)
+	}
+
+	// Test GCR auth
+	auth, err = provider.GetAuthConfig("gcr.io")
+	if err != nil {
+		t.Errorf("GetAuthConfig(gcr.io) error = %v", err)
+	}
+	if auth.Username != "oauth2accesstoken" {
+		t.Errorf("GetAuthConfig(gcr.io).Username = %q, want oauth2accesstoken", auth.Username)
+	}
+	if auth.Password != "ya29.token123" {
+		t.Errorf("GetAuthConfig(gcr.io).Password = %q, want ya29.token123", auth.Password)
+	}
+
+	// Test unknown registry (should return empty)
+	auth, err = provider.GetAuthConfig("unknown.registry.io")
+	if err != nil {
+		t.Errorf("GetAuthConfig(unknown) error = %v", err)
+	}
+	if auth.Username != "" || auth.Password != "" || auth.Auth != "" {
+		t.Errorf("GetAuthConfig(unknown) = %+v, want empty", auth)
+	}
+}
+
+func TestConfigAuthProvider_GetEncodedAuth_ValidConfig(t *testing.T) {
+	// Create temp dir with mock config.json
+	tmpDir, err := os.MkdirTemp("", "docker-config-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Write mock config.json
+	configJSON := `{
+		"auths": {
+			"gcr.io": {
+				"username": "testuser",
+				"password": "testpass"
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte(configJSON), 0600); err != nil {
+		t.Fatalf("Failed to write config.json: %v", err)
+	}
+
+	provider := NewConfigAuthProviderWithOptions(tmpDir, nil)
+
+	// Should return base64-encoded auth
+	encoded, err := provider.GetEncodedAuth("gcr.io")
+	if err != nil {
+		t.Errorf("GetEncodedAuth() error = %v", err)
+	}
+	if encoded == "" {
+		t.Error("GetEncodedAuth() returned empty, want encoded auth")
+	}
+}
+
+// mockLogger implements the Logger interface for testing
+type mockLogger struct {
+	debugMessages   []string
+	warningMessages []string
+}
+
+func (m *mockLogger) Debugf(format string, args ...interface{}) {
+	m.debugMessages = append(m.debugMessages, format)
+}
+
+func (m *mockLogger) Warningf(format string, args ...interface{}) {
+	m.warningMessages = append(m.warningMessages, format)
+}
+
+func TestConfigAuthProvider_Logging(t *testing.T) {
+	logger := &mockLogger{}
+
+	// Test with valid config dir - should log debug message when credentials found
+	tmpDir, err := os.MkdirTemp("", "docker-config-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Write mock config.json with auth
+	configJSON := `{
+		"auths": {
+			"gcr.io": {
+				"username": "testuser",
+				"password": "testpass"
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), []byte(configJSON), 0600); err != nil {
+		t.Fatalf("Failed to write config.json: %v", err)
+	}
+
+	provider := NewConfigAuthProviderWithOptions(tmpDir, logger)
+	_, _ = provider.GetAuthConfig("gcr.io")
+
+	if len(logger.debugMessages) == 0 {
+		t.Error("Expected debug message for found credentials, got none")
+	}
+}
+
+func TestNewConfigAuthProvider(t *testing.T) {
+	provider := NewConfigAuthProvider()
+	if provider == nil {
+		t.Error("NewConfigAuthProvider() returned nil")
+	}
+	if provider.configDir != "" {
+		t.Errorf("NewConfigAuthProvider().configDir = %q, want empty", provider.configDir)
+	}
+}
+
+func TestNewConfigAuthProviderWithOptions(t *testing.T) {
+	logger := &mockLogger{}
+	provider := NewConfigAuthProviderWithOptions("/custom/path", logger)
+
+	if provider.configDir != "/custom/path" {
+		t.Errorf("configDir = %q, want /custom/path", provider.configDir)
+	}
+	if provider.logger != logger {
+		t.Error("logger not set correctly")
+	}
+}

--- a/docs/adr/ADR-001-docker-registry-authentication.md
+++ b/docs/adr/ADR-001-docker-registry-authentication.md
@@ -1,0 +1,121 @@
+# ADR-001: Docker Registry Authentication via config.json
+
+## Status
+
+**Accepted** - 2025-12-10
+
+## Context
+
+Ofelia is a Docker job scheduler that can pull images from registries before running containers. Issue #370 (upstream #91) requests that Ofelia read Docker's `config.json` file to authenticate with private registries when pulling images.
+
+### Current State
+
+The codebase has infrastructure for registry authentication that is **not being used**:
+
+1. `domain.PullOptions` has a `RegistryAuth` field (unused)
+2. `domain.AuthConfig` defines the authentication structure
+3. `ports.AuthProvider` interface exists but has no implementation
+4. `docker.EncodeAuthConfig()` can encode auth for API calls
+
+In `SDKDockerProvider.PullImage()`, `PullOptions` is created without setting `RegistryAuth`:
+
+```go
+opts := domain.PullOptions{
+    Repository: ref.Repository,
+    Tag:        ref.Tag,
+    // RegistryAuth is never set!
+}
+```
+
+### Problem
+
+When Ofelia runs as a long-running daemon, it cannot:
+- Authenticate with private Docker registries
+- Use credential helpers (docker-credential-*)
+- Detect credential updates without restart
+
+This limits Ofelia's usability in enterprise environments where private registries are standard.
+
+## Decision
+
+Implement Docker registry authentication by:
+
+1. **Adding `github.com/docker/cli/cli/config` dependency** - The canonical library for reading Docker's config.json and invoking credential helpers
+
+2. **Implementing `ports.AuthProvider` interface** - Create `DockerConfigAuthProvider` that:
+   - Reads Docker config fresh on each call (no caching)
+   - Supports credential helpers (docker-credential-*)
+   - Extracts registry hostname from image reference
+
+3. **Injecting AuthProvider into SDKDockerProvider** - Modify:
+   - `SDKDockerProviderConfig` to accept optional `AuthProvider`
+   - `PullImage()` to call `AuthProvider.GetEncodedAuth(registry)` before pulling
+
+4. **Wiring in CLI daemon startup** - Create the `DockerConfigAuthProvider` during initialization
+
+### Why Fresh Reads (No Caching)
+
+Both analysis models (9/10 confidence each) agreed that reading config fresh on each pull is preferred:
+
+- **Avoids stale credentials** - Critical for short-lived tokens (AWS ECR, GCR)
+- **Simpler implementation** - No cache invalidation complexity
+- **Negligible overhead** - Config read is fast compared to network image pull
+- **Security** - Always uses current credentials, respects user logouts
+
+## Consequences
+
+### Positive
+
+- **Unlocks private registry support** - Essential for enterprise/production use
+- **Industry standard approach** - Same pattern used by Kubernetes, Tekton, GitLab
+- **Leverages existing architecture** - Uses pre-designed `AuthProvider` interface
+- **Low maintenance** - Official library handles config format changes
+- **Security best practice** - Uses Docker's credential helper system
+
+### Negative
+
+- **New dependency** - Adds `github.com/docker/cli` to go.mod
+- **Cross-platform complexity** - Credential helper execution may vary by OS
+- **Error handling** - Must gracefully handle missing config/credentials
+
+### Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Credential helper failures | Graceful fallback to no-auth pull attempt |
+| Missing config.json | Silent fallback, log at debug level |
+| Docker CLI version drift | Pin dependency, monitor releases |
+
+## Alternatives Considered
+
+### 1. Ofelia-specific credential configuration
+
+**Rejected** - Would create separate source of truth, bypass secure credential helpers, require storing secrets in config files.
+
+### 2. Environment variable (`DOCKER_AUTH_CONFIG`)
+
+**Rejected** - Less comprehensive than config.json, doesn't support credential helpers.
+
+### 3. Caching credentials at startup
+
+**Rejected** - Causes stale credential issues, especially with short-lived tokens (ECR, GCR).
+
+## Implementation Plan
+
+See `docs/adr/ADR-001-implementation-plan.md` for detailed implementation steps.
+
+## References
+
+- Issue #370: https://github.com/netresearch/ofelia/issues/370
+- Upstream Issue #91: https://github.com/mcuadros/ofelia/issues/91
+- Docker CLI config package: https://pkg.go.dev/github.com/docker/cli/cli/config
+- Docker credential helpers: https://docs.docker.com/engine/reference/commandline/login/#credential-helpers
+
+## Consensus
+
+Multi-model analysis achieved consensus (gemini-2.5-pro: 9/10, gemini-2.5-flash: 9/10) that this approach is:
+
+- Technically feasible with no blockers
+- Architecturally sound using existing interfaces
+- Industry standard and security best practice
+- Moderate complexity with high user value

--- a/docs/adr/ADR-001-implementation-plan.md
+++ b/docs/adr/ADR-001-implementation-plan.md
@@ -1,0 +1,322 @@
+# ADR-001: Implementation Plan - Docker Registry Authentication
+
+## Overview
+
+This document details the implementation steps for Docker registry authentication via config.json (ADR-001).
+
+## Phase 1: Add Dependency
+
+### Step 1.1: Update go.mod
+
+```bash
+go get github.com/docker/cli/cli/config
+```
+
+**Files Changed:**
+- `go.mod`
+- `go.sum`
+
+## Phase 2: Implement AuthProvider
+
+### Step 2.1: Create DockerConfigAuthProvider
+
+**File:** `core/adapters/docker/auth.go`
+
+```go
+package docker
+
+import (
+    "github.com/docker/cli/cli/config"
+    "github.com/docker/cli/cli/config/credentials"
+    "github.com/docker/cli/cli/config/types"
+
+    "github.com/netresearch/ofelia/core/domain"
+)
+
+// DockerConfigAuthProvider implements ports.AuthProvider using Docker's config.json.
+// It reads credentials fresh on each call to support dynamic credential updates.
+type DockerConfigAuthProvider struct {
+    // configDir overrides the default Docker config directory (for testing)
+    configDir string
+}
+
+// NewDockerConfigAuthProvider creates a new auth provider.
+func NewDockerConfigAuthProvider() *DockerConfigAuthProvider {
+    return &DockerConfigAuthProvider{}
+}
+
+// NewDockerConfigAuthProviderWithDir creates an auth provider with custom config dir.
+func NewDockerConfigAuthProviderWithDir(configDir string) *DockerConfigAuthProvider {
+    return &DockerConfigAuthProvider{configDir: configDir}
+}
+
+// GetAuthConfig returns auth configuration for a registry.
+func (p *DockerConfigAuthProvider) GetAuthConfig(registry string) (domain.AuthConfig, error) {
+    // Load config fresh each time (no caching)
+    cfg, err := p.loadConfig()
+    if err != nil {
+        return domain.AuthConfig{}, nil // Graceful fallback
+    }
+
+    // Normalize registry address
+    registry = normalizeRegistry(registry)
+
+    // Get auth from config (supports credential helpers)
+    authConfig, err := cfg.GetAuthConfig(registry)
+    if err != nil {
+        return domain.AuthConfig{}, nil // Graceful fallback
+    }
+
+    return convertAuthConfig(authConfig), nil
+}
+
+// GetEncodedAuth returns base64-encoded auth for a registry.
+func (p *DockerConfigAuthProvider) GetEncodedAuth(registry string) (string, error) {
+    auth, err := p.GetAuthConfig(registry)
+    if err != nil {
+        return "", err
+    }
+
+    // Empty auth is valid (public registry)
+    if auth.Username == "" && auth.Password == "" && auth.IdentityToken == "" {
+        return "", nil
+    }
+
+    return EncodeAuthConfig(auth)
+}
+
+func (p *DockerConfigAuthProvider) loadConfig() (*configfile.ConfigFile, error) {
+    if p.configDir != "" {
+        return config.Load(p.configDir)
+    }
+    return config.Load(config.Dir())
+}
+
+func normalizeRegistry(registry string) string {
+    // Docker Hub special cases
+    if registry == "" || registry == "docker.io" || registry == "index.docker.io" {
+        return "https://index.docker.io/v1/"
+    }
+    return registry
+}
+
+func convertAuthConfig(src types.AuthConfig) domain.AuthConfig {
+    return domain.AuthConfig{
+        Username:      src.Username,
+        Password:      src.Password,
+        Auth:          src.Auth,
+        Email:         src.Email,
+        ServerAddress: src.ServerAddress,
+        IdentityToken: src.IdentityToken,
+        RegistryToken: src.RegistryToken,
+    }
+}
+```
+
+### Step 2.2: Add Helper to Extract Registry from Image
+
+**File:** `core/adapters/docker/auth.go` (append)
+
+```go
+// ExtractRegistry extracts the registry hostname from an image reference.
+func ExtractRegistry(image string) string {
+    ref := domain.ParseRepositoryTag(image)
+    repo := ref.Repository
+
+    // Check for registry prefix (contains . or :)
+    if idx := strings.Index(repo, "/"); idx > 0 {
+        prefix := repo[:idx]
+        if strings.Contains(prefix, ".") || strings.Contains(prefix, ":") {
+            return prefix
+        }
+    }
+
+    // Default to Docker Hub
+    return "docker.io"
+}
+```
+
+## Phase 3: Integrate into SDKDockerProvider
+
+### Step 3.1: Update SDKDockerProviderConfig
+
+**File:** `core/docker_sdk_provider.go`
+
+```go
+// SDKDockerProviderConfig configures the SDK provider.
+type SDKDockerProviderConfig struct {
+    Host            string
+    Logger          Logger
+    MetricsRecorder MetricsRecorder
+    AuthProvider    ports.AuthProvider // NEW: Optional auth provider
+}
+```
+
+### Step 3.2: Store AuthProvider in Provider
+
+```go
+type SDKDockerProvider struct {
+    client          ports.DockerClient
+    logger          Logger
+    metricsRecorder MetricsRecorder
+    authProvider    ports.AuthProvider // NEW
+}
+```
+
+### Step 3.3: Update NewSDKDockerProvider
+
+```go
+func NewSDKDockerProvider(cfg *SDKDockerProviderConfig) (*SDKDockerProvider, error) {
+    // ... existing code ...
+
+    var authProvider ports.AuthProvider
+    if cfg != nil {
+        logger = cfg.Logger
+        metricsRecorder = cfg.MetricsRecorder
+        authProvider = cfg.AuthProvider // NEW
+    }
+
+    return &SDKDockerProvider{
+        client:          client,
+        logger:          logger,
+        metricsRecorder: metricsRecorder,
+        authProvider:    authProvider, // NEW
+    }, nil
+}
+```
+
+### Step 3.4: Update PullImage to Use Auth
+
+```go
+func (p *SDKDockerProvider) PullImage(ctx context.Context, image string) error {
+    p.recordOperation("pull_image")
+
+    ref := domain.ParseRepositoryTag(image)
+    opts := domain.PullOptions{
+        Repository: ref.Repository,
+        Tag:        ref.Tag,
+    }
+
+    // NEW: Get registry auth if provider configured
+    if p.authProvider != nil {
+        registry := dockeradapter.ExtractRegistry(image)
+        if auth, err := p.authProvider.GetEncodedAuth(registry); err == nil && auth != "" {
+            opts.RegistryAuth = auth
+            p.logDebug("Using registry auth for %s", registry)
+        }
+    }
+
+    if err := p.client.Images().PullAndWait(ctx, opts); err != nil {
+        p.recordError("pull_image")
+        return WrapImageError("pull", image, err)
+    }
+
+    p.logNotice("Pulled image %s", image)
+    return nil
+}
+```
+
+## Phase 4: Wire Up in CLI
+
+### Step 4.1: Create AuthProvider in Daemon
+
+**File:** `cli/daemon.go`
+
+In `buildProvider()` or equivalent initialization:
+
+```go
+import dockeradapter "github.com/netresearch/ofelia/core/adapters/docker"
+
+func (c *DaemonCommand) createDockerProvider() (*core.SDKDockerProvider, error) {
+    authProvider := dockeradapter.NewDockerConfigAuthProvider()
+
+    return core.NewSDKDockerProvider(&core.SDKDockerProviderConfig{
+        Logger:       c.Logger,
+        AuthProvider: authProvider,
+    })
+}
+```
+
+## Phase 5: Testing
+
+### Step 5.1: Unit Tests for AuthProvider
+
+**File:** `core/adapters/docker/auth_test.go`
+
+```go
+func TestDockerConfigAuthProvider_GetAuthConfig(t *testing.T) {
+    // Test with mock config directory
+}
+
+func TestDockerConfigAuthProvider_GetEncodedAuth(t *testing.T) {
+    // Test encoding
+}
+
+func TestExtractRegistry(t *testing.T) {
+    tests := []struct {
+        image    string
+        expected string
+    }{
+        {"alpine", "docker.io"},
+        {"nginx:latest", "docker.io"},
+        {"gcr.io/project/image:tag", "gcr.io"},
+        {"localhost:5000/myimage", "localhost:5000"},
+        {"registry.example.com/org/image", "registry.example.com"},
+        {"192.168.1.1:5000/image", "192.168.1.1:5000"},
+    }
+    // ...
+}
+
+func TestDockerConfigAuthProvider_GracefulFallback(t *testing.T) {
+    // Test missing config, invalid credentials
+}
+```
+
+### Step 5.2: Integration Tests
+
+**File:** `core/adapters/docker/auth_integration_test.go`
+
+```go
+//go:build integration
+
+func TestDockerConfigAuthProvider_RealConfig(t *testing.T) {
+    // Only runs when real Docker config exists
+}
+```
+
+## File Summary
+
+| File | Action | Description |
+|------|--------|-------------|
+| `go.mod` | Modify | Add docker/cli dependency |
+| `core/adapters/docker/auth.go` | Create | AuthProvider implementation |
+| `core/adapters/docker/auth_test.go` | Create | Unit tests |
+| `core/adapters/docker/auth_integration_test.go` | Create | Integration tests |
+| `core/docker_sdk_provider.go` | Modify | Add AuthProvider support |
+| `cli/daemon.go` | Modify | Wire up AuthProvider |
+
+## Validation Checklist
+
+- [ ] `go mod tidy` succeeds
+- [ ] All existing tests pass
+- [ ] New unit tests pass
+- [ ] Linter passes
+- [ ] Integration tests pass (if Docker available)
+- [ ] Manual test with private registry (optional)
+
+## Rollback Plan
+
+If issues arise:
+1. Set `AuthProvider: nil` in daemon.go to disable feature
+2. Feature is opt-in via the provider interface, no breaking changes
+
+## Timeline Estimate
+
+| Phase | Effort |
+|-------|--------|
+| Phase 1: Dependency | 15 min |
+| Phase 2: AuthProvider | 2-3 hours |
+| Phase 3: Integration | 1-2 hours |
+| Phase 4: CLI Wiring | 30 min |
+| Phase 5: Testing | 2-3 hours |
+| **Total** | **6-9 hours** |

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2
 	github.com/containerd/errdefs v1.0.0
 	github.com/creasty/defaults v1.8.0
+	github.com/distribution/reference v0.6.0
+	github.com/docker/cli v29.1.2+incompatible
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-connections v0.6.0
 	github.com/emersion/go-smtp v0.24.0
@@ -32,7 +34,7 @@ require (
 	github.com/chzyer/readline v1.5.1 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
-	github.com/distribution/reference v0.6.0 // indirect
+	github.com/docker/docker-credential-helpers v0.9.4 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,12 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/docker/cli v29.1.2+incompatible h1:s4QI7drXpIo78OM+CwuthPsO5kCf8cpNsck5PsLVTH8=
+github.com/docker/cli v29.1.2+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/docker v28.5.2+incompatible h1:DBX0Y0zAjZbSrm1uzOkdr1onVghKaftjlSWt4AFexzM=
 github.com/docker/docker v28.5.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker-credential-helpers v0.9.4 h1:76ItO69/AP/V4yT9V4uuuItG0B1N8hvt0T0c0NN/DzI=
+github.com/docker/docker-credential-helpers v0.9.4/go.mod h1:v1S+hepowrQXITkEfw6o4+BMbGot02wiKpzWhGUZK6c=
 github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
 github.com/docker/go-connections v0.6.0/go.mod h1:AahvXYshr6JgfUJGdDCs2b5EZG/vmaMAntpSFH5BFKE=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=


### PR DESCRIPTION
## Summary
- Implement Docker registry authentication using `~/.docker/config.json` credentials
- Add `ConfigAuthProvider` that reads credentials fresh on each call (supports credential rotation)
- Support credential helpers (docker-credential-*) for AWS ECR, GCR, and other cloud registries
- Document decision and implementation plan in ADR-001

## Implementation Details
- New `core/adapters/docker/auth.go` with `ConfigAuthProvider` implementing `ports.AuthProvider`
- Uses canonical `github.com/docker/cli/cli/config` library for config parsing
- Uses `github.com/distribution/reference` for image reference parsing  
- Integrated into `SDKDockerProvider.PullImage()` for authenticated image pulls
- Graceful fallback with logging when credentials are missing or invalid

## Registries Supported
- Docker Hub (docker.io, index.docker.io)
- Google Container Registry (gcr.io)
- AWS ECR (*.dkr.ecr.*.amazonaws.com)
- GitHub Container Registry (ghcr.io)
- Quay.io
- Custom private registries

## Test plan
- [x] Unit tests for `ExtractRegistry()` - 15+ test cases
- [x] Unit tests for `normalizeRegistry()`  
- [x] Unit tests for `ConfigAuthProvider` with mock config
- [x] Tests for graceful fallback on missing config
- [x] Tests for logging behavior
- [x] All existing tests pass
- [x] Linter passes
- [x] Pre-commit hooks pass (gosec security scan)

Closes #370