### PR TITLE
fix: bump Go to 1.26.2 for stdlib security fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,14 +54,14 @@ tidy:
 .PHONY: lint
 lint:
 	@mkdir -p $(BUILD_PATH)/.tools
-	@GOTOOLCHAIN=go1.25.0 GOBIN=$(BUILD_PATH)/.tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@GOTOOLCHAIN=go1.26.2 GOBIN=$(BUILD_PATH)/.tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	@$(BUILD_PATH)/.tools/golangci-lint version || true
 	@$(BUILD_PATH)/.tools/golangci-lint run --timeout=5m
 
 .PHONY: lint-fix
 lint-fix:
 	@mkdir -p $(BUILD_PATH)/.tools
-	@GOTOOLCHAIN=go1.25.0 GOBIN=$(BUILD_PATH)/.tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@GOTOOLCHAIN=go1.26.2 GOBIN=$(BUILD_PATH)/.tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	@$(BUILD_PATH)/.tools/golangci-lint run --fix --timeout=5m
 
 .PHONY: lint-full

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/netresearch/ofelia
 
-go 1.26.2
+go 1.26
+
+toolchain go1.26.2
 
 require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/netresearch/ofelia
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2


### PR DESCRIPTION
## Summary
- Bumps the `go` directive in `go.mod` from 1.26.1 to 1.26.2
- Resolves govulncheck failures blocking dependabot PRs (e.g. #556)

## Vulnerabilities fixed by go1.26.2
- GO-2026-4947, GO-2026-4946, GO-2026-4866 (crypto/x509)
- GO-2026-4870 (crypto/tls)
- GO-2026-4865 (html/template)

The two remaining govulncheck findings (GO-2026-4887, GO-2026-4883) are in `github.com/docker/docker` and currently have no fix available upstream; they are out of scope for this PR.

## Test plan
- [ ] CI govulncheck job passes
- [ ] All unit / integration tests pass