### PR TITLE
fix(ci): work around SLSA builder private repo detection bug

### DIFF
--- a/.github/workflows/release-slsa.yml
+++ b/.github/workflows/release-slsa.yml
@@ -49,7 +49,8 @@ jobs:
       evaluated-envs: "VERSION:${{ github.ref_name }}, COMMIT:${{ github.sha }}"
       upload-assets: true
       draft-release: false
-      private-repository: false
+      # Workaround for SLSA builder bug detecting public repos as private (see slsa-framework/slsa-github-generator#942)
+      private-repository: true
 
   # Generate SBOMs for all binaries
   sbom:


### PR DESCRIPTION
## Summary
- The SLSA builder incorrectly detects public repositories as private
- This causes builds to fail with: "Repository is private. The workflow has halted..."
- Setting `private-repository: true` allows the build to proceed
- The repo is public anyway, so uploading to public transparency log is fine

## Related Issues
- https://github.com/slsa-framework/slsa-github-generator/issues/942

## Test plan
- Verify the release workflow completes successfully after this fix

Sources:
- [slsa-github-generator issue #942](https://github.com/slsa-framework/slsa-github-generator/issues/942)