### PR TITLE
fix(ci): correct SLSA builder SHA

### DIFF
--- a/.github/workflows/release-slsa.yml
+++ b/.github/workflows/release-slsa.yml
@@ -42,7 +42,7 @@ jobs:
       id-token: write
       contents: write
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204c # v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
     with:
       go-version-file: go.mod
       config-file: .slsa-goreleaser/${{ matrix.target }}.yml


### PR DESCRIPTION
## Summary
- The SHA `f7dd8c54c2067bafc12ca7a55595d5ee9b75204c` does not exist in slsa-framework/slsa-github-generator
- Changed to the correct SHA `f7dd8c54c2067bafc12ca7a55595d5ee9b75204a` for v2.1.0

This was causing release workflows to fail immediately with 0 jobs created.

## Test plan
- Verify the release workflow triggers and runs successfully after this fix