### PR TITLE
fix: bump Go version to 1.25.7 for security patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Pin base images by digest for supply chain security
 # Renovate will automatically update these digests
-FROM golang:1.25.6-alpine@sha256:98e6cffc31ccc44c7c15d83df1d69891efee8115a5bb7ede2bf30a38af3e3c92 AS builder
+FROM golang:1.25.7-alpine@sha256:724e212d86d79b45b7ace725b44ff3b6c2684bfd3131c43d5d60441de151d98e AS builder
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache gcc musl-dev git

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/netresearch/ofelia
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2


### PR DESCRIPTION
## Summary
- Bump Go from 1.25.6 to 1.25.7 in `go.mod` and `Dockerfile`
- Fixes [GO-2026-4337](https://pkg.go.dev/vuln/GO-2026-4337): Unexpected session resumption in `crypto/tls`

## Affected code paths
- `web.Start` → `http.Server.ListenAndServe` → `tls.Conn.HandshakeContext`
- `docker.ExecServiceAdapter.Start` → `tls.Dial` / `tls.Dialer.DialContext`
- `cli.ProgressReporter.Step` → `tls.Conn.Write`
- `mock.ContainerService.CopyLogs` → `tls.Conn.Read`

## Test plan
- [x] `govulncheck ./...` reports 0 vulnerabilities with Go 1.25.7
- [x] All existing tests pass