### PR TITLE
fix(ci): fix heredoc syntax error in release notification job

### DIFF
--- a/.github/workflows/release-slsa.yml
+++ b/.github/workflows/release-slsa.yml
@@ -196,33 +196,30 @@ jobs:
             exit 0
           fi
 
-          # Append verification instructions (indented for YAML, then stripped)
-          cat > /tmp/verification.md << 'VERIFICATION_EOF'
-
-          ## Verification
-
-          All binaries include SLSA Level 3 provenance attestations.
-
-          ### Verify binary provenance
-          ```bash
-          slsa-verifier verify-artifact ofelia-linux-amd64 \
-            --provenance-path ofelia-linux-amd64.intoto.jsonl \
-            --source-uri github.com/netresearch/ofelia
-          ```
-
-          ### Verify checksums signature
-          ```bash
-          cosign verify-blob \
-            --certificate checksums.txt.pem \
-            --signature checksums.txt.sig \
-            --certificate-identity "https://github.com/netresearch/ofelia/.github/workflows/release-slsa.yml@refs/tags/RELEASE_TAG_PLACEHOLDER" \
-            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-            checksums.txt
-          ```
-          VERIFICATION_EOF
-
-          # Strip indentation and replace placeholder
-          sed 's/^          //' /tmp/verification.md | sed "s/RELEASE_TAG_PLACEHOLDER/${RELEASE_TAG}/g" >> /tmp/notes.md
+          # Append verification instructions
+          {
+            echo ""
+            echo "## Verification"
+            echo ""
+            echo "All binaries include SLSA Level 3 provenance attestations."
+            echo ""
+            echo "### Verify binary provenance"
+            echo '```bash'
+            echo "slsa-verifier verify-artifact ofelia-linux-amd64 \\"
+            echo "  --provenance-path ofelia-linux-amd64.intoto.jsonl \\"
+            echo "  --source-uri github.com/netresearch/ofelia"
+            echo '```'
+            echo ""
+            echo "### Verify checksums signature"
+            echo '```bash'
+            echo "cosign verify-blob \\"
+            echo "  --certificate checksums.txt.pem \\"
+            echo "  --signature checksums.txt.sig \\"
+            echo "  --certificate-identity \"https://github.com/netresearch/ofelia/.github/workflows/release-slsa.yml@refs/tags/${RELEASE_TAG}\" \\"
+            echo "  --certificate-oidc-issuer \"https://token.actions.githubusercontent.com\" \\"
+            echo "  checksums.txt"
+            echo '```'
+          } >> /tmp/notes.md
 
           gh release edit "$RELEASE_TAG" --notes-file /tmp/notes.md
 
@@ -399,17 +396,16 @@ jobs:
             # Add label
             gh pr edit "$pr" --add-label "released:${RELEASE_TAG}" 2>/dev/null || true
 
-            # Add comment (use unquoted heredoc for natural variable expansion)
-            cat > /tmp/pr_comment.md << PR_EOF
-            🚀 **Released in [${RELEASE_TAG}](${RELEASE_URL})**
-
-            Thank you for your contribution! 🙏
-
-            This is now available in the latest release. Please test and verify everything works as expected in your environment.
-
-            If you encounter any issues, please open a new issue.
-            PR_EOF
-            sed -i 's/^            //' /tmp/pr_comment.md
+            # Add comment
+            {
+              echo "🚀 **Released in [${RELEASE_TAG}](${RELEASE_URL})**"
+              echo ""
+              echo "Thank you for your contribution! 🙏"
+              echo ""
+              echo "This is now available in the latest release. Please test and verify everything works as expected in your environment."
+              echo ""
+              echo "If you encounter any issues, please open a new issue."
+            } > /tmp/pr_comment.md
             gh pr comment "$pr" --body-file /tmp/pr_comment.md 2>/dev/null || true
 
             # Process linked issues
@@ -426,17 +422,16 @@ jobs:
               # Add label
               gh issue edit "$issue" --add-label "released:${RELEASE_TAG}" 2>/dev/null || true
 
-              # Add comment (use unquoted heredoc for natural variable expansion)
-              cat > /tmp/issue_comment.md << ISSUE_EOF
-              🚀 **Released in [${RELEASE_TAG}](${RELEASE_URL})**
-
-              Thank you for reporting this! 🙏
-
-              The fix/feature is now available in the latest release. Please update and verify everything works as expected.
-
-              If the issue persists or you find related problems, please open a new issue.
-              ISSUE_EOF
-              sed -i 's/^              //' /tmp/issue_comment.md
+              # Add comment
+              {
+                echo "🚀 **Released in [${RELEASE_TAG}](${RELEASE_URL})**"
+                echo ""
+                echo "Thank you for reporting this! 🙏"
+                echo ""
+                echo "The fix/feature is now available in the latest release. Please update and verify everything works as expected."
+                echo ""
+                echo "If the issue persists or you find related problems, please open a new issue."
+              } > /tmp/issue_comment.md
               gh issue comment "$issue" --body-file /tmp/issue_comment.md 2>/dev/null || true
             done
           done


### PR DESCRIPTION
## Summary

- Replace heredoc+sed patterns with echo blocks in the release-slsa workflow
- Fixes bash syntax error `unexpected end of file (wanted 'PR_EOF')` in the "Notify Released PRs/Issues" job

## Root Cause

Heredoc closing delimiters (`PR_EOF`, `ISSUE_EOF`) inside `for` loops were indented by the YAML block scalar indentation. After YAML processing strips the base indentation, the delimiters still had 2-4 spaces of leading whitespace. Since `<<` (without `-`) requires the closing delimiter at column 0, bash fails with a syntax error.

The `VERIFICATION_EOF` heredoc had the same fragile pattern (though it happened to work because it wasn't inside a loop).

## Fix

Replace all three heredoc+sed patterns with simple `{ echo ...; } > file` blocks that are immune to YAML indentation issues.

## Failed run

https://github.com/netresearch/ofelia/actions/runs/21807613643/job/62913771307