### PR TITLE
ci: migrate auto-merge to org-level reusable workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -2,39 +2,12 @@ name: Auto-merge dependency PRs
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-latest
-    if: >-
-      github.event.pull_request.user.login == 'dependabot[bot]' ||
-      github.event.pull_request.user.login == 'renovate[bot]'
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-
-      - name: Auto-approve PR
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr review --approve "$PR_URL"
-
-      - name: Enable auto-merge
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-        run: |
-          STRATEGY=$(gh api "repos/$REPO" --jq '
-            if .allow_squash_merge then "--squash"
-            elif .allow_merge_commit then "--merge"
-            elif .allow_rebase_merge then "--rebase"
-            else "--merge" end')
-          gh pr merge --auto "$STRATEGY" "$PR_URL"
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
## Summary

`.github/workflows/auto-merge.yml` was a full inline duplicate of [`netresearch/.github/.github/workflows/auto-merge-deps.yml`](https://github.com/netresearch/.github/blob/main/.github/workflows/auto-merge-deps.yml) — same harden-runner step, same `gh pr review --approve`, same `gh pr merge --auto` with strategy detection. Replaces the 37-line inline job with a 10-line caller to the org reusable workflow (the pattern all ~30 skill repos now use).

## Why

- **No more per-file Dependabot churn.** Group bumps like #565 currently have to touch `auto-merge.yml` to bump `harden-runner`. After this change, that step lives in the reusable workflow and is maintained once org-wide.
- **Automatic uptake of central improvements.** Future changes to the reusable workflow (new hardening steps, bug fixes, error handling) reach ofelia without a PR here.
- **Smaller blast radius.** The `pull_request_target` write-scoped `GITHUB_TOKEN` is granted by the central workflow instead of each caller.

## Behavior preserved

- Filter: `dependabot[bot]` or `renovate[bot]` only (identical `if:` in the reusable workflow)
- Action: auto-approve + `gh pr merge --auto` with per-repo strategy detection
- Trigger: `pull_request_target` (unchanged)
- Permissions: `contents: write`, `pull-requests: write` (unchanged, now scoped at job level passed to reusable workflow)

No `secrets: inherit` — upstream only uses auto-provided `GITHUB_TOKEN`.

## Note on #565

The in-flight dependabot group bump #565 touches `auto-merge.yml` to bump `harden-runner`. If this PR merges first, that file edit becomes a no-op (file no longer contains the action); the other updates in #565 (ci.yml, mutation.yml, pr-quality.yml, scorecard.yml, cleanup-containers.yml) are unaffected and should still be merged.