### PR TITLE
fix: strip leading slash from Docker container names

### DIFF
--- a/core/adapters/docker/convert.go
+++ b/core/adapters/docker/convert.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"strings"
 	"time"
 
 	cerrdefs "github.com/containerd/errdefs"
@@ -123,7 +124,9 @@ func convertFromContainerJSON(c *containertypes.InspectResponse) *domain.Contain
 func convertFromAPIContainer(c *containertypes.Summary) domain.Container {
 	var name string
 	if len(c.Names) > 0 {
-		name = c.Names[0]
+		// Docker API returns container names with leading slash (e.g., "/my-container").
+		// Strip it to prevent malformed URLs in the web UI (issue #422).
+		name = strings.TrimPrefix(c.Names[0], "/")
 	}
 
 	return domain.Container{

--- a/core/adapters/docker/convert_test.go
+++ b/core/adapters/docker/convert_test.go
@@ -527,8 +527,10 @@ func TestConvertFromAPIContainer(t *testing.T) {
 				if result.ID != "abc123" {
 					t.Errorf("ID = %q, want %q", result.ID, "abc123")
 				}
-				if result.Name != "/my-container" {
-					t.Errorf("Name = %q, want %q", result.Name, "/my-container")
+				// Regression test for issue #422: Docker API returns names with leading slash
+				// but Ofelia should strip it to prevent malformed API URLs like /api/jobs//container.job/history
+				if result.Name != "my-container" {
+					t.Errorf("Name = %q, want %q (leading slash should be stripped)", result.Name, "my-container")
 				}
 				if result.Image != "nginx:latest" {
 					t.Errorf("Image = %q, want %q", result.Image, "nginx:latest")
@@ -558,6 +560,10 @@ func TestConvertFromAPIContainer(t *testing.T) {
 				if result.State.Running {
 					t.Error("State.Running = true, want false")
 				}
+				// Leading slash should be stripped (issue #422)
+				if result.Name != "stopped" {
+					t.Errorf("Name = %q, want %q (leading slash stripped)", result.Name, "stopped")
+				}
 			},
 		},
 		{
@@ -585,8 +591,9 @@ func TestConvertFromAPIContainer(t *testing.T) {
 				State:   "running",
 			},
 			check: func(t *testing.T, result domain.Container) {
-				if result.Name != "/primary" {
-					t.Errorf("Name = %q, want %q (first name)", result.Name, "/primary")
+				// First name should be used with leading slash stripped (issue #422)
+				if result.Name != "primary" {
+					t.Errorf("Name = %q, want %q (first name, leading slash stripped)", result.Name, "primary")
 				}
 			},
 		},


### PR DESCRIPTION
## Summary

- Strip leading `/` from container names returned by Docker API
- Fixes web UI job history returning 404 due to malformed URLs

## Root Cause

Docker API returns container names with a leading slash (e.g., `/my-container`). When used in job names, this caused web UI history requests to fail:

```
Container name from API: /my-container
Job name: /my-container.job-name
History URL: /api/jobs//my-container.job-name/history  ← Double slash causes 404
```

## Fix

In `core/adapters/docker/convert.go`, strip the leading slash when converting from Docker API container summary.

## Test plan

- [x] Added regression tests that fail without the fix
- [x] Tests pass with fix applied
- [x] Full test suite passes
- [x] Linting passes

Fixes #422