### PR TITLE
fix(ci): revert SLSA builder to v2.0.0

### DIFF
--- a/.github/workflows/release-slsa.yml
+++ b/.github/workflows/release-slsa.yml
@@ -42,7 +42,7 @@ jobs:
       id-token: write
       contents: write
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@5a775b367a56d5bd118a224a811bba288150a563 # v2.0.0
     with:
       go-version-file: go.mod
       config-file: .slsa-goreleaser/${{ matrix.target }}.yml


### PR DESCRIPTION
## Summary
- The v2.1.0 SLSA builder incorrectly detects the repository as private
- This causes all builds to fail with: "Repository is private. The workflow has halted..."
- The repository is public and `private-repository: false` is set
- Reverting to v2.0.0 which worked correctly for v0.17.0 release

## Test plan
- Verify the release workflow completes successfully after this fix