### PR TITLE
fix: add allow-list for global config keys from Docker labels

### DIFF
--- a/cli/docker-labels.go
+++ b/cli/docker-labels.go
@@ -52,10 +52,11 @@ var globalLabelAllowList = map[string]bool{
 	"restore-history":         true,
 	"restore-history-max-age": true,
 
-	// Webhook global settings
-	"webhooks":              true,
-	"webhook-allowed-hosts": true,
-	"preset-cache-ttl":      true,
+	// Webhook global settings (security-sensitive keys like webhook-allowed-hosts,
+	// allow-remote-presets, and trusted-preset-sources are intentionally NOT allowed
+	// via labels to prevent SSRF and remote configuration injection)
+	"webhooks":         true,
+	"preset-cache-ttl": true,
 }
 
 func (c *Config) buildFromDockerContainers(containers []DockerContainerInfo) error {


### PR DESCRIPTION
## Summary

- Adds a `globalLabelAllowList` in `cli/docker-labels.go` that defines which global config keys may be set via Docker labels on service containers
- Blocks security-sensitive keys (`allow-host-jobs-from-labels`, web auth settings, pprof, `default-user`) from being overridden via labels — they can only be set via config file
- Blocked keys emit a `SECURITY: Blocked global config key ...` warning log
- Adds 3 test cases: blocked keys filtered, allowed keys pass through, full attack scenario (label cannot enable host job execution)

## Security Context

Any container with `ofelia.service=true` could override **any** global config field via Docker labels, including `allow-host-jobs-from-labels` (enabling host code execution) and web authentication settings. This PR closes that privilege escalation vector with a secure-by-default allow-list.

See detailed analysis in #486.

## Test Plan

- [x] `TestGlobalLabelAllowListBlocksSecurityKeys` — verifies 7 security-sensitive keys are blocked
- [x] `TestGlobalLabelAllowListPermitsSafeKeys` — verifies 5 safe keys pass through
- [x] `TestGlobalLabelAllowListPreventsHostJobEscalation` — full attack scenario end-to-end
- [x] Full test suite passes (`go test ./...`)
- [x] golangci-lint clean, go vet clean

Closes #486