### PR TITLE
chore(ci): add codecov config, make project coverage informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        target: 80%


### PR DESCRIPTION
## Summary
- Adds `codecov.yml` to make `codecov/project` status check informational (non-blocking)
- `codecov/patch` remains enforced at 80% target to ensure new code is tested
- Fixes PRs being blocked by minor project-wide coverage fluctuations (e.g. #461)