### PR TITLE
feat: add skipped trigger and custom email subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ See [Architecture overview](docs/architecture.md) for details about the schedule
 - `smtp-tls-skip-verify` - when `true` ignores certificate signed by unknown authority error.
 - `email-to` - mail address of the receiver of the mail.
 - `email-from` - mail address of the sender of the mail.
+- `email-subject` - custom subject template for emails. Uses Go template syntax with access to `.Job` and `.Execution`. Example: `[ALERT] Job {{.Job.GetName}} {{status .Execution}}`. If not set, uses default format.
 - `mail-only-on-error` - only send a mail if the execution was not successful.
 
 - `save-folder` - directory in which the reports shall be written. The folder is created automatically if it doesn't exist using an equivalent of `mkdir -p`.

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -71,7 +71,7 @@ Ofelia includes presets for popular notification services:
 | `secret` | string | Service-specific secret/token |
 | `link` | string | Optional URL to include in notification (e.g., link to logs) |
 | `link-text` | string | Display text for link (default: "View Details") |
-| `trigger` | string | When to send: `always`, `error`, `success` (default: `always`) |
+| `trigger` | string | When to send: `always`, `error`, `success`, `skipped` (default: `error`) |
 | `timeout` | duration | HTTP request timeout (default: `30s`) |
 | `retry-count` | int | Number of retries on failure (default: `3`) |
 | `retry-delay` | duration | Delay between retries (default: `5s`) |

--- a/middlewares/webhook_config.go
+++ b/middlewares/webhook_config.go
@@ -13,6 +13,7 @@ const (
 	TriggerAlways  TriggerType = "always"  // Send on every execution
 	TriggerError   TriggerType = "error"   // Send only on errors
 	TriggerSuccess TriggerType = "success" // Send only on success
+	TriggerSkipped TriggerType = "skipped" // Send only on skipped executions
 )
 
 // WebhookConfig holds configuration for a single webhook endpoint
@@ -151,10 +152,10 @@ func (c *WebhookConfig) Validate() error {
 
 	// Validate trigger type
 	switch c.Trigger {
-	case TriggerAlways, TriggerError, TriggerSuccess, "":
+	case TriggerAlways, TriggerError, TriggerSuccess, TriggerSkipped, "":
 		// Valid or empty (will use default)
 	default:
-		return fmt.Errorf("webhook %q: invalid trigger %q (must be always, error, or success)", c.Name, c.Trigger)
+		return fmt.Errorf("webhook %q: invalid trigger %q (must be always, error, success, or skipped)", c.Name, c.Trigger)
 	}
 
 	if c.Timeout < 0 {
@@ -197,6 +198,8 @@ func (c *WebhookConfig) ShouldNotify(failed, skipped bool) bool {
 		return failed
 	case TriggerSuccess:
 		return !failed && !skipped
+	case TriggerSkipped:
+		return skipped
 	case TriggerAlways:
 		return true
 	default:

--- a/middlewares/webhook_config_test.go
+++ b/middlewares/webhook_config_test.go
@@ -35,6 +35,7 @@ func (s *SuiteWebhookConfig) TestTriggerType_Constants(c *C) {
 	c.Assert(TriggerAlways, Equals, TriggerType("always"))
 	c.Assert(TriggerSuccess, Equals, TriggerType("success"))
 	c.Assert(TriggerError, Equals, TriggerType("error"))
+	c.Assert(TriggerSkipped, Equals, TriggerType("skipped"))
 }
 
 func (s *SuiteWebhookConfig) TestParseWebhookNames_Empty(c *C) {
@@ -123,6 +124,14 @@ func (s *SuiteWebhookConfig) TestWebhookConfig_ShouldNotify_Always(c *C) {
 	c.Assert(config.ShouldNotify(true, false), Equals, true)  // Failed
 	c.Assert(config.ShouldNotify(false, false), Equals, true) // Success
 	c.Assert(config.ShouldNotify(false, true), Equals, true)  // Skipped
+}
+
+func (s *SuiteWebhookConfig) TestWebhookConfig_ShouldNotify_Skipped(c *C) {
+	config := &WebhookConfig{Trigger: TriggerSkipped}
+
+	c.Assert(config.ShouldNotify(true, false), Equals, false)  // Failed
+	c.Assert(config.ShouldNotify(false, false), Equals, false) // Success
+	c.Assert(config.ShouldNotify(false, true), Equals, true)   // Skipped
 }
 
 func (s *SuiteWebhookConfig) TestWebhookConfig_ApplyDefaults(c *C) {


### PR DESCRIPTION
## Summary
- Add `trigger = skipped` option to webhook notifications (#341)
- Add `email-subject` config option to mail middleware (#329)

## Changes

### Webhook: Skipped Trigger (#341)
Allows monitoring jobs that are skipped due to overlap prevention or other conditions.

```ini
[webhook "overlap-alerts"]
preset = slack
trigger = skipped
```

Available triggers: `error` (default), `success`, `skipped`, `always`

### Mail: Custom Subject (#329)
Supports Go template syntax with access to `.Job` and `.Execution`.

```ini
[global]
email-subject = [ALERT] Job {{.Job.GetName}} - {{status .Execution}}
```

If not set, uses default format: `[Execution {status}] Job {name} finished in {duration}`

## Test plan
- [x] Added tests for `TriggerSkipped` constant and `ShouldNotify` logic
- [x] Added tests for custom and default email subject templates
- [x] All existing tests pass

Closes #329, #341