### PR TITLE
fix(ci): fix dependabot.yml indentation syntax

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,11 @@
 
 version: 2
 updates:
- - package-ecosystem: "devcontainers"
-   directory: "/"
-   schedule:
-     interval: weekly
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly


### PR DESCRIPTION
## Summary
- Fixes inconsistent YAML indentation in `.github/dependabot.yml`
- The `devcontainers` entry had 1-space indent, `gomod` had 2-space, causing the gomod entry to be parsed as nested under devcontainers instead of as a sibling list item

## Housekeeping
- Deleted orphaned branch `fix/auto-approve-external-contributors` (had a dangling commit after PR #464 merged)