### PR TITLE
fix: don’t track internal labels as config params

### DIFF
--- a/cli/docker-labels.go
+++ b/cli/docker-labels.go
@@ -228,6 +228,11 @@ func (c *Config) splitContainersLabelsIntoJobMapsByType(containers []DockerConta
 		containerExecJobs := make(map[string]map[string]any)
 
 		for k, jobParamValue := range labelSet {
+			if k == requiredLabel || k == serviceLabel {
+				// Do not track internal labels as global config parameters.
+				continue
+			}
+
 			parts := strings.Split(k, ".")
 			if len(parts) < 4 {
 				if isService {


### PR DESCRIPTION
Another tiny fix.

I've got two false-positive warnings about unused keys:
```
time=2026-02-18T11:03:45.349Z level=WARN source=github.com/netresearch/ofelia/cli/docker-labels.go:33 msg="Unknown global label keys (possible typo): [enabled service]"

time=2026-02-18T11:03:54.262Z level=WARN source=github.com/netresearch/ofelia/cli/docker-labels.go:33 msg="Unknown global label keys (possible typo): [enabled service]"
```

Those keys are Docker labels for internal use only, and do not affect global config (because `len(strings.Split(k, ".")) < 4` below), so we just safely ignore them and don't add to the `globalConfigs`.