### PR TITLE
chore: limit the number of Docker events

### DIFF
--- a/cli/docker_config_handler.go
+++ b/cli/docker_config_handler.go
@@ -344,7 +344,25 @@ func (c *DockerHandler) watchEvents() {
 		}
 
 		eventCh, errCh := c.dockerProvider.SubscribeEvents(c.ctx, domain.EventFilter{
-			Filters: map[string][]string{"type": {"container"}},
+			Filters: map[string][]string{
+				"type":  {"container"},
+				"label": {"ofelia.enabled=true"},
+				"event": {
+					// Lifecycle events
+					domain.EventActionCreate,
+					domain.EventActionStart,
+					domain.EventActionRestart,
+					domain.EventActionStop,
+					domain.EventActionKill,
+					domain.EventActionDie,
+					domain.EventActionDestroy,
+					// Management events
+					domain.EventActionPause,
+					domain.EventActionUnpause,
+					domain.EventActionRename,
+					domain.EventActionUpdate,
+				},
+			},
 		})
 
 		// Inner loop: process events until error or shutdown


### PR DESCRIPTION
## Problem
Right now, with `--docker-events`, Ofelia listens for all events for all containers, including non-relevant health-checks, execs. And on each insignificant event, it fetches container labels, parses...
I added some logging and got **8 dockerContainersUpdate** in just **one** second:
```
DEBU[2026-02-14 18:13:24] Docker event: exec_create: /bin/sh -c curl --insecure --fail http://localhost:9696/ping
DEBU[2026-02-14 18:13:24] dockerContainersUpdate started
DEBU[2026-02-14 18:13:24] Docker event: exec_start: /bin/sh -c curl --insecure --fail http://localhost:9696/ping
DEBU[2026-02-14 18:13:24] dockerContainersUpdate started
DEBU[2026-02-14 18:13:24] Docker event: exec_die
DEBU[2026-02-14 18:13:24] Docker event: exec_create: /bin/sh -c curl --insecure --fail http://localhost:8989/ping
DEBU[2026-02-14 18:13:24] dockerContainersUpdate started
DEBU[2026-02-14 18:13:24] Docker event: exec_start: /bin/sh -c curl --insecure --fail http://localhost:8989/ping
DEBU[2026-02-14 18:13:24] dockerContainersUpdate started
DEBU[2026-02-14 18:13:24] Docker event: exec_die
DEBU[2026-02-14 18:13:24] Docker event: exec_create: /ldap healthcheck
DEBU[2026-02-14 18:13:24] dockerContainersUpdate started
DEBU[2026-02-14 18:13:24] Docker event: exec_create: /proxy healthcheck
DEBU[2026-02-14 18:13:24] dockerContainersUpdate started
DEBU[2026-02-14 18:13:24] Docker event: exec_start: /ldap healthcheck
DEBU[2026-02-14 18:13:24] dockerContainersUpdate started
DEBU[2026-02-14 18:13:24] Docker event: exec_start: /proxy healthcheck
DEBU[2026-02-14 18:13:24] dockerContainersUpdate started
DEBU[2026-02-14 18:13:24] Docker event: exec_die
DEBU[2026-02-14 18:13:24] Docker event: exec_die
```

## Solution
More strict filters when subscribing to Docker events.
1. Only from relevant containers: label `ofelia.enabled` is specified and it's `true`.
2. Only for relevant life-cycle events (no exec_*).

With this, I have 0 non-relevant events in the log 🎉, and no unnecessary load on Docker socket and no parsing.