### PR TITLE
fix: auto-merge workflow and dependency review license list

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -30,7 +30,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --auto "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,7 +270,9 @@ jobs:
             pkg:golang/go.opentelemetry.io/otel/trace,
             pkg:golang/golang.org/x/crypto,
             pkg:golang/golang.org/x/sys,
-            pkg:golang/golang.org/x/text
+            pkg:golang/golang.org/x/term,
+            pkg:golang/golang.org/x/text,
+            pkg:golang/golang.org/x/time
           comment-summary-in-pr: always
 
   license-check:


### PR DESCRIPTION
## Summary
- Remove `--squash` from auto-merge workflow — the merge queue controls the merge method, passing `--squash` is redundant and may conflict
- Add `golang.org/x/term` and `golang.org/x/time` to `allow-dependencies-licenses` in dependency review (compound SPDX expression with Google patent grant, same as other `x/` packages already listed)

## Context
All 5 open Dependabot PRs (#512-#516) failed to auto-merge because:
1. The merge queue grouped them together (all modify `go.mod`/`go.sum`), they conflicted, and all got dequeued
2. PR #515 (`golang.org/x/time`) was also blocked by Dependency Review flagging `LicenseRef-scancode-google-patent-license-golang` as incompatible

## Test plan
- [ ] CI passes (especially Dependency Review)
- [ ] After merge, re-trigger auto-merge on #512-#516 and verify they process through the merge queue one at a time