### PR TITLE
fix(test): fix race condition and flaky test

### DIFF
--- a/cli/config_extra_test.go
+++ b/cli/config_extra_test.go
@@ -55,7 +55,7 @@ func TestBuildFromFileError(t *testing.T) {
 
 // Test InitializeApp returns error when Docker handler factory fails
 func TestInitializeAppErrorDockerHandler(t *testing.T) {
-	t.Parallel()
+	// Cannot use t.Parallel() - modifies global newDockerHandler
 	// Override newDockerHandler to simulate factory error
 	orig := newDockerHandler
 	defer func() { newDockerHandler = orig }()

--- a/core/scheduler_edge_cases_test.go
+++ b/core/scheduler_edge_cases_test.go
@@ -268,9 +268,9 @@ func TestSchedulerStopDuringJobExecution(t *testing.T) {
 	go scheduler.RunJob("long-job-3")
 
 	testutil.Eventually(t, func() bool {
-		return longJob1.GetRunCount() > 0 || longJob2.GetRunCount() > 0 || longJob3.GetRunCount() > 0
-	}, testutil.WithTimeout(100*time.Millisecond), testutil.WithInterval(5*time.Millisecond),
-		testutil.WithMessage("at least one job should start"))
+		return longJob1.GetRunCount() > 0 && longJob2.GetRunCount() > 0 && longJob3.GetRunCount() > 0
+	}, testutil.WithTimeout(200*time.Millisecond), testutil.WithInterval(5*time.Millisecond),
+		testutil.WithMessage("all jobs should start"))
 
 	stopStart := time.Now()
 	stopErr := scheduler.Stop()


### PR DESCRIPTION
## Summary

Fixes race conditions detected in CI unit tests:

1. **Race condition fix**: Removed `t.Parallel()` from `TestInitializeAppErrorDockerHandler` which was modifying the global `newDockerHandler` variable while running in parallel with other tests that read the same variable.

2. **Flaky test fix**: Fixed `TestSchedulerStopDuringJobExecution` which was only waiting for ANY job to start (`||`) before stopping, but then asserting ALL jobs ran. Changed to wait for ALL jobs to start (`&&`) with increased timeout.

## Test Results

All tests pass locally including with `-race` flag:
```
ok  github.com/netresearch/ofelia/cli    2.581s
ok  github.com/netresearch/ofelia/core   2.242s
```