### PR TITLE
fix(docker): add explicit build context for pre-built binary Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,6 +533,7 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         id: push
         with:
+          context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-slsa.yml
+++ b/.github/workflows/release-slsa.yml
@@ -297,6 +297,7 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         id: push
         with:
+          context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Adds `context: .` to `docker/build-push-action` in both `ci.yml` and `release-slsa.yml`
- Fixes Docker build failure where pre-built binaries in `bin/` were not included in the build context

## Root Cause
`docker/build-push-action` defaults to **Git context** (only committed/tracked files). Since PR #459 changed the Docker build to use pre-built binaries downloaded into `bin/` at workflow runtime, these files exist on the filesystem but are not tracked by git — so they were excluded from the build context, causing `lstat /bin: no such file or directory`.

## Test plan
- [ ] CI passes (build-binaries + build_image jobs)
- [ ] Verify Docker build step includes `bin/` contents in context