### PR TITLE
fix(ci): use tag reference for SLSA builder

### DIFF
--- a/.github/workflows/release-slsa.yml
+++ b/.github/workflows/release-slsa.yml
@@ -75,7 +75,7 @@ jobs:
       id-token: write
       contents: write
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@5a775b367a56d5bd118a224a811bba288150a563 # v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.0.0
     with:
       go-version-file: go.mod
       config-file: .slsa-goreleaser/${{ matrix.target }}.yml


### PR DESCRIPTION
## Summary

Fixes the SLSA Level 3 release workflow failure where the builder rejects SHA references.

**Error:** `Invalid ref: 5a775b367a56d5bd118a224a811bba288150a563. Expected ref of the form refs/tags/vX.Y.Z`

**Root cause:** The SLSA builder requires being invoked via a version tag reference (e.g., `@v2.0.0`) rather than a SHA hash. SHA pinning causes validation failures.

**Fix:** Use `@v2.0.0` tag reference instead of SHA.

**Note:** Also fixes incorrect version comment (was labeled v2.1.0 when using v2.0.0 SHA).

## Test Plan

- [ ] After merge, re-run the release workflow for v0.17.0