### PR TITLE
fix(ci): correct mutation score regex to match gremlins output

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -62,8 +62,8 @@ jobs:
         run: |
           echo "Running full mutation testing..."
           gremlins unleash --config=.gremlins.yaml 2>&1 | tee mutation-output.txt
-          # Extract mutation score
-          SCORE=$(grep -oP 'Mutation Score: \K[\d.]+' mutation-output.txt || echo "0")
+          # Extract mutation score (gremlins outputs "Test efficacy: X.XX%")
+          SCORE=$(grep -oP 'Test efficacy: \K[\d.]+' mutation-output.txt || echo "0")
           echo "MUTATION_SCORE=${SCORE}" >> "$GITHUB_ENV"
           {
             echo "## Mutation Testing Results"
@@ -97,8 +97,8 @@ jobs:
           fi
           echo "Testing mutations in changed files..."
           gremlins unleash --config=.gremlins.yaml --diff "$BASE_REF" 2>&1 | tee mutation-output.txt
-          # Extract mutation score
-          SCORE=$(grep -oP 'Mutation Score: \K[\d.]+' mutation-output.txt || echo "0")
+          # Extract mutation score (gremlins outputs "Test efficacy: X.XX%")
+          SCORE=$(grep -oP 'Test efficacy: \K[\d.]+' mutation-output.txt || echo "0")
           echo "MUTATION_SCORE=${SCORE}" >> "$GITHUB_ENV"
           {
             echo "## Mutation Testing Results (Diff Mode)"


### PR DESCRIPTION
## Summary

Fix the mutation testing workflow to correctly parse the score from gremlins output.

**Problem:** The workflow was looking for `Mutation Score: X.XX%` but gremlins outputs `Test efficacy: X.XX%`. This caused all PRs to show 0% mutation score even when the actual efficacy was 94.12%.

**Solution:** Updated the regex pattern in both full and diff-only mutation testing paths.

## Changes

- Fix regex pattern from `'Mutation Score: \K[\d.]+'` to `'Test efficacy: \K[\d.]+'`
- Added clarifying comment explaining gremlins output format

## Evidence

From PR #388 mutation test logs:
```
Killed: 16, Lived: 1, Not covered: 4
Timed out: 0, Not viable: 0, Skipped: 1413
Test efficacy: 94.12%
Mutator coverage: 80.95%
```

But PR comment showed: `Mutation Score: 0% (threshold: 60%)`

## Test Plan

- [ ] Create PR and observe mutation testing workflow
- [ ] Verify PR comment shows correct score (should be > 0% for code with tests)