### PR TITLE
ci: sync with netresearch/.github templates/go-app

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,16 @@ updates:
       docker:
         patterns: ['*']
 
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      npm:
+        patterns: ['*']
+
   - package-ecosystem: devcontainers
     directory: /
     schedule:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,10 @@ ci:
       - any-glob-to-any-file: ['.github/**/*', 'Makefile']
 dependencies:
   - changed-files:
-      - any-glob-to-any-file: ['go.mod', 'go.sum', 'Dockerfile', '.devcontainer/**/*']
+      - any-glob-to-any-file: ['go.mod', 'go.sum', 'Dockerfile', '.devcontainer/**/*', 'package.json', 'package-lock.json', 'bun.lock', 'bun.lockb', 'yarn.lock', 'tsconfig*.json']
 tests:
   - changed-files:
-      - any-glob-to-any-file: ['**/*_test.go', 'testdata/**/*']
+      - any-glob-to-any-file: ['**/*_test.go', 'testdata/**/*', '**/*.test.ts', '**/*.test.tsx', '**/*.spec.ts']
+frontend:
+  - changed-files:
+      - any-glob-to-any-file: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx', '**/*.css', '**/*.scss', '**/*.html', '**/*.templ']

--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -6,3 +6,6 @@ intentional-drift:
 - path: .github/workflows/container.yml
   reason: "GHCR package name is 'ofelia' (short form), not 'netresearch/ofelia' \u2014\
     \ pre-dates template; renaming would break existing image consumers."
+- path: .github/workflows/ci.yml
+  reason: "enable-integration-tests: true \u2014 repo has integration tests (12 files)\
+    \ that run in CI with -tags=integration"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       enable-fuzz: true
       enable-license-check: true
       enable-codecov: true
+      enable-integration-tests: true
       coverage-threshold: 80.0
     permissions:
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,10 +11,38 @@ on:
 permissions: {}
 
 jobs:
+  detect:
+    name: Detect languages
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    outputs:
+      languages: ${{ steps.detect.outputs.languages }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df # v2.18.0
+        with:
+          egress-policy: audit
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Detect TS/JS + Go
+        id: detect
+        run: |
+          set -euo pipefail
+          langs="go"
+          if [ -f package.json ] || [ -n "$(find . -maxdepth 3 -name '*.ts' -o -name '*.tsx' -o -name '*.mts' 2>/dev/null | head -1)" ]; then
+            langs="${langs},javascript-typescript"
+          fi
+          echo "languages=${langs}" >> "$GITHUB_OUTPUT"
+
   codeql:
+    needs: detect
     uses: netresearch/.github/.github/workflows/codeql.yml@main
     with:
-      languages: go
+      languages: ${{ needs.detect.outputs.languages }}
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,19 +13,14 @@ on:
 permissions: {}
 
 jobs:
+  # Creates the GitHub release shell. Consumers that ship binaries or images
+  # add their own caller of netresearch/.github/.github/workflows/build-go-attest.yml
+  # (matrix over goos/goarch) and/or build-container.yml in a separate PR —
+  # those need per-repo knowledge (binary name, platforms, pre-build-command
+  # for Bun/templ/etc.) that doesn't belong in a one-size-fits-all template.
   create:
     uses: netresearch/.github/.github/workflows/create-release.yml@main
     with:
       tag: ${{ inputs.tag || github.ref_name }}
     permissions:
       contents: write
-
-  binaries:
-    needs: create
-    uses: netresearch/.github/.github/workflows/build-go-attest.yml@main
-    with:
-      tag: ${{ inputs.tag || github.ref_name }}
-    permissions:
-      contents: write
-      id-token: write
-      attestations: write

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Ofelia - a job scheduler
 
+[![Template Drift](https://github.com/netresearch/ofelia/actions/workflows/check-template-drift.yml/badge.svg)](https://github.com/netresearch/ofelia/actions/workflows/check-template-drift.yml)
+[![managed by netresearch/.github templates](https://img.shields.io/badge/template-netresearch%2F.github-2F99A4?logo=github)](https://github.com/netresearch/.github/tree/main/templates/go-app)
+
 [![Go Reference](https://pkg.go.dev/badge/github.com/netresearch/ofelia.svg)](https://pkg.go.dev/github.com/netresearch/ofelia)
 [![CI](https://github.com/netresearch/ofelia/actions/workflows/ci.yml/badge.svg)](https://github.com/netresearch/ofelia/actions/workflows/ci.yml)
 [![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json&style=flat&label=benchmarks&logo=codspeed)](https://codspeed.io/netresearch/ofelia)


### PR DESCRIPTION
Auto-opened by sync-template.sh. Brings this repo back into alignment with the canonical `go-app` template in `netresearch/.github`.

To keep any diverging files, add their paths to `.github/template.yaml`'s `intentional-drift:` list before merging — otherwise the next sync run will revert them.