### PR TITLE
fix(ci): scope workflow permissions to job level for least privilege

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -4,14 +4,15 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   auto-merge:
     name: Auto-merge Dependabot/Renovate PRs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     # Only run for dependency update bots
     if: >-
       github.actor == 'dependabot[bot]' ||

--- a/.github/workflows/cleanup-containers.yml
+++ b/.github/workflows/cleanup-containers.yml
@@ -41,8 +41,7 @@ on:
         default: "7"
         type: string
 
-permissions:
-  packages: write
+permissions: read-all
 
 env:
   PACKAGE_NAME: ofelia
@@ -56,6 +55,8 @@ jobs:
   cleanup-edge-images:
     name: Cleanup Old Edge Images
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
@@ -182,6 +183,8 @@ jobs:
     name: Cleanup Orphaned Untagged Images
     runs-on: ubuntu-latest
     needs: cleanup-edge-images
+    permissions:
+      packages: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0


### PR DESCRIPTION
## Summary

- Move top-level `contents: write` + `pull-requests: write` to job-level in `auto-merge.yml`
- Move top-level `packages: write` to job-level in `cleanup-containers.yml`
- Set top-level permissions to `read-all` in both workflows

Fixes OpenSSF Scorecard [Token-Permissions](https://securityscorecards.dev/viewer/?uri=github.com/netresearch/ofelia) warnings:
- `Warn: topLevel 'contents' permission set to 'write': .github/workflows/auto-merge.yml:8`
- `Warn: topLevel 'packages' permission set to 'write': .github/workflows/cleanup-containers.yml:45`

## Test plan

- [ ] Verify Scorecard re-scan no longer flags these workflows
- [ ] Trigger cleanup-containers with dry-run to confirm permissions work
- [ ] Verify auto-merge still works on next Dependabot/Renovate PR