### PR TITLE
fix(ci): make package description update non-critical

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -426,23 +426,38 @@ jobs:
           cosign sign --yes ${{ env.REGISTRY }}/${{ github.repository_owner }}/ofelia:edge@${{ steps.push.outputs.digest }}
 
       - name: Update package description
+        # This step is non-critical - package description is cosmetic
+        # The API may return 404 if the package doesn't exist yet or permissions are insufficient
+        continue-on-error: true
         env:
           OWNER: ${{ github.repository_owner }}
         run: |
-          set -euo pipefail
           # Try organization endpoint first, fall back to user endpoint if it fails
-          if ! curl -sSf -X PATCH \
+          # Using -s (silent) without -f (fail) to handle 404 gracefully
+          ORG_RESULT=$(curl -sS -w "%{http_code}" -o /dev/null -X PATCH \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/orgs/${OWNER}/packages/container/ofelia" \
-            -d '{"description":"A docker job scheduler (based on mcuadros/ofelia)"}'; then
-            curl -sSf -X PATCH \
+            -d '{"description":"A docker job scheduler (based on mcuadros/ofelia)"}')
+
+          if [ "$ORG_RESULT" = "200" ]; then
+            echo "Package description updated via organization endpoint"
+          else
+            echo "Organization endpoint returned $ORG_RESULT, trying user endpoint..."
+            USER_RESULT=$(curl -sS -w "%{http_code}" -o /dev/null -X PATCH \
               -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               -H "Accept: application/vnd.github+json" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "https://api.github.com/users/${OWNER}/packages/container/ofelia" \
-              -d '{"description":"A docker job scheduler (based on mcuadros/ofelia)"}'
+              -d '{"description":"A docker job scheduler (based on mcuadros/ofelia)"}')
+
+            if [ "$USER_RESULT" = "200" ]; then
+              echo "Package description updated via user endpoint"
+            else
+              echo "Warning: Could not update package description (org: $ORG_RESULT, user: $USER_RESULT)"
+              echo "This is non-critical - package metadata may require manual update or a PAT with packages:write scope"
+            fi
           fi
 
   hadolint:


### PR DESCRIPTION
## Summary

Fix the failing "Build and push container image" CI job caused by the "Update package description" step returning 404 errors.

## Problem

The step was failing because:
1. `GITHUB_TOKEN` lacks `packages:write` scope for the GitHub Packages API endpoint
2. The `curl -sSf` flag causes immediate failure on non-200 HTTP responses
3. Both organization and user API endpoints return 404

## Solution

- Add `continue-on-error: true` since package description is cosmetic metadata
- Improve error handling to capture and display HTTP status codes
- Provide helpful diagnostic message about PAT requirements when both endpoints fail
- Remove `set -euo pipefail` since we're handling errors gracefully

## Evidence

From failed run https://github.com/netresearch/ofelia/actions/runs/20091203405/job/57638902206:
```
curl: (22) The requested URL returned error: 404
curl: (22) The requested URL returned error: 404
##[error]Process completed with exit code 22.
```

## Test Plan

- [ ] Verify CI passes with this change
- [ ] Check that image push still succeeds even if description update fails