### PR TITLE
ci: add Codecov integration and badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,13 @@ jobs:
           name: coverage-merged
           path: coverage.out
 
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        with:
+          files: coverage.out
+          fail_ci_if_error: false
+          verbose: true
+
   # Summary job for branch protection - required status check
   unit-tests-summary:
     name: unit tests

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/netresearch/ofelia.svg)](https://pkg.go.dev/github.com/netresearch/ofelia)
 [![CI](https://github.com/netresearch/ofelia/actions/workflows/ci.yml/badge.svg)](https://github.com/netresearch/ofelia/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/netresearch/ofelia/graph/badge.svg)](https://codecov.io/gh/netresearch/ofelia)
 [![CodeQL](https://github.com/netresearch/ofelia/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/netresearch/ofelia/actions/workflows/github-code-scanning/codeql)
 [![GitHub release](https://img.shields.io/github/v/release/netresearch/ofelia)](https://github.com/netresearch/ofelia/releases/latest)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/netresearch/ofelia)](go.mod)


### PR DESCRIPTION
## Summary

- Add Codecov upload step to the unit-coverage job in CI workflow
- Add Codecov badge to README

This enables code coverage tracking and visibility via Codecov.