### PR TITLE
fix(ci): add checkout step to release-notes job

### DIFF
--- a/.github/workflows/release-slsa.yml
+++ b/.github/workflows/release-slsa.yml
@@ -177,6 +177,9 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Append verification instructions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- The release-notes job was missing the checkout step
- This caused 'gh release' commands to fail with 'fatal: not a git repository' error

## Test plan
- Verify the release-notes job completes successfully in future releases