### PR TITLE
fix(ci): add private-repository: false to SLSA workflow

### DIFF
--- a/.github/workflows/release-slsa.yml
+++ b/.github/workflows/release-slsa.yml
@@ -82,6 +82,7 @@ jobs:
       evaluated-envs: "VERSION:${{ github.ref_name }}, COMMIT:${{ github.sha }}"
       upload-assets: true
       draft-release: false
+      private-repository: false
 
   # Generate SBOMs for all binaries
   sbom:


### PR DESCRIPTION
## Summary

Fixes the SLSA Level 3 release workflow failure where the builder incorrectly detects netresearch/ofelia as a private repository.

**Error:** `Repository is private. The workflow has halted in order to keep the repository name from being exposed in the public transparency log.`

**Root cause:** The SLSA builder's private repository detection fails for this public repo, blocking builds from logging to the public transparency log.

**Fix:** Explicitly set `private-repository: false` in the workflow configuration.

## Test Plan

- [x] Verify repo is public: `gh repo view --json isPrivate` returns `false`
- [ ] After merge, re-run the release workflow for v0.17.0