### PR TITLE
fix(ci): use SLSA builder tag reference

### DIFF
--- a/.github/workflows/release-slsa.yml
+++ b/.github/workflows/release-slsa.yml
@@ -42,7 +42,7 @@ jobs:
       id-token: write
       contents: write
       actions: read
-    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@5a775b367a56d5bd118a224a811bba288150a563 # v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v2.0.0
     with:
       go-version-file: go.mod
       config-file: .slsa-goreleaser/${{ matrix.target }}.yml


### PR DESCRIPTION
## Summary
- Using the mutable @v2.0.0 tag instead of the pinned SHA
- This was working for v0.17.0 release
- The pinned SHA might not be resolving correctly

## Test plan
- Verify the release workflow completes successfully