### PR TITLE
fix(ci): update codeql-action to recognized commit hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,7 +340,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@66b39da20ccc656acc90dd27ea30f5d458ec33ce # v3.28.19
+        uses: github/codeql-action/init@45c373516f557556c15d420e3f5e0aa3d64366bc # v3.31.9
         with:
           languages: go
 
@@ -348,10 +348,10 @@ jobs:
         run: go mod download
 
       - name: Build
-        uses: github/codeql-action/autobuild@66b39da20ccc656acc90dd27ea30f5d458ec33ce # v3.28.19
+        uses: github/codeql-action/autobuild@45c373516f557556c15d420e3f5e0aa3d64366bc # v3.31.9
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@66b39da20ccc656acc90dd27ea30f5d458ec33ce # v3.28.19
+        uses: github/codeql-action/analyze@45c373516f557556c15d420e3f5e0aa3d64366bc # v3.31.9
 
   gosec:
     name: gosec
@@ -560,7 +560,7 @@ jobs:
           severity: CRITICAL,HIGH
           exit-code: 1
       - name: Upload Trivy SARIF
-        uses: github/codeql-action/upload-sarif@66b39da20ccc656acc90dd27ea30f5d458ec33ce # v3.28.19
+        uses: github/codeql-action/upload-sarif@45c373516f557556c15d420e3f5e0aa3d64366bc # v3.31.9
         if: always()  # Upload even if vulnerabilities found (exit-code: 1)
         with:
           sarif_file: trivy-results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -38,6 +38,6 @@ jobs:
           publish_results: true
 
       - name: Upload Scorecard results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@c37a8b7cd97e31de3fcbd9d84c401870edeb8d34 # v3
+        uses: github/codeql-action/upload-sarif@45c373516f557556c15d420e3f5e0aa3d64366bc # v3.31.9
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Fixed OpenSSF Scorecard workflow failure due to unverified codeql-action commit
- Updated codeql-action to latest v3.31.9 with verified commit hash
- Updated all codeql-action references in ci.yml for consistency

## Changes
- `scorecard.yml`: Updated upload-sarif to v3.31.9 with specific version tag
- `ci.yml`: Updated init, autobuild, analyze, upload-sarif to v3.31.9

## Test plan
- [x] Verified v3.31.9 is latest stable v3 release
- [ ] CI checks pass on PR
- [ ] Scorecard workflow runs successfully after merge