### PR TITLE
fix(.gitignore): anchor /ofelia to avoid shadowing source files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .chunkhound/*.json
 .chunkhound/**
 .vscode
-ofelia
+/ofelia
 debug
 build/
 bin/


### PR DESCRIPTION
Fleet-wide .gitignore hardening. Bare `ofelia` matches any file or directory of that name anywhere in the tree; anchor with `/` so only the repo-root binary is ignored. Pre-emptive fix for the same class of bug that hit ldap-manager's cmd/ldap-manager/main_test.go earlier.