### PR TITLE
fix: bump Go version to 1.25.6 for security patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Pin base images by digest for supply chain security
 # Renovate will automatically update these digests
-FROM golang:1.25.5-alpine@sha256:26111811bc967321e7b6f852e914d14bede324cd1accb7f81811929a6a57fea9 AS builder
+FROM golang:1.25.6-alpine@sha256:98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92 AS builder
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache gcc musl-dev git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/netresearch/ofelia
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2


### PR DESCRIPTION
## Summary
- Bumps Go version from 1.25.5 to 1.25.6 to address stdlib security vulnerabilities

## Vulnerabilities Fixed
| ID | CVE | Package | Description |
|----|-----|---------|-------------|
| GO-2026-4341 | CVE-2025-61726 | `net/url` | Memory exhaustion via many query parameters |
| GO-2026-4340 | CVE-2025-61730 | `crypto/tls` | TLS 1.3 handshake information disclosure |

## References
- https://pkg.go.dev/vuln/GO-2026-4341
- https://pkg.go.dev/vuln/GO-2026-4340
- https://groups.google.com/g/golang-announce/c/Vd2tYVM8eUc

## Test plan
- [ ] CI passes with Go 1.25.6
- [ ] govulncheck passes without stdlib vulnerabilities