### PR TITLE
ci: skip gitleaks for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,7 +390,7 @@ jobs:
     name: gitleaks
     # gitleaks-action doesn't support merge_group events
     # Skip for fork PRs as secrets are not available
-    if: github.event_name != 'merge_group' && github.event.pull_request.head.repo.fork != true
+    if: github.event_name != 'merge_group' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true)
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Skip gitleaks job for PRs from forks since secrets are not available (GitHub security feature)
- Gitleaks will still run on direct pushes and when code is merged to main

## Context
PR #446 from external contributor fails gitleaks because `GITLEAKS_KEY` org secret is inaccessible to fork PRs.

## Test plan
- [ ] Verify gitleaks job is skipped for fork PRs
- [ ] Verify gitleaks still runs for internal PRs and pushes to main