### PR TITLE
chore: add SPDX headers, DCO enforcement, and build-debug target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,50 @@ Thank you for your interest in contributing to Ofelia! This document provides gu
 
 ## Table of Contents
 
+- [Developer Certificate of Origin (DCO)](#developer-certificate-of-origin-dco)
 - [Development Setup](#development-setup)
 - [Testing Strategy](#testing-strategy)
 - [Code Style](#code-style)
 - [Pull Request Process](#pull-request-process)
 - [Release Process](#release-process)
+
+## Developer Certificate of Origin (DCO)
+
+All contributions to Ofelia must include a `Signed-off-by` trailer in the
+commit message, certifying that you wrote the code or have the right to submit
+it under the project's open-source license. This is the
+[Developer Certificate of Origin (DCO)](https://developercertificate.org/).
+
+### How to sign off
+
+Add `--signoff` (or `-s`) to your `git commit` command:
+
+```bash
+git commit --signoff -m "feat(core): add new scheduler algorithm"
+```
+
+This appends a line like:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+If you have already made commits without sign-off, you can amend or rebase to
+add it:
+
+```bash
+# Amend the last commit
+git commit --amend --signoff --no-edit
+
+# Rebase and sign off all commits on your branch
+git rebase --signoff HEAD~N   # where N is the number of commits
+```
+
+### Automated enforcement
+
+The project's lefthook `commit-msg` hook validates the presence of
+`Signed-off-by` locally. CI also checks all commits in a pull request via the
+[DCO GitHub App](https://github.com/apps/dco).
 
 ## Development Setup
 
@@ -261,6 +300,7 @@ job.Run(ctx)
 
 ### PR Checklist
 
+- [ ] All commits are signed off (`git commit --signoff`) per [DCO](#developer-certificate-of-origin-dco)
 - [ ] Tests added for new functionality
 - [ ] All tests pass (`go test -tags=integration,e2e -v ./...`)
 - [ ] Code follows project style guidelines

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,11 @@ PKG_TAG = latest
 GOCMD = go
 GOBUILD = $(GOCMD) build
 GHRELEASE = github-release
-LDFLAGS = -ldflags "-X main.version=$(BRANCH) -X main.build=$(BUILD)" 
+# BUILD_FLAGS defaults to stripping debug info for smaller binaries.
+# Override to preserve debug symbols: make build BUILD_FLAGS=""
+# Or build with: make build-debug
+BUILD_FLAGS ?= -s -w
+LDFLAGS = -ldflags "$(BUILD_FLAGS) -X main.version=$(BRANCH) -X main.build=$(BUILD)"
 
 # Coverage
 COVERAGE_REPORT = coverage.txt
@@ -254,7 +258,8 @@ help:
 	@echo "Ofelia Development Commands:"
 	@echo ""
 	@echo "🏗️  Building:"
-	@echo "  build              - Build local binary"
+	@echo "  build              - Build local binary (stripped, no debug symbols)"
+	@echo "  build-debug        - Build local binary with debug symbols preserved"
 	@echo "  packages           - Build cross-platform binaries"
 	@echo "  docker-build       - Build Docker image"
 	@echo "  docker-run         - Build and run Docker container"
@@ -297,7 +302,12 @@ help:
 
 build:
 	@mkdir -p $(BUILD_PATH)
-	@go build -o $(BUILD_PATH)/$(PROJECT) ofelia.go
+	@go build $(LDFLAGS) -o $(BUILD_PATH)/$(PROJECT) ofelia.go
+
+.PHONY: build-debug
+build-debug: BUILD_FLAGS =
+build-debug: build
+	@echo "Built with debug symbols preserved (no -s -w flags)"
 
 packages:
 	@for os in $(PKG_OS); do \

--- a/cli/config.go
+++ b/cli/config.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_comprehensive_test.go
+++ b/cli/config_comprehensive_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_decode.go
+++ b/cli/config_decode.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_decode_test.go
+++ b/cli/config_decode_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_dependencies_test.go
+++ b/cli/config_dependencies_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_execjob_init_test.go
+++ b/cli/config_execjob_init_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_extra_test.go
+++ b/cli/config_extra_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_fuzz_test.go
+++ b/cli/config_fuzz_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_initialize_test.go
+++ b/cli/config_initialize_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_jobsource_test.go
+++ b/cli/config_jobsource_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_mutation_test.go
+++ b/cli/config_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_parsing_test.go
+++ b/cli/config_parsing_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_show.go
+++ b/cli/config_show.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_show_test.go
+++ b/cli/config_show_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_validate.go
+++ b/cli/config_validate.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_validate_test.go
+++ b/cli/config_validate_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_webhook.go
+++ b/cli/config_webhook.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_webhook_integration_test.go
+++ b/cli/config_webhook_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/config_webhook_test.go
+++ b/cli/config_webhook_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/daemon_boot_test.go
+++ b/cli/daemon_boot_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/daemon_execute_test.go
+++ b/cli/daemon_execute_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/daemon_full_lifecycle_test.go
+++ b/cli/daemon_full_lifecycle_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/daemon_lifecycle_test.go
+++ b/cli/daemon_lifecycle_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/daemon_mutation_test.go
+++ b/cli/daemon_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/daemon_test.go
+++ b/cli/daemon_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/deprecations.go
+++ b/cli/deprecations.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/deprecations_mutation_test.go
+++ b/cli/deprecations_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/deprecations_test.go
+++ b/cli/deprecations_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/docker-labels.go
+++ b/cli/docker-labels.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/docker_config_handler.go
+++ b/cli/docker_config_handler.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/docker_config_handler_mutation_test.go
+++ b/cli/docker_config_handler_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/docker_handler_integration_test.go
+++ b/cli/docker_handler_integration_test.go
@@ -1,5 +1,7 @@
 //go:build integration
 
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
 package cli
 
 import (

--- a/cli/docker_handler_shutdown_test.go
+++ b/cli/docker_handler_shutdown_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/docker_labels_test.go
+++ b/cli/docker_labels_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/doctor_mutation_test.go
+++ b/cli/doctor_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/doctor_test.go
+++ b/cli/doctor_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import "errors"

--- a/cli/hashpw.go
+++ b/cli/hashpw.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/init.go
+++ b/cli/init.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/init_mutation_test.go
+++ b/cli/init_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/init_test.go
+++ b/cli/init_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/logging.go
+++ b/cli/logging.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/logging_test.go
+++ b/cli/logging_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/progress.go
+++ b/cli/progress.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/progress_test.go
+++ b/cli/progress_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/testhelpers_test.go
+++ b/cli/testhelpers_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 // setJobSource assigns the given JobSource to all jobs in the provided Config.

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/cli/validate_test.go
+++ b/cli/validate_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package cli
 
 import (

--- a/config/command_validator.go
+++ b/config/command_validator.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/config/command_validator_mutation_test.go
+++ b/config/command_validator_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/config/command_validator_test.go
+++ b/config/command_validator_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/config/sanitizer.go
+++ b/config/sanitizer.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/config/sanitizer_mutation_test.go
+++ b/config/sanitizer_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/config/sanitizer_test.go
+++ b/config/sanitizer_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/config/validator.go
+++ b/config/validator.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/config/validator2_mutation_test.go
+++ b/config/validator2_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/config/validator_boundary_test.go
+++ b/config/validator_boundary_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/config/validator_mutation_test.go
+++ b/config/validator_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/config/validator_test.go
+++ b/config/validator_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package config
 
 import (

--- a/core/adapters/docker/auth.go
+++ b/core/adapters/docker/auth.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package docker
 
 import (

--- a/core/adapters/docker/auth_test.go
+++ b/core/adapters/docker/auth_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package docker
 
 import (

--- a/core/adapters/docker/benchmark_test.go
+++ b/core/adapters/docker/benchmark_test.go
@@ -1,5 +1,7 @@
 //go:build integration
 
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
 package docker_test
 
 import (

--- a/core/adapters/docker/client.go
+++ b/core/adapters/docker/client.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 // Package docker provides an adapter for the official Docker SDK.
 package docker
 

--- a/core/adapters/docker/client_integration_test.go
+++ b/core/adapters/docker/client_integration_test.go
@@ -1,5 +1,7 @@
 //go:build integration
 
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
 package docker_test
 
 import (

--- a/core/adapters/docker/client_mutation_test.go
+++ b/core/adapters/docker/client_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package docker
 
 import (

--- a/core/adapters/docker/client_test.go
+++ b/core/adapters/docker/client_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package docker_test
 
 import (

--- a/core/adapters/docker/container.go
+++ b/core/adapters/docker/container.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package docker
 
 import (

--- a/core/adapters/docker/convert.go
+++ b/core/adapters/docker/convert.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package docker
 
 import (

--- a/core/adapters/docker/convert_mutation_test.go
+++ b/core/adapters/docker/convert_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package docker
 
 import (

--- a/core/adapters/docker/convert_test.go
+++ b/core/adapters/docker/convert_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package docker
 
 import (

--- a/core/adapters/docker/event.go
+++ b/core/adapters/docker/event.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package docker
 
 import (

--- a/core/adapters/docker/exec.go
+++ b/core/adapters/docker/exec.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package docker
 
 import (

--- a/core/adapters/docker/image.go
+++ b/core/adapters/docker/image.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package docker
 
 import (

--- a/core/adapters/docker/integration_test.go
+++ b/core/adapters/docker/integration_test.go
@@ -1,5 +1,7 @@
 //go:build integration
 
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
 package docker_test
 
 import (

--- a/core/adapters/docker/network.go
+++ b/core/adapters/docker/network.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package docker
 
 import (

--- a/core/adapters/docker/service.go
+++ b/core/adapters/docker/service.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package docker
 
 import (

--- a/core/adapters/docker/system.go
+++ b/core/adapters/docker/system.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package docker
 
 import (

--- a/core/adapters/mock/client.go
+++ b/core/adapters/mock/client.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 // Package mock provides mock implementations of the ports interfaces for testing.
 package mock
 

--- a/core/adapters/mock/client_test.go
+++ b/core/adapters/mock/client_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package mock_test
 
 import (

--- a/core/adapters/mock/event.go
+++ b/core/adapters/mock/event.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package mock
 
 import (

--- a/core/adapters/mock/exec.go
+++ b/core/adapters/mock/exec.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package mock
 
 import (

--- a/core/adapters/mock/image.go
+++ b/core/adapters/mock/image.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package mock
 
 import (

--- a/core/adapters/mock/network.go
+++ b/core/adapters/mock/network.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package mock
 
 import (

--- a/core/adapters/mock/service.go
+++ b/core/adapters/mock/service.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package mock
 
 import (

--- a/core/adapters/mock/system.go
+++ b/core/adapters/mock/system.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package mock
 
 import (

--- a/core/annotations.go
+++ b/core/annotations.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/annotations_test.go
+++ b/core/annotations_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/bare_job.go
+++ b/core/bare_job.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/bare_job_extra_test.go
+++ b/core/bare_job_extra_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/bare_job_test.go
+++ b/core/bare_job_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/buffer_pool.go
+++ b/core/buffer_pool.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/buffer_pool_benchmark_test.go
+++ b/core/buffer_pool_benchmark_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/buffer_pool_integration_test.go
+++ b/core/buffer_pool_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/buffer_pool_mutation_test.go
+++ b/core/buffer_pool_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/clock.go
+++ b/core/clock.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/clock_test.go
+++ b/core/clock_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/common.go
+++ b/core/common.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/common_extra3_test.go
+++ b/core/common_extra3_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/common_test.go
+++ b/core/common_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/composejob.go
+++ b/core/composejob.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/composejob_test.go
+++ b/core/composejob_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/context_log_test.go
+++ b/core/context_log_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/cron_utils.go
+++ b/core/cron_utils.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import "log/slog"

--- a/core/cron_utils_test.go
+++ b/core/cron_utils_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/docker_benchmark_test.go
+++ b/core/docker_benchmark_test.go
@@ -1,5 +1,7 @@
 //go:build integration
 
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
 package core
 
 import (

--- a/core/docker_interface.go
+++ b/core/docker_interface.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/docker_sdk_provider.go
+++ b/core/docker_sdk_provider.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/docker_sdk_provider_test.go
+++ b/core/docker_sdk_provider_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core_test
 
 import (

--- a/core/domain/container.go
+++ b/core/domain/container.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 // Package domain contains SDK-agnostic domain models for Docker operations.
 // These types are designed to be independent of any specific Docker client implementation.
 package domain

--- a/core/domain/errors.go
+++ b/core/domain/errors.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package domain
 
 import (

--- a/core/domain/event.go
+++ b/core/domain/event.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package domain
 
 import "time"

--- a/core/domain/exec.go
+++ b/core/domain/exec.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package domain
 
 import (

--- a/core/domain/image.go
+++ b/core/domain/image.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package domain
 
 import (

--- a/core/domain/network.go
+++ b/core/domain/network.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package domain
 
 import "time"

--- a/core/domain/service.go
+++ b/core/domain/service.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package domain
 
 import "time"

--- a/core/domain/system.go
+++ b/core/domain/system.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package domain
 
 import "time"

--- a/core/errors.go
+++ b/core/errors.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/errors_test.go
+++ b/core/errors_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/execjob.go
+++ b/core/execjob.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/execjob_integration_test.go
+++ b/core/execjob_integration_test.go
@@ -1,5 +1,7 @@
 //go:build integration
 
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
 package core
 
 import (

--- a/core/execjob_simple_test.go
+++ b/core/execjob_simple_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/execjob_workingdir_test.go
+++ b/core/execjob_workingdir_test.go
@@ -1,5 +1,7 @@
 //go:build integration
 
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
 package core
 
 import (

--- a/core/hash_test.go
+++ b/core/hash_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/helpers_suite_test.go
+++ b/core/helpers_suite_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/integration_test_main.go
+++ b/core/integration_test_main.go
@@ -1,5 +1,7 @@
 //go:build integration
 
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
 package core
 
 import (

--- a/core/job_test_helpers.go
+++ b/core/job_test_helpers.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/localjob.go
+++ b/core/localjob.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/localjob_comprehensive_test.go
+++ b/core/localjob_comprehensive_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/localjob_test.go
+++ b/core/localjob_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/missing_coverage_test.go
+++ b/core/missing_coverage_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/performance_metrics.go
+++ b/core/performance_metrics.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/performance_metrics_integration_test.go
+++ b/core/performance_metrics_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/performance_metrics_mutation_test.go
+++ b/core/performance_metrics_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/ports/container.go
+++ b/core/ports/container.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package ports
 
 import (

--- a/core/ports/docker.go
+++ b/core/ports/docker.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 // Package ports defines the port interfaces for Docker operations.
 // These interfaces abstract the Docker client implementation, enabling
 // easy testing with mocks and future SDK migrations.

--- a/core/ports/event.go
+++ b/core/ports/event.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package ports
 
 import (

--- a/core/ports/exec.go
+++ b/core/ports/exec.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package ports
 
 import (

--- a/core/ports/image.go
+++ b/core/ports/image.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package ports
 
 import (

--- a/core/ports/network.go
+++ b/core/ports/network.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package ports
 
 import (

--- a/core/ports/service.go
+++ b/core/ports/service.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package ports
 
 import (

--- a/core/ports/system.go
+++ b/core/ports/system.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package ports
 
 import (

--- a/core/regression_test.go
+++ b/core/regression_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/resilience.go
+++ b/core/resilience.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/resilience_mutation_test.go
+++ b/core/resilience_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/resilience_test.go
+++ b/core/resilience_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/resilient_job.go
+++ b/core/resilient_job.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/retry.go
+++ b/core/retry.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/retry_mutation_test.go
+++ b/core/retry_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/retry_test.go
+++ b/core/retry_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/runjob.go
+++ b/core/runjob.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/runjob_annotations_test.go
+++ b/core/runjob_annotations_test.go
@@ -1,5 +1,7 @@
 //go:build integration
 
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
 package core
 
 import (

--- a/core/runjob_extra_test.go
+++ b/core/runjob_extra_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import "testing"

--- a/core/runjob_integration_test.go
+++ b/core/runjob_integration_test.go
@@ -1,5 +1,7 @@
 //go:build integration
 
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
 package core
 
 import (

--- a/core/runjob_simple_test.go
+++ b/core/runjob_simple_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/runservice.go
+++ b/core/runservice.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/runservice_integration_test.go
+++ b/core/runservice_integration_test.go
@@ -1,5 +1,7 @@
 //go:build integration
 
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
 package core
 
 import (

--- a/core/runservice_test.go
+++ b/core/runservice_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/runservicejob_annotations_test.go
+++ b/core/runservicejob_annotations_test.go
@@ -1,5 +1,7 @@
 //go:build integration
 
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
 package core
 
 import (

--- a/core/scheduler.go
+++ b/core/scheduler.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/scheduler_concurrency_benchmark_test.go
+++ b/core/scheduler_concurrency_benchmark_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/scheduler_concurrency_test.go
+++ b/core/scheduler_concurrency_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/scheduler_edge_cases_test.go
+++ b/core/scheduler_edge_cases_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/scheduler_more_test.go
+++ b/core/scheduler_more_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/scheduler_mutation_test.go
+++ b/core/scheduler_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/scheduler_test.go
+++ b/core/scheduler_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/shutdown.go
+++ b/core/shutdown.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/shutdown_test.go
+++ b/core/shutdown_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/workflow.go
+++ b/core/workflow.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/workflow_test.go
+++ b/core/workflow_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/e2e/scheduler_lifecycle_test.go
+++ b/e2e/scheduler_lifecycle_test.go
@@ -1,6 +1,8 @@
 //go:build e2e
 // +build e2e
 
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
 package e2e
 
 import (

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -121,6 +121,26 @@ commit-msg:
 
         echo "✅ Commit message format validated"
 
+    # Enforce Developer Certificate of Origin (DCO)
+    dco-signoff:
+      run: |
+        msg=$(cat {1})
+
+        # Skip merge commits
+        if echo "$msg" | grep -q "^Merge"; then
+          exit 0
+        fi
+
+        if ! echo "$msg" | grep -qE "^Signed-off-by: .+ <.+>"; then
+          echo "❌ Missing DCO sign-off!"
+          echo ""
+          echo "All commits must include a Signed-off-by trailer."
+          echo "Use: git commit --signoff -m \"your message\""
+          echo ""
+          echo "See CONTRIBUTING.md for details."
+          exit 1
+        fi
+
 pre-push:
   parallel: true
   commands:

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package metrics
 
 import (

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package metrics
 
 import (

--- a/middlewares/common.go
+++ b/middlewares/common.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import "reflect"

--- a/middlewares/common_test.go
+++ b/middlewares/common_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/dedup.go
+++ b/middlewares/dedup.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/dedup_test.go
+++ b/middlewares/dedup_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/errors.go
+++ b/middlewares/errors.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import "errors"

--- a/middlewares/mail.go
+++ b/middlewares/mail.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/mail_test.go
+++ b/middlewares/mail_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/overlap.go
+++ b/middlewares/overlap.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import "github.com/netresearch/ofelia/core"

--- a/middlewares/overlap_test.go
+++ b/middlewares/overlap_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/preset.go
+++ b/middlewares/preset.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/preset_cache.go
+++ b/middlewares/preset_cache.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/preset_cache_test.go
+++ b/middlewares/preset_cache_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/preset_github.go
+++ b/middlewares/preset_github.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/preset_github_test.go
+++ b/middlewares/preset_github_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/preset_mutation_test.go
+++ b/middlewares/preset_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/preset_test.go
+++ b/middlewares/preset_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/restore.go
+++ b/middlewares/restore.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/restore_test.go
+++ b/middlewares/restore_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/sanitize.go
+++ b/middlewares/sanitize.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/sanitize_test.go
+++ b/middlewares/sanitize_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/save.go
+++ b/middlewares/save.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/save_test.go
+++ b/middlewares/save_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/slack.go
+++ b/middlewares/slack.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/slack_mutation_test.go
+++ b/middlewares/slack_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/slack_test.go
+++ b/middlewares/slack_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/webhook.go
+++ b/middlewares/webhook.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/webhook_config.go
+++ b/middlewares/webhook_config.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/webhook_config_test.go
+++ b/middlewares/webhook_config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/webhook_mutation_test.go
+++ b/middlewares/webhook_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/webhook_security.go
+++ b/middlewares/webhook_security.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/webhook_security_test.go
+++ b/middlewares/webhook_security_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/middlewares/webhook_test.go
+++ b/middlewares/webhook_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package middlewares
 
 import (

--- a/ofelia.go
+++ b/ofelia.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/ofelia_test.go
+++ b/ofelia_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package main
 
 import (

--- a/static/static.go
+++ b/static/static.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package static
 
 import "embed"

--- a/test/testlogger.go
+++ b/test/testlogger.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package test
 
 import (

--- a/test/testutil/eventually.go
+++ b/test/testutil/eventually.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 // Package testutil provides common test utilities for the Ofelia project.
 package testutil
 

--- a/test/testutil/eventually_test.go
+++ b/test/testutil/eventually_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package testutil
 
 import (

--- a/web/auth_integration_test.go
+++ b/web/auth_integration_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package web_test
 
 import (

--- a/web/auth_secure.go
+++ b/web/auth_secure.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package web
 
 import (

--- a/web/health.go
+++ b/web/health.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package web
 
 import (

--- a/web/health_test.go
+++ b/web/health_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package web
 
 import (

--- a/web/middleware.go
+++ b/web/middleware.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package web
 
 import (

--- a/web/middleware_mutation_test.go
+++ b/web/middleware_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package web
 
 import (

--- a/web/middleware_test.go
+++ b/web/middleware_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package web
 
 import (

--- a/web/missing_coverage_test.go
+++ b/web/missing_coverage_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package web
 
 import (

--- a/web/server.go
+++ b/web/server.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package web
 
 import (

--- a/web/server_more_test.go
+++ b/web/server_more_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package web
 
 import (

--- a/web/server_mutation_test.go
+++ b/web/server_mutation_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package web
 
 import (

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
 package web_test
 
 import (


### PR DESCRIPTION
## Summary
- Add SPDX copyright and MIT license headers to all 225 Go source files
- Add DCO enforcement via lefthook commit-msg hook
- Add `build-debug` Makefile target and `BUILD_FLAGS` variable for debug symbol preservation
- Supports OpenSSF Best Practices Silver badge criteria (license_per_file, copyright_per_file, dco, build_preserve_debug)

## Test plan
- [ ] Verify SPDX headers present in Go files
- [ ] Verify `make build-debug` produces binary with debug symbols
- [ ] Verify lefthook DCO hook rejects unsigned commits