### PR TITLE
docs(adr): rewrite ADR-003 to proper decision format

### DIFF
--- a/docs/adr/ADR-003-config-validation-improvements.md
+++ b/docs/adr/ADR-003-config-validation-improvements.md
@@ -1,6 +1,6 @@
 # ADR-003: Configuration Validation Improvements
 
-**Status**: Proposed
+**Status**: Accepted
 **Date**: 2025-12-24
 **Authors**: SME
 
@@ -8,27 +8,14 @@
 
 Ofelia's configuration parsing has several gaps that affect user experience and maintainability:
 
-### Current State
+### Problems Identified
 
-1. **INI/Label Parsing Flow**:
-   ```
-   INI File → go-ini/ini → sectionToMap() → mapstructure.WeakDecode() → Config struct
-   Labels   → Docker API → parseJobLabels() → mapstructure.WeakDecode() → Config struct
-   ```
-
-2. **Problems Identified**:
-
-   | Problem | Impact | Example |
-   |---------|--------|---------|
-   | Unknown keys silently ignored | Typos go unnoticed | `scheduel = @hourly` works (no error) |
-   | No value range validation | Invalid values accepted | `smtp-port = 99999` passes |
-   | Deprecated detection by VALUE | Zero-value deprecations missed | `poll-interval = 0` not flagged |
-   | Mixed validation systems | Maintenance burden | Custom `config/validator.go` + struct tags |
-
-3. **Current Validation**:
-   - `mapstructure.WeakDecode()` - permissive type coercion, silently ignores unknown keys
-   - `config/validator.go` - custom reflection-based validation, runs after decode
-   - No integration between unknown key detection and validation
+| Problem | Impact | Example |
+|---------|--------|---------|
+| Unknown keys silently ignored | Typos go unnoticed | `scheduel = @hourly` works (no error) |
+| No value range validation | Invalid values accepted | `smtp-port = 99999` passes |
+| Deprecated detection by VALUE | Zero-value deprecations missed | `poll-interval = 0` not flagged |
+| Mixed validation systems | Maintenance burden | Custom `config/validator.go` + struct tags |
 
 ### Why Current Approach is Insufficient
 
@@ -78,193 +65,28 @@ Implement a two-layer validation approach using:
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-### Implementation Details
+### Key Design Decisions
 
-#### 1. New Decoder Function
+1. **DecodeResult struct** tracks used and unused keys:
+   ```go
+   type DecodeResult struct {
+       UsedKeys   map[string]bool // Keys present in input
+       UnusedKeys []string        // Keys not matching any struct field
+   }
+   ```
 
-```go
-// cli/config_decode.go
+2. **Deprecation detection by key presence**, not just value - enables detecting `poll-interval = 0`
 
-type DecodeResult struct {
-    UsedKeys     map[string]bool   // Keys that were present in input
-    UnusedKeys   []string          // Keys not matching any struct field
-    Warnings     []string          // Non-fatal issues
-    Errors       []error           // Fatal validation errors
-}
+3. **Levenshtein distance** for "did you mean?" suggestions on unknown keys
 
-func decodeWithMetadata(input map[string]interface{}, output interface{}) (*DecodeResult, error) {
-    var metadata mapstructure.Metadata
-
-    config := &mapstructure.DecoderConfig{
-        Result:           output,
-        Metadata:         &metadata,
-        WeaklyTypedInput: true,
-        TagName:          "mapstructure",
-        // ErrorUnused: true would fail; we want to collect them instead
-    }
-
-    decoder, err := mapstructure.NewDecoder(config)
-    if err != nil {
-        return nil, err
-    }
-
-    if err := decoder.Decode(input); err != nil {
-        return nil, err
-    }
-
-    result := &DecodeResult{
-        UsedKeys:   make(map[string]bool),
-        UnusedKeys: metadata.Unused,
-    }
-
-    // Track which keys were present
-    for _, key := range metadata.Keys {
-        result.UsedKeys[key] = true
-    }
-
-    return result, nil
-}
-```
-
-#### 2. Validator Integration
-
-```go
-// cli/config_validate.go
-
-import "github.com/go-playground/validator/v10"
-
-var validate = validator.New()
-
-func init() {
-    // Register custom validators
-    validate.RegisterValidation("cron", validateCron)
-    validate.RegisterValidation("dockerimage", validateDockerImage)
-}
-
-func validateConfig(cfg *Config) error {
-    return validate.Struct(cfg)
-}
-```
-
-#### 3. Struct Tag Updates
-
-```go
-// cli/config.go - DockerConfig example
-
-type DockerConfig struct {
-    // ConfigPollInterval controls how often to check for INI config file changes.
-    ConfigPollInterval time.Duration `mapstructure:"config-poll-interval" validate:"gte=0" default:"10s"`
-
-    // UseEvents enables Docker event-based container detection.
-    UseEvents bool `mapstructure:"events" default:"true"`
-
-    // DockerPollInterval enables periodic polling for container changes.
-    DockerPollInterval time.Duration `mapstructure:"docker-poll-interval" validate:"gte=0" default:"0"`
-
-    // PollingFallback auto-enables container polling if event subscription fails.
-    PollingFallback time.Duration `mapstructure:"polling-fallback" validate:"gte=0" default:"10s"`
-
-    // Deprecated fields - detected by key presence, not value
-    PollInterval   time.Duration `mapstructure:"poll-interval" validate:"gte=0"`
-    DisablePolling bool          `mapstructure:"no-poll"`
-}
-```
-
-#### 4. Enhanced Deprecation Detection
-
-```go
-// cli/deprecations.go - Updated CheckFunc signature
-
-type Deprecation struct {
-    Option         string
-    Replacement    string
-    RemovalVersion string
-    Message        string
-
-    // CheckFunc now receives decode metadata for presence-based detection
-    CheckFunc   func(cfg *Config, usedKeys map[string]bool) bool
-    MigrateFunc func(cfg *Config)
-}
-
-// Example: poll-interval deprecation
-{
-    Option:         "poll-interval",
-    Replacement:    "config-poll-interval and docker-poll-interval",
-    RemovalVersion: "v1.0.0",
-    CheckFunc: func(cfg *Config, usedKeys map[string]bool) bool {
-        // Detect by presence, not value!
-        return usedKeys["poll-interval"]
-    },
-    MigrateFunc: func(cfg *Config) {
-        // ... migration logic
-    },
-}
-```
-
-#### 5. Unknown Key Reporting
-
-```go
-// cli/config.go - BuildFromFile
-
-func BuildFromFile(filename string, logger core.Logger) (*Config, error) {
-    // ... INI loading ...
-
-    result, err := decodeWithMetadata(sectionToMap(sec), &c.Global)
-    if err != nil {
-        return nil, err
-    }
-
-    // Report unknown keys
-    for _, key := range result.UnusedKeys {
-        logger.Warningf("Unknown configuration key '%s' in [global] section (typo?)", key)
-    }
-
-    // Validate struct
-    if err := validateConfig(c); err != nil {
-        return nil, fmt.Errorf("validation failed: %w", err)
-    }
-
-    // Check deprecations with key presence info
-    checkDeprecationsWithMetadata(c, result.UsedKeys)
-
-    // ...
-}
-```
-
-### Validation Tag Reference
-
-| Tag | Purpose | Example |
-|-----|---------|---------|
-| `validate:"required"` | Field must be non-zero | `Schedule string` |
-| `validate:"gte=0,lte=65535"` | Numeric range | `SMTPPort int` |
-| `validate:"oneof=debug info warning error"` | Enum values | `LogLevel string` |
-| `validate:"url"` | Valid URL format | `SlackWebhook string` |
-| `validate:"email"` | Valid email format | `EmailFrom string` |
-| `validate:"min=1,max=255"` | String length | `Container string` |
-| Custom: `validate:"cron"` | Cron expression | `Schedule string` |
-| Custom: `validate:"dockerimage"` | Docker image ref | `Image string` |
-
-### Error Messages
-
-```
-Unknown configuration keys detected:
-  - [global] scheduel (did you mean 'schedule'?)
-  - [job-exec "backup"] comand (did you mean 'command'?)
-
-Validation errors:
-  - [global] smtp-port: must be between 1 and 65535 (got: 99999)
-  - [job-exec "backup"] schedule: required field is empty
-
-Deprecation warnings:
-  - 'poll-interval' is deprecated (present in config), use 'config-poll-interval' instead
-```
+4. **Warnings, not errors** for unknown keys - maintains backwards compatibility
 
 ## Consequences
 
 ### Positive
 
 1. **Better User Experience**:
-   - Immediate feedback on typos
+   - Immediate feedback on typos with suggestions
    - Clear validation error messages
    - Deprecation warnings for all deprecated keys (not just non-zero values)
 
@@ -281,97 +103,37 @@ Deprecation warnings:
 4. **Compatibility**:
    - mapstructure already in use (no new dependency for decoding)
    - go-playground/validator is mature, widely used
-   - Existing config files continue to work (warnings, not errors for unknown keys)
+   - Existing config files continue to work
 
 ### Negative
 
-1. **New Dependency**:
-   - Adds `github.com/go-playground/validator/v10`
-   - ~2MB additional binary size
+1. **New Dependency**: Adds `github.com/go-playground/validator/v10` (~2MB binary size)
 
-2. **Migration Effort**:
-   - Must update all struct definitions with validation tags
-   - Must update all `mapstructure.WeakDecode()` calls
-   - Tests need updating
+2. **Two validation systems temporarily**: `config/validator.go` (existing) coexists with new validator
 
-3. **Strict vs Lenient Behavior**:
-   - Unknown keys now generate warnings (may surprise users)
-   - Decision: Warnings only (not errors) for backwards compatibility
-   - Can make strict mode opt-in via `enable-strict-validation: true`
+3. **Unknown keys now generate warnings**: May surprise users with existing typos
 
-### Neutral
+### Scope Limitations
 
-1. **Two validation systems temporarily**:
-   - `config/validator.go` (existing) - phased out
-   - `go-playground/validator` (new) - primary going forward
-   - Migration path: gradual replacement over time
+- Unknown key detection currently applies to `[global]` and `[docker]` sections only
+- Job sections (`[job-exec]`, etc.) do not yet report unknown keys
 
 ## Alternatives Considered
 
 ### 1. mapstructure ErrorUnused Only
-
-**Rejected**: Only detects unknown keys, no value validation. Would still need custom validation.
+**Rejected**: Only detects unknown keys, no value validation.
 
 ### 2. Custom Validation Framework
-
-**Rejected**: Already have one (`config/validator.go`), it's maintenance burden. go-playground/validator is battle-tested.
+**Rejected**: Already have one (`config/validator.go`), it's maintenance burden.
 
 ### 3. JSON Schema Validation
-
-**Rejected**: INI format not directly convertible, adds complexity without benefit for this use case.
+**Rejected**: INI format not directly convertible, adds complexity.
 
 ### 4. Keep Current System
-
 **Rejected**: User experience issues (silent typos, missed deprecations) are significant pain points.
-
-## Implementation Plan
-
-### Phase 1: Core Infrastructure (This PR)
-
-1. Add `go-playground/validator/v10` dependency
-2. Create `cli/config_decode.go` with `decodeWithMetadata()`
-3. Create `cli/config_validate.go` with validator setup and custom validators
-4. Update deprecation `CheckFunc` signature to accept `usedKeys`
-5. Add comprehensive tests
-
-### Phase 2: Integration (This PR)
-
-6. Update `sectionToMap()` calls to use new decoder
-7. Add validation tags to all config structs
-8. Integrate validation into `BuildFromFile()` and `BuildFromString()`
-9. Add unknown key warnings to logger
-10. Update `dockerLabelsUpdate()` for label parsing
-
-### Phase 3: Cleanup (Future)
-
-11. Deprecate `config/validator.go` custom validators
-12. Migrate remaining manual validation to struct tags
-13. Add Levenshtein distance for "did you mean?" suggestions
 
 ## References
 
 - mapstructure Metadata: https://pkg.go.dev/github.com/mitchellh/mapstructure#Metadata
 - go-playground/validator: https://pkg.go.dev/github.com/go-playground/validator/v10
-- Current deprecation system: `cli/deprecations.go`
-- Current validation: `config/validator.go`
-
-## Test Plan
-
-1. **Unknown Key Detection**:
-   - Typo in global section → warning logged
-   - Typo in job section → warning logged
-   - Valid unknown key in shadowed section → no warning
-
-2. **Value Validation**:
-   - Invalid port number → error
-   - Invalid cron expression → error
-   - Invalid enum value → error
-
-3. **Deprecation Detection**:
-   - `poll-interval = 30s` → warning (value-based, existing)
-   - `poll-interval = 0` → warning (presence-based, NEW)
-   - No poll-interval key → no warning
-
-4. **Backwards Compatibility**:
-   - Existing valid configs continue to work
-   - Only new validation errors/warnings, no behavior changes
+- Implementation: `cli/config_decode.go`, `cli/config_validate.go`, `cli/deprecations.go`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,7 +20,7 @@ Each ADR follows this structure:
 |-----|-------|--------|------|
 | [ADR-001](./ADR-001-docker-registry-authentication.md) | Docker Registry Authentication | Accepted | 2025-12-10 |
 | [ADR-002](./ADR-002-security-boundaries.md) | Security Boundary Definition | Accepted | 2025-12-17 |
-| [ADR-003](./ADR-003-config-validation-improvements.md) | Configuration Validation Improvements | Proposed | 2025-12-24 |
+| [ADR-003](./ADR-003-config-validation-improvements.md) | Configuration Validation Improvements | Accepted | 2025-12-24 |
 
 ## Creating New ADRs
 


### PR DESCRIPTION
## Summary
- Rewrite ADR-003 to follow proper ADR conventions (decisions, not plans)
- Remove implementation plan and test plan sections
- Fix DecodeResult struct to match implementation
- Document Levenshtein distance as part of the decision
- Add Scope Limitations section for job section limitation
- Update status from Proposed to Accepted

## Addresses
Copilot review comments from PR #432:
- DecodeResult struct mismatch
- Levenshtein phase placement
- Job sections unknown key limitation

## Test plan
- [x] ADR follows proper format (Context, Decision, Consequences)
- [x] README index updated with Accepted status