### PR TITLE
fix(ci): add checkout step to notify-released job

### DIFF
--- a/.github/workflows/release-slsa.yml
+++ b/.github/workflows/release-slsa.yml
@@ -349,6 +349,11 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
       - name: Label and comment on released PRs/Issues
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds missing checkout step to the `notify-released` job in the release workflow

## Problem
The `notify-released` job was failing with:
```
fatal: not a git repository (or any of the parent directories): .git
```

The `gh` CLI needs access to the git repository for tag comparison operations (`gh api repos/.../compare/...`).

## Fix
Added `actions/checkout@v4` with `fetch-depth: 0` to fetch all history needed for tag comparison.

Fixes the failure in: https://github.com/netresearch/ofelia/actions/runs/20531053171/job/58982892071