### PR TITLE
fix: update Go to 1.26.1 to fix stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/netresearch/ofelia
 
-go 1.26.0
+go 1.26.1
 
 require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2


### PR DESCRIPTION
## Summary
- Updates Go from 1.26.0 to 1.26.1 to fix 5 stdlib vulnerabilities detected by govulncheck
- Fixes: GO-2026-4599, GO-2026-4600, GO-2026-4601, GO-2026-4602, GO-2026-4603

## Vulnerabilities fixed
- `crypto/x509`: Panic in name constraint checking, incorrect email constraint enforcement
- `net/url`: Incorrect parsing of IPv6 host literals
- `os`: FileInfo can escape from a Root
- `html/template`: URLs in meta content attribute actions not escaped