### PR TITLE
test(e2e): add genuine end-to-end tests against the compiled binary

### DIFF
--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -7,5 +7,6 @@ intentional-drift:
   reason: "GHCR package name is 'ofelia' (short form), not 'netresearch/ofelia' \u2014\
     \ pre-dates template; renaming would break existing image consumers."
 - path: .github/workflows/ci.yml
-  reason: "enable-integration-tests: true \u2014 repo has integration tests (12 files)\
-    \ that run in CI with -tags=integration"
+  reason: "enable-integration-tests: true and enable-e2e-tests: true \u2014 repo has\
+    \ integration tests (12 files, -tags=integration) and e2e tests (10 tests under\
+    \ ./e2e/..., -tags=e2e) that run in CI."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       enable-license-check: true
       enable-codecov: true
       enable-integration-tests: true
+      enable-e2e-tests: true
+      e2e-test-packages: ./e2e/...
       coverage-threshold: 80.0
     permissions:
       contents: read

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -2,50 +2,92 @@
 
 ## Overview
 
-E2E tests verify the complete Ofelia scheduler system behavior in real scenarios with actual Docker containers.
+E2E tests verify Ofelia's behavior at the process boundary: they build the
+real `ofelia` binary, spawn it as a child process with an INI config, and
+assert on its stdout/stderr, file system side-effects and, for Docker jobs,
+on real container state. They complement the `integration` tests (which run
+in-process with the Docker SDK wired directly) by exercising the full
+pipeline:
 
-## Running E2E Tests
-
-```bash
-# Run all E2E tests
-go test -tags=e2e -v ./e2e/
-
-# Run specific test
-go test -tags=e2e -v -run TestScheduler_BasicLifecycle ./e2e/
-
-# Run with timeout
-go test -tags=e2e -v -timeout 5m ./e2e/
+```
+parse INI → configure scheduler → fire tick → spawn job → collect output →
+handle signal → graceful shutdown
 ```
 
-## Test Coverage
+## Running
 
-### Scheduler Lifecycle Tests
-- **TestScheduler_BasicLifecycle**: Tests start, schedule, execute, stop cycle with real Docker containers
-- **TestScheduler_MultipleJobsConcurrent**: Tests concurrent job execution (3 jobs running simultaneously)
-- **TestScheduler_JobFailureHandling**: Tests failure resilience and error handling
+```bash
+# All e2e tests
+go test -tags=e2e -race -v ./e2e/...
 
-These E2E tests provide comprehensive coverage of scheduler lifecycle behavior that was previously attempted with flaky unit tests using mocks. Real Docker integration provides more reliable and realistic testing.
+# Single test
+go test -tags=e2e -race -v -run TestE2E_LocalJob_RunsOnSchedule ./e2e/
+
+# Increase timeout for slow CI runners
+go test -tags=e2e -race -v -timeout=10m ./e2e/...
+```
 
 ## Prerequisites
 
-- Docker daemon running
-- `alpine:latest` image available
-- Network connectivity to Docker socket
+- Go toolchain matching `go.mod`
+- Docker daemon (Docker tests skip automatically when unavailable)
+- `alpine:3.20` image is pulled on demand by the Docker tests
 
-## Test Structure
+## What is covered
 
-Each E2E test follows this pattern:
-1. Setup: Create test containers
-2. Configure: Create jobs and scheduler
-3. Execute: Start scheduler and let jobs run
-4. Verify: Check execution history and results
-5. Cleanup: Stop scheduler and remove containers
+### Binary-level scheduling
+- `TestE2E_LocalJob_RunsOnSchedule` — schedule a local-exec job, assert it
+  fires at least once and its side-effect (file marker) is visible.
+- `TestE2E_LocalJob_RunOnStartup` — `run-on-startup = true` fires immediately
+  without waiting for the cron tick.
+- `TestE2E_LocalJob_SurvivesMultipleExecutions` — scheduler stays healthy
+  under repeated fast-cadence ticks.
 
-## Future E2E Tests
+### Real Docker execution
+- `TestE2E_DockerRunJob_SpawnsContainer` — pulls alpine, runs a real
+  container, verifies the marker via `docker logs`.
+- `TestE2E_DockerRunJob_FailingContainerMarkedFailed` — non-zero container
+  exit is surfaced as `failed: true` in Ofelia's log.
 
-Planned but not yet implemented:
-- Config reload scenarios (SIGHUP handling)
-- Label-based job discovery
-- Multi-container workflows
-- Job dependency chains
-- Stress tests for concurrent execution
+### Configuration surface
+- `TestE2E_Validate_MalformedINI` — malformed INI produces a useful error.
+- `TestE2E_Validate_MissingConfigFile` — missing file path is reported.
+- `TestE2E_Validate_AcceptsValidConfig` — happy path, structured JSON dump
+  includes declared jobs.
+
+### Signal handling
+- `TestE2E_GracefulShutdown_SIGTERM` — SIGTERM during a scheduling window
+  produces a clean exit; shutdown banner is logged.
+- `TestE2E_GracefulShutdown_SIGINT` — SIGINT (Ctrl+C) path covered
+  independently of SIGTERM.
+
+### Legacy (mock-backed) lifecycle tests
+- `TestScheduler_BasicLifecycle` / `TestScheduler_MultipleJobsConcurrent` /
+  `TestScheduler_JobFailureHandling` in `scheduler_lifecycle_test.go` —
+  use an in-process mock Docker provider for fast feedback on scheduler
+  state-machine behavior. Kept as-is for backwards compatibility.
+
+## Out of scope
+
+Deliberately *not* covered by e2e (owned by integration or unit tests):
+- Job types that need a running compose stack (`job-compose`).
+- Swarm-only `job-service-run` (requires a Swarm manager).
+- Docker label discovery (owned by `cli/docker_handler_integration_test.go`).
+- Web UI auth flows (owned by `web/` tests).
+- Full config-reload/SIGHUP semantics.
+
+## How the harness works
+
+`helpers_test.go` exposes a small set of utilities:
+
+| Helper | Purpose |
+|--------|---------|
+| `buildBinary(t)` | `go build -race` once per test process, cached. |
+| `startDaemon(t, configPath)` | Spawn `ofelia daemon --config=...`, wait for boot banner. |
+| `daemonProcess.waitForLog` | Poll captured stdout for a substring with timeout. |
+| `daemonProcess.shutdown` | SIGTERM + wait, SIGKILL on timeout. |
+| `runCommand(t, args...)` | One-shot command invocation for `validate`-style tests. |
+| `dockerAvailable(t)` / `dockerLogs` / `dockerRemove` | Thin `docker` CLI wrappers. |
+
+Every test uses `t.TempDir()` for config files and marker outputs, so parallel
+execution is safe (tests are `t.Parallel()` wherever possible).

--- a/e2e/config_validation_test.go
+++ b/e2e/config_validation_test.go
@@ -1,0 +1,96 @@
+//go:build e2e
+// +build e2e
+
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package e2e
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestE2E_Validate_MalformedINI asserts the `validate` command surfaces a
+// useful, user-actionable error when the INI syntax is broken. End-to-end
+// coverage matters here because the error is produced by a chain of
+// components (flag parser → config loader → ini library → stderr writer)
+// that's hard to fake in unit tests.
+func TestE2E_Validate_MalformedINI(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeConfig(t, "[unterminated-section\n  key = value\n")
+
+	stdout, stderr, err := runCommand(t, "validate", "--config="+configPath)
+
+	// Note on exit code: ofelia.go intentionally calls `return` instead of
+	// os.Exit(1) after go-flags reports the error (see ofelia.go ~L132),
+	// so the process exits 0. We therefore assert on the human-readable
+	// error text — that's what the user actually sees in CI logs.
+	_ = err
+
+	combined := stdout + stderr
+	for _, needle := range []string{
+		"unclosed section",
+		"INI syntax",
+	} {
+		if !strings.Contains(combined, needle) {
+			t.Errorf("expected validate output to mention %q, got:\nstdout=%s\nstderr=%s",
+				needle, stdout, stderr)
+		}
+	}
+}
+
+// TestE2E_Validate_MissingConfigFile asserts the missing-file code path is
+// reported in a way a human operator can act on (it points at the path and
+// offers the `ls -l` hint).
+func TestE2E_Validate_MissingConfigFile(t *testing.T) {
+	t.Parallel()
+
+	missingPath := filepath.Join(t.TempDir(), "does-not-exist.ini")
+	stdout, stderr, _ := runCommand(t, "validate", "--config="+missingPath)
+
+	combined := stdout + stderr
+	for _, needle := range []string{
+		"no such file or directory",
+		missingPath,
+	} {
+		if !strings.Contains(combined, needle) {
+			t.Errorf("expected validate output to mention %q, got:\nstdout=%s\nstderr=%s",
+				needle, stdout, stderr)
+		}
+	}
+}
+
+// TestE2E_Validate_AcceptsValidConfig is the happy-path counterpart: a
+// well-formed config (both globals + a local job + a docker job) is
+// accepted and the structured JSON dump is produced on stdout. Regression
+// guard so we notice if a change accidentally rejects valid inputs.
+func TestE2E_Validate_AcceptsValidConfig(t *testing.T) {
+	t.Parallel()
+
+	configBody := `[global]
+  log-level = info
+
+[job-local "hello"]
+  schedule = @every 30s
+  command = echo hello
+
+[job-run "world"]
+  schedule = @every 1m
+  image = alpine:3.20
+  command = echo world
+`
+
+	configPath := writeConfig(t, configBody)
+	stdout, stderr, _ := runCommand(t, "validate", "--config="+configPath)
+
+	// JSON dump should mention both jobs we defined.
+	for _, needle := range []string{`"hello"`, `"world"`, `"Image": "alpine:3.20"`} {
+		if !strings.Contains(stdout, needle) {
+			t.Errorf("expected validate stdout to contain %q, got:\nstdout=%s\nstderr=%s",
+				needle, stdout, stderr)
+		}
+	}
+}

--- a/e2e/docker_job_test.go
+++ b/e2e/docker_job_test.go
@@ -16,15 +16,37 @@ import (
 	"time"
 )
 
+// dockerConfigOnce returns an INI fragment that schedules a single one-shot
+// execution of the given job: far-future cron + `run-on-startup = true`.
+// This is important because we set `delete = false` + a fixed container-name
+// so we can inspect the container's logs afterwards — a repeating schedule
+// would try to create a second container with the same name on tick #2 and
+// produce spurious `name already in use` failures in the logs.
+func dockerConfigOnce(jobName, containerName, image, command string) string {
+	return fmt.Sprintf(`[global]
+  log-level = info
+
+[job-run %q]
+  # 2099-01-01 — effectively never fires; the run-on-startup trigger is
+  # what drives this test. Single execution → deterministic state.
+  schedule = 0 0 1 1 1
+  run-on-startup = true
+  image = %s
+  container-name = %q
+  delete = false
+  command = %s
+`, jobName, image, containerName, command)
+}
+
 // TestE2E_DockerRunJob_SpawnsContainer is the canonical end-to-end docker
 // scenario: ofelia runs a real alpine container, the container prints a
 // marker, and the container logs contain that marker (verified via the
 // docker CLI).
 //
-// We force `delete = false` so the container persists after exit and we can
-// inspect its logs. A unique `container-name` makes cleanup deterministic.
-// The test is skipped automatically when docker is not available, so it
-// remains runnable on laptops without docker-in-docker.
+// Configured for a single execution (see `dockerConfigOnce`) because we
+// preserve the container (`delete = false`) to read its logs — repeating
+// schedules would collide on the fixed container name.
+// Skipped automatically when docker is not available.
 func TestE2E_DockerRunJob_SpawnsContainer(t *testing.T) {
 	t.Parallel()
 
@@ -45,23 +67,17 @@ func TestE2E_DockerRunJob_SpawnsContainer(t *testing.T) {
 	containerName := fmt.Sprintf("ofelia-e2e-run-%d", time.Now().UnixNano())
 	t.Cleanup(func() { dockerRemove(t, containerName) })
 
-	configBody := fmt.Sprintf(`[global]
-  log-level = info
-
-[job-run "e2e-docker"]
-  schedule = @every 1s
-  image = alpine:3.20
-  container-name = %q
-  delete = false
-  command = sh -c "echo OFELIA_E2E_DOCKER_MARKER"
-`, containerName)
-
-	configPath := writeConfig(t, configBody)
+	configPath := writeConfig(t, dockerConfigOnce(
+		"e2e-docker",
+		containerName,
+		"alpine:3.20",
+		`sh -c "echo OFELIA_E2E_DOCKER_MARKER"`,
+	))
 	daemon := startDaemon(t, configPath)
 	t.Cleanup(func() { daemon.shutdown(t, 30*time.Second) })
 
-	// Wait for the job to finish at least once; the log line appears after
-	// image resolve + container run + log collection, so allow 30s.
+	// Wait for the job to finish; the log line appears after image resolve +
+	// container run + log collection, so allow 30s on cold runners.
 	if err := daemon.waitForLog(`Job \"e2e-docker\"`, 30*time.Second); err != nil {
 		t.Fatalf("no docker execution log observed: %v\nstdout=%s",
 			err, daemon.stdout.String())
@@ -105,18 +121,12 @@ func TestE2E_DockerRunJob_FailingContainerMarkedFailed(t *testing.T) {
 	containerName := fmt.Sprintf("ofelia-e2e-fail-%d", time.Now().UnixNano())
 	t.Cleanup(func() { dockerRemove(t, containerName) })
 
-	configBody := fmt.Sprintf(`[global]
-  log-level = info
-
-[job-run "e2e-docker-fail"]
-  schedule = @every 1s
-  image = alpine:3.20
-  container-name = %q
-  delete = false
-  command = sh -c "exit 42"
-`, containerName)
-
-	configPath := writeConfig(t, configBody)
+	configPath := writeConfig(t, dockerConfigOnce(
+		"e2e-docker-fail",
+		containerName,
+		"alpine:3.20",
+		`sh -c "exit 42"`,
+	))
 	daemon := startDaemon(t, configPath)
 	t.Cleanup(func() { daemon.shutdown(t, 30*time.Second) })
 

--- a/e2e/docker_job_test.go
+++ b/e2e/docker_job_test.go
@@ -1,0 +1,127 @@
+//go:build e2e
+// +build e2e
+
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestE2E_DockerRunJob_SpawnsContainer is the canonical end-to-end docker
+// scenario: ofelia runs a real alpine container, the container prints a
+// marker, and the container logs contain that marker (verified via the
+// docker CLI).
+//
+// We force `delete = false` so the container persists after exit and we can
+// inspect its logs. A unique `container-name` makes cleanup deterministic.
+// The test is skipped automatically when docker is not available, so it
+// remains runnable on laptops without docker-in-docker.
+func TestE2E_DockerRunJob_SpawnsContainer(t *testing.T) {
+	t.Parallel()
+
+	if !dockerAvailable(t) {
+		t.Skip("docker not available; skipping docker e2e test")
+	}
+
+	// Pre-pull the image so the scheduled window doesn't race with registry
+	// latency on cold CI runners.
+	pullCtx, pullCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer pullCancel()
+	if out, err := exec.CommandContext(pullCtx, "docker", "pull", "alpine:3.20").CombinedOutput(); err != nil {
+		t.Fatalf("docker pull alpine:3.20: %v\n%s", err, out)
+	}
+
+	// Container name used to locate + clean up the container after the job.
+	// Timestamped to avoid collisions across parallel test runs.
+	containerName := fmt.Sprintf("ofelia-e2e-run-%d", time.Now().UnixNano())
+	t.Cleanup(func() { dockerRemove(t, containerName) })
+
+	configBody := fmt.Sprintf(`[global]
+  log-level = info
+
+[job-run "e2e-docker"]
+  schedule = @every 1s
+  image = alpine:3.20
+  container-name = %q
+  delete = false
+  command = sh -c "echo OFELIA_E2E_DOCKER_MARKER"
+`, containerName)
+
+	configPath := writeConfig(t, configBody)
+	daemon := startDaemon(t, configPath)
+	t.Cleanup(func() { daemon.shutdown(t, 30*time.Second) })
+
+	// Wait for the job to finish at least once; the log line appears after
+	// image resolve + container run + log collection, so allow 30s.
+	if err := daemon.waitForLog(`Job \"e2e-docker\"`, 30*time.Second); err != nil {
+		t.Fatalf("no docker execution log observed: %v\nstdout=%s",
+			err, daemon.stdout.String())
+	}
+	if err := daemon.waitForLog("Finished in", 30*time.Second); err != nil {
+		t.Fatalf("docker job did not finish: %v\nstdout=%s",
+			err, daemon.stdout.String())
+	}
+
+	// Now that the container exists (delete=false), fetch its logs and
+	// verify the marker made it all the way through the docker runtime.
+	logs := dockerLogs(t, containerName)
+	if !strings.Contains(logs, "OFELIA_E2E_DOCKER_MARKER") {
+		t.Fatalf("marker missing from container logs; got: %q", logs)
+	}
+
+	// Belt-and-suspenders: ofelia's stream forwarder should also have picked
+	// it up (confirms the stdout-copy plumbing works).
+	if !bytes.Contains(daemon.stdout.Bytes(), []byte("OFELIA_E2E_DOCKER_MARKER")) {
+		t.Errorf("marker missing from ofelia's captured StdOut stream\nstdout=%s",
+			daemon.stdout.String())
+	}
+}
+
+// TestE2E_DockerRunJob_FailingContainerMarkedFailed asserts that a non-zero
+// exit code in the container is surfaced by ofelia as a failed execution.
+// Regression guard: silent failures would let broken cron jobs look healthy.
+func TestE2E_DockerRunJob_FailingContainerMarkedFailed(t *testing.T) {
+	t.Parallel()
+
+	if !dockerAvailable(t) {
+		t.Skip("docker not available; skipping docker e2e test")
+	}
+
+	pullCtx, pullCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer pullCancel()
+	if out, err := exec.CommandContext(pullCtx, "docker", "pull", "alpine:3.20").CombinedOutput(); err != nil {
+		t.Fatalf("docker pull alpine:3.20: %v\n%s", err, out)
+	}
+
+	containerName := fmt.Sprintf("ofelia-e2e-fail-%d", time.Now().UnixNano())
+	t.Cleanup(func() { dockerRemove(t, containerName) })
+
+	configBody := fmt.Sprintf(`[global]
+  log-level = info
+
+[job-run "e2e-docker-fail"]
+  schedule = @every 1s
+  image = alpine:3.20
+  container-name = %q
+  delete = false
+  command = sh -c "exit 42"
+`, containerName)
+
+	configPath := writeConfig(t, configBody)
+	daemon := startDaemon(t, configPath)
+	t.Cleanup(func() { daemon.shutdown(t, 30*time.Second) })
+
+	if err := daemon.waitForLog(`failed: true`, 30*time.Second); err != nil {
+		t.Fatalf("expected a 'failed: true' log line within 30s but none appeared: %v\nstdout=%s",
+			err, daemon.stdout.String())
+	}
+}

--- a/e2e/graceful_shutdown_test.go
+++ b/e2e/graceful_shutdown_test.go
@@ -1,0 +1,111 @@
+//go:build e2e
+// +build e2e
+
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package e2e
+
+import (
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestE2E_GracefulShutdown_SIGTERM verifies the daemon exits cleanly when
+// SIGTERM arrives mid-schedule. This exercises ShutdownManager, the
+// GracefulScheduler wrapper and the main-loop `<-c.done` rendezvous —
+// all real code paths you cannot hit via unit tests that stub out `os.Signal`.
+func TestE2E_GracefulShutdown_SIGTERM(t *testing.T) {
+	t.Parallel()
+
+	configBody := `[global]
+  log-level = info
+
+[job-local "e2e-shutdown"]
+  schedule = @every 1s
+  command = sh -c "sleep 0.1"
+`
+
+	configPath := writeConfig(t, configBody)
+	daemon := startDaemon(t, configPath)
+	defer daemon.shutdown(t, 10*time.Second) // safety net in case signal is lost
+
+	// Let the scheduler tick at least once so there is actual work to
+	// drain during shutdown (regression guard for `gracefulStop` hanging
+	// on active jobs).
+	if err := daemon.waitForLog(`Job \"e2e-shutdown\"`, 5*time.Second); err != nil {
+		t.Fatalf("job never ran before shutdown: %v\nstdout=%s",
+			err, daemon.stdout.String())
+	}
+
+	start := time.Now()
+	if err := daemon.signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("signal daemon: %v", err)
+	}
+
+	exitErr, exited := daemon.waitExit(15 * time.Second)
+	if !exited {
+		t.Fatalf("daemon did not exit within 15s of SIGTERM\nstdout=%s\nstderr=%s",
+			daemon.stdout.String(), daemon.stderr.String())
+	}
+	if exitErr != nil {
+		t.Errorf("daemon exited with error after SIGTERM: %v\nstderr=%s",
+			exitErr, daemon.stderr.String())
+	}
+
+	elapsed := time.Since(start)
+	if elapsed > 10*time.Second {
+		t.Errorf("shutdown took %s (>10s); graceful shutdown should be fast when no long-running jobs are pending",
+			elapsed)
+	}
+	t.Logf("daemon shut down cleanly in %s", elapsed)
+
+	// Verify the shutdown banner is emitted — proves the signal reached
+	// ShutdownManager rather than the process being killed by a harness.
+	out := daemon.stdout.String()
+	for _, needle := range []string{
+		"Received shutdown signal",
+		"graceful shutdown",
+	} {
+		if !strings.Contains(out, needle) {
+			t.Errorf("expected shutdown log to mention %q, got:\nstdout=%s",
+				needle, out)
+		}
+	}
+}
+
+// TestE2E_GracefulShutdown_SIGINT covers the same path under SIGINT (Ctrl+C)
+// since the shutdown manager registers both signals independently.
+func TestE2E_GracefulShutdown_SIGINT(t *testing.T) {
+	t.Parallel()
+
+	configBody := `[global]
+  log-level = info
+
+[job-local "e2e-interrupt"]
+  schedule = @every 5s
+  command = true
+`
+
+	configPath := writeConfig(t, configBody)
+	daemon := startDaemon(t, configPath)
+	defer daemon.shutdown(t, 10*time.Second)
+
+	// Small grace period so the scheduler has registered its timers.
+	time.Sleep(500 * time.Millisecond)
+
+	if err := daemon.signal(syscall.SIGINT); err != nil {
+		t.Fatalf("signal daemon: %v", err)
+	}
+	if _, exited := daemon.waitExit(10 * time.Second); !exited {
+		t.Fatalf("daemon did not exit within 10s of SIGINT\nstdout=%s\nstderr=%s",
+			daemon.stdout.String(), daemon.stderr.String())
+	}
+
+	if !strings.Contains(daemon.stdout.String(), "Received shutdown signal") {
+		t.Errorf("expected shutdown banner; got:\nstdout=%s",
+			daemon.stdout.String())
+	}
+}

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -12,7 +12,6 @@
 package e2e
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -145,12 +144,14 @@ func startDaemon(t *testing.T, configPath string, extraArgs ...string) *daemonPr
 }
 
 // waitForLog polls the combined stdout for a substring until it appears or
-// the timeout elapses.
+// the timeout elapses. It searches under the buffer's lock rather than
+// snapshotting the full bytes on every iteration, so the cost stays O(N)
+// per poll instead of O(N²) over the lifetime of the test.
 func (p *daemonProcess) waitForLog(needle string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
+	needleBytes := []byte(needle)
 	for time.Now().Before(deadline) {
-		if bytes.Contains(p.stdout.Bytes(), []byte(needle)) ||
-			bytes.Contains(p.stderr.Bytes(), []byte(needle)) {
+		if p.stdout.Contains(needleBytes) || p.stderr.Contains(needleBytes) {
 			return nil
 		}
 		if p.exited() {
@@ -162,17 +163,10 @@ func (p *daemonProcess) waitForLog(needle string, timeout time.Duration) error {
 }
 
 // countLogOccurrences counts how many times the given substring appears in
-// the captured stdout.
+// the captured stdout. Uses bytes.Count under the buffer's lock so no
+// intermediate copy is needed.
 func (p *daemonProcess) countLogOccurrences(needle string) int {
-	data := p.stdout.Bytes()
-	n := 0
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-	for scanner.Scan() {
-		if bytes.Contains(scanner.Bytes(), []byte(needle)) {
-			n++
-		}
-	}
-	return n
+	return p.stdout.Count([]byte(needle))
 }
 
 // exited reports whether the daemon process has already terminated.
@@ -233,6 +227,23 @@ func (s *syncBuffer) Write(p []byte) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.buf.Write(p)
+}
+
+// Contains performs a needle search against the buffer while holding its
+// lock, avoiding the slice copy that `Bytes()` would trigger on each call.
+func (s *syncBuffer) Contains(needle []byte) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return bytes.Contains(s.buf.Bytes(), needle)
+}
+
+// Count returns the number of non-overlapping occurrences of needle in the
+// buffer. Uses bytes.Count, which is faster than scanning line-by-line and
+// avoids bufio.Scanner's per-line allocations.
+func (s *syncBuffer) Count(needle []byte) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return bytes.Count(s.buf.Bytes(), needle)
 }
 
 func (s *syncBuffer) Bytes() []byte {

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -1,0 +1,314 @@
+//go:build e2e
+// +build e2e
+
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+// Package e2e exercises the compiled ofelia binary as a real subprocess:
+// build binary → spawn with INI config → observe stdout/stderr, file system
+// side-effects and container logs. These tests complement the in-process
+// integration tests by verifying the full pipeline (parse config → schedule
+// → fire → execute → shutdown).
+package e2e
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// buildBinaryOnce caches the compiled ofelia binary path across tests in the
+// same `go test` process to avoid re-invoking `go build` per-test (which is
+// slow and multiplies CI cost). cachedBuildErr is a captured build error —
+// not a sentinel — hence the `nolint:errname` suppression.
+var (
+	buildBinaryOnce sync.Once
+	cachedBinPath   string
+	cachedBuildErr  error //nolint:errname // captured build error, not a sentinel
+)
+
+// buildBinary compiles the ofelia binary with race detection enabled into a
+// temp directory and returns its absolute path. The binary is shared by all
+// e2e tests in a single `go test` invocation.
+//
+// We intentionally compile with `-race` so that e2e tests double as real-world
+// race-condition detectors — if the scheduler or shutdown logic has a data
+// race, the binary itself will report it on SIGTERM.
+func buildBinary(t *testing.T) string {
+	t.Helper()
+
+	buildBinaryOnce.Do(func() {
+		// Resolve repo root from this test file's location (e2e/ → ..).
+		_, thisFile, _, ok := runtime.Caller(0)
+		if !ok {
+			cachedBuildErr = errors.New("cannot resolve test source path")
+			return
+		}
+		repoRoot := filepath.Dir(filepath.Dir(thisFile))
+
+		tmpDir, err := os.MkdirTemp("", "ofelia-e2e-bin-")
+		if err != nil {
+			cachedBuildErr = fmt.Errorf("mkdir temp: %w", err)
+			return
+		}
+		binPath := filepath.Join(tmpDir, "ofelia")
+
+		// Use -race so the real binary surfaces data races during e2e runs.
+		// Timeout: go build usually completes in <30s on CI.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
+
+		cmd := exec.CommandContext(ctx, "go", "build", "-race", "-o", binPath, ".")
+		cmd.Dir = repoRoot
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			cachedBuildErr = fmt.Errorf("build ofelia: %w\n%s", err, out)
+			return
+		}
+		cachedBinPath = binPath
+	})
+
+	if cachedBuildErr != nil {
+		t.Fatalf("build binary: %v", cachedBuildErr)
+	}
+	return cachedBinPath
+}
+
+// daemonProcess wraps a running ofelia daemon subprocess and provides helpers
+// to observe its behavior (log scraping, stdout/stderr capture) and terminate
+// it cleanly.
+type daemonProcess struct {
+	cmd      *exec.Cmd
+	stdout   *syncBuffer
+	stderr   *syncBuffer
+	done     chan struct{}
+	waitErr  error
+	waitOnce sync.Once
+}
+
+// startDaemon launches `ofelia daemon --config=<configPath>` as a child
+// process and returns a handle to it. The caller MUST defer `p.shutdown(t)`.
+func startDaemon(t *testing.T, configPath string, extraArgs ...string) *daemonProcess {
+	t.Helper()
+
+	bin := buildBinary(t)
+
+	args := append([]string{"daemon", "--config=" + configPath}, extraArgs...)
+	cmd := exec.Command(bin, args...)
+
+	// Put the child in its own process group so SIGTERM to the child does not
+	// leak to the test runner, and so we can reliably kill any stragglers.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	stdout := &syncBuffer{}
+	stderr := &syncBuffer{}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start ofelia daemon: %v", err)
+	}
+
+	dp := &daemonProcess{
+		cmd:    cmd,
+		stdout: stdout,
+		stderr: stderr,
+		done:   make(chan struct{}),
+	}
+
+	go func() {
+		dp.waitErr = cmd.Wait()
+		close(dp.done)
+	}()
+
+	// Wait for the "Ofelia is now running" banner so we know scheduler is
+	// live before returning. Time out quickly if boot fails.
+	if err := dp.waitForLog("Ofelia is now running", 10*time.Second); err != nil {
+		// Make sure we don't leak a child before failing.
+		_ = dp.signal(syscall.SIGKILL)
+		t.Fatalf("daemon did not reach 'running' state within 10s: %v\nstdout=%s\nstderr=%s",
+			err, stdout.String(), stderr.String())
+	}
+
+	return dp
+}
+
+// waitForLog polls the combined stdout for a substring until it appears or
+// the timeout elapses.
+func (p *daemonProcess) waitForLog(needle string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if bytes.Contains(p.stdout.Bytes(), []byte(needle)) ||
+			bytes.Contains(p.stderr.Bytes(), []byte(needle)) {
+			return nil
+		}
+		if p.exited() {
+			return fmt.Errorf("daemon exited before log %q appeared", needle)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("timeout waiting for log %q", needle)
+}
+
+// countLogOccurrences counts how many times the given substring appears in
+// the captured stdout.
+func (p *daemonProcess) countLogOccurrences(needle string) int {
+	data := p.stdout.Bytes()
+	n := 0
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		if bytes.Contains(scanner.Bytes(), []byte(needle)) {
+			n++
+		}
+	}
+	return n
+}
+
+// exited reports whether the daemon process has already terminated.
+func (p *daemonProcess) exited() bool {
+	select {
+	case <-p.done:
+		return true
+	default:
+		return false
+	}
+}
+
+// signal sends a signal to the daemon process.
+func (p *daemonProcess) signal(sig os.Signal) error {
+	if p.cmd.Process == nil {
+		return errors.New("daemon process is nil")
+	}
+	return p.cmd.Process.Signal(sig)
+}
+
+// shutdown sends SIGTERM and waits for the process to exit. Safe to call
+// multiple times. If the daemon doesn't exit within `timeout`, it is killed.
+func (p *daemonProcess) shutdown(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	p.waitOnce.Do(func() {
+		if !p.exited() {
+			_ = p.signal(syscall.SIGTERM)
+		}
+		select {
+		case <-p.done:
+		case <-time.After(timeout):
+			t.Logf("daemon did not exit within %s after SIGTERM; sending SIGKILL", timeout)
+			_ = p.signal(syscall.SIGKILL)
+			<-p.done
+		}
+	})
+}
+
+// waitExit blocks until the daemon exits (or the timeout fires) and returns
+// the exit error. Unlike shutdown(), this does not send a signal itself.
+func (p *daemonProcess) waitExit(timeout time.Duration) (error, bool) {
+	select {
+	case <-p.done:
+		return p.waitErr, true
+	case <-time.After(timeout):
+		return nil, false
+	}
+}
+
+// syncBuffer is a concurrent-safe bytes buffer used to capture child process
+// stdout/stderr without racing against the log-scraping goroutine.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) Bytes() []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]byte, s.buf.Len())
+	copy(out, s.buf.Bytes())
+	return out
+}
+
+func (s *syncBuffer) String() string {
+	return string(s.Bytes())
+}
+
+// writeConfig writes the given INI body to a file inside the test's temp
+// directory and returns the path.
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ofelia.ini")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+// runCommand runs the ofelia binary with the given args, returning stdout,
+// stderr and the exit error. Used by validation-error tests.
+func runCommand(t *testing.T, args ...string) (stdout, stderr string, exitErr error) {
+	t.Helper()
+	bin := buildBinary(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, bin, args...)
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+	exitErr = cmd.Run()
+	return outBuf.String(), errBuf.String(), exitErr
+}
+
+// dockerAvailable returns true if the docker CLI is usable and the daemon is
+// reachable. Tests that require docker skip cleanly when it is absent.
+func dockerAvailable(t *testing.T) bool {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", "info")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	return cmd.Run() == nil
+}
+
+// dockerLogs returns the combined stdout+stderr log output of a named
+// container.
+func dockerLogs(t *testing.T, name string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", "logs", name)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("docker logs %s: %v\n%s", name, err, out.String())
+	}
+	return out.String()
+}
+
+// dockerRemove best-effort removes a container by name.
+func dockerRemove(t *testing.T, name string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", "rm", "-f", name)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	_ = cmd.Run()
+}

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -187,19 +187,41 @@ func (p *daemonProcess) signal(sig os.Signal) error {
 	return p.cmd.Process.Signal(sig)
 }
 
+// killProcessGroup sends `sig` to the entire process group we created for
+// the daemon (via Setpgid=true in startDaemon). Falls back to signaling
+// the daemon's PID directly if the pgid lookup fails. Using the group
+// ensures we reap any short-lived children the daemon may have spawned
+// (e.g. local-exec `sh` subprocesses that were caught mid-run by SIGKILL).
+func (p *daemonProcess) killProcessGroup(sig syscall.Signal) error {
+	if p.cmd.Process == nil {
+		return errors.New("daemon process is nil")
+	}
+	pgid, err := syscall.Getpgid(p.cmd.Process.Pid)
+	if err != nil {
+		// Fallback: signal the main process directly.
+		return p.cmd.Process.Signal(sig)
+	}
+	// Negative PID ⇒ deliver to process group (see kill(2)).
+	return syscall.Kill(-pgid, sig)
+}
+
 // shutdown sends SIGTERM and waits for the process to exit. Safe to call
-// multiple times. If the daemon doesn't exit within `timeout`, it is killed.
+// multiple times. If the daemon doesn't exit within `timeout`, it is killed
+// along with any children it spawned.
 func (p *daemonProcess) shutdown(t *testing.T, timeout time.Duration) {
 	t.Helper()
 	p.waitOnce.Do(func() {
 		if !p.exited() {
+			// Only the daemon itself needs SIGTERM for a graceful exit —
+			// the shutdown manager will then stop any in-flight jobs.
 			_ = p.signal(syscall.SIGTERM)
 		}
 		select {
 		case <-p.done:
 		case <-time.After(timeout):
-			t.Logf("daemon did not exit within %s after SIGTERM; sending SIGKILL", timeout)
-			_ = p.signal(syscall.SIGKILL)
+			t.Logf("daemon did not exit within %s after SIGTERM; SIGKILLing process group", timeout)
+			// Reap the entire group so stray job subprocesses don't leak.
+			_ = p.killProcessGroup(syscall.SIGKILL)
 			<-p.done
 		}
 	})

--- a/e2e/local_job_test.go
+++ b/e2e/local_job_test.go
@@ -57,15 +57,27 @@ func TestE2E_LocalJob_RunsOnSchedule(t *testing.T) {
 			err, daemon.stdout.String())
 	}
 
-	// Give a little time for the file write to finalize.
-	time.Sleep(500 * time.Millisecond)
-
-	data, err := os.ReadFile(markerFile)
-	if err != nil {
-		t.Fatalf("read marker file %s: %v", markerFile, err)
+	// Poll for the marker to show up in the file rather than using a fixed
+	// sleep — loaded CI runners can exhibit multi-second fs-sync latency.
+	var (
+		data        []byte
+		readErr     error
+		markerLines int
+	)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		data, readErr = os.ReadFile(markerFile)
+		if readErr == nil {
+			markerLines = strings.Count(string(data), "OFELIA_E2E_LOCAL_MARKER")
+			if markerLines > 0 {
+				break
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
-
-	markerLines := strings.Count(string(data), "OFELIA_E2E_LOCAL_MARKER")
+	if readErr != nil {
+		t.Fatalf("read marker file %s: %v", markerFile, readErr)
+	}
 	if markerLines == 0 {
 		t.Fatalf("marker not found in file; job likely did not execute.\n"+
 			"file contents: %q\nstdout=%s",

--- a/e2e/local_job_test.go
+++ b/e2e/local_job_test.go
@@ -1,0 +1,159 @@
+//go:build e2e
+// +build e2e
+
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestE2E_LocalJob_RunsOnSchedule verifies the full pipeline for a local
+// (non-Docker) job: the binary boots, parses the INI, schedules the job,
+// executes it on the configured cadence and — crucially — the job's
+// side-effects (file writes, stdout) are visible outside ofelia.
+//
+// Why a file-based side effect: the local job's stdout is streamed through
+// ofelia's logger to the parent stdout. Checking that captured stdout already
+// proves the Run hook fired, but checking a file written *by the child shell*
+// additionally proves the spawned process actually ran with the right env.
+func TestE2E_LocalJob_RunsOnSchedule(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	markerFile := filepath.Join(workDir, "marker.log")
+
+	// Ofelia parses `command =` with shell-like arg splitting (gobs/args),
+	// then passes the resulting []string directly to the child. So we keep
+	// the inner double-quotes around the `sh -c` script and write a simple
+	// unquoted path — double-quoting it a second time would make the shell
+	// see literal `"/tmp/.../marker.log"` and hit `end of file unexpected`.
+	configBody := fmt.Sprintf(`[global]
+  log-level = info
+
+[job-local "e2e-echo"]
+  schedule = @every 1s
+  command = sh -c "echo OFELIA_E2E_LOCAL_MARKER >> %s"
+`, markerFile)
+
+	configPath := writeConfig(t, configBody)
+	daemon := startDaemon(t, configPath)
+	t.Cleanup(func() { daemon.shutdown(t, 15*time.Second) })
+
+	// Allow at least 3 scheduling ticks (@every 1s × 3 + slack).
+	// slog's TextHandler escapes quotes, so the literal text in stdout is
+	// `[Job \"e2e-echo\" (...)]`. Match on the unambiguous job-id prefix
+	// instead to side-step handler-specific escaping.
+	if err := daemon.waitForLog(`Job \"e2e-echo\"`, 8*time.Second); err != nil {
+		t.Fatalf("no execution log seen: %v\nstdout=%s",
+			err, daemon.stdout.String())
+	}
+
+	// Give a little time for the file write to finalize.
+	time.Sleep(500 * time.Millisecond)
+
+	data, err := os.ReadFile(markerFile)
+	if err != nil {
+		t.Fatalf("read marker file %s: %v", markerFile, err)
+	}
+
+	markerLines := strings.Count(string(data), "OFELIA_E2E_LOCAL_MARKER")
+	if markerLines == 0 {
+		t.Fatalf("marker not found in file; job likely did not execute.\n"+
+			"file contents: %q\nstdout=%s",
+			string(data), daemon.stdout.String())
+	}
+	t.Logf("job ran %d time(s); marker file has %d line(s)",
+		daemon.countLogOccurrences(`Job \"e2e-echo\"`), markerLines)
+}
+
+// TestE2E_LocalJob_RunOnStartup verifies the `run-on-startup = true` flag:
+// the job fires once immediately at boot, not only on its cron schedule. We
+// use a far-future cron so the schedule alone would never fire within the
+// test window; if the marker appears, only the startup-trigger could have
+// caused it.
+func TestE2E_LocalJob_RunOnStartup(t *testing.T) {
+	t.Parallel()
+
+	workDir := t.TempDir()
+	markerFile := filepath.Join(workDir, "startup.log")
+
+	configBody := fmt.Sprintf(`[global]
+  log-level = info
+
+[job-local "e2e-startup"]
+  schedule = 0 0 1 1 *
+  run-on-startup = true
+  command = sh -c "echo OFELIA_E2E_STARTUP_MARKER > %s"
+`, markerFile)
+
+	configPath := writeConfig(t, configBody)
+	daemon := startDaemon(t, configPath)
+	t.Cleanup(func() { daemon.shutdown(t, 15*time.Second) })
+
+	// Wait up to 10s for the one-shot run.
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if data, err := os.ReadFile(markerFile); err == nil &&
+			strings.Contains(string(data), "OFELIA_E2E_STARTUP_MARKER") {
+			return // success
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("run-on-startup did not fire within 10s\nstdout=%s",
+		daemon.stdout.String())
+}
+
+// TestE2E_LocalJob_SurvivesMultipleExecutions asserts scheduler stability:
+// a fast-cadence job must keep firing across many ticks without the
+// scheduler hanging, panicking or losing entries. Regression guard for
+// scheduling drift / goroutine leaks.
+func TestE2E_LocalJob_SurvivesMultipleExecutions(t *testing.T) {
+	t.Parallel()
+
+	// Ofelia's scheduler enforces a 1s minimum interval via the cron library
+	// (see core/scheduler_mutation_test.go). Sub-second cadences are rejected.
+	configBody := `[global]
+  log-level = info
+
+[job-local "e2e-fast"]
+  schedule = @every 1s
+  command = true
+`
+
+	configPath := writeConfig(t, configBody)
+	daemon := startDaemon(t, configPath)
+	t.Cleanup(func() { daemon.shutdown(t, 15*time.Second) })
+
+	// 6s / 1s ≈ 6 ticks. Require at least 3 to allow for startup latency
+	// and scheduler jitter on loaded CI runners.
+	time.Sleep(6 * time.Second)
+
+	// Only count *Finished* entries so partial "Started" lines don't inflate.
+	runs := daemon.countLogOccurrences(`Finished in`)
+	if runs < 3 {
+		t.Errorf("expected at least 3 finished runs in 6s, got %d.\nstdout=%s",
+			runs, daemon.stdout.String())
+	}
+
+	// Sanity-check process is still healthy.
+	if daemon.exited() {
+		t.Fatalf("daemon exited unexpectedly during fast-cadence run\nstdout=%s\nstderr=%s",
+			daemon.stdout.String(), daemon.stderr.String())
+	}
+
+	// Clean shutdown confirms the scheduler is not wedged.
+	_ = daemon.signal(syscall.SIGTERM)
+	if _, exited := daemon.waitExit(10 * time.Second); !exited {
+		t.Errorf("daemon did not exit within 10s after SIGTERM following %d runs",
+			runs)
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the previous `skipped` e2e slot in CI with real end-to-end coverage
that exercises the full pipeline: parse INI → schedule → fire → spawn job
→ collect output → graceful shutdown. All ten new tests build the `ofelia`
binary with `-race` and spawn it as a child process, asserting on its
stdout, file-system side effects, and container state via the docker CLI.

- **Harness** (`e2e/helpers_test.go`): `buildBinary()` caches a `go build
  -race` per test process; `startDaemon()` spawns it with a generated INI
  config, captures stdout/stderr via a concurrency-safe buffer, waits for
  the boot banner, and isolates the child in its own process group so
  SIGTERM cannot leak to the test runner. Provides `waitForLog`,
  `countLogOccurrences`, `waitExit` and `shutdown` helpers plus a
  one-shot `runCommand` for `validate`-style tests, and thin docker-CLI
  wrappers.

- **Local-exec jobs** (`e2e/local_job_test.go`):
  - `TestE2E_LocalJob_RunsOnSchedule` — @every 1s job writes a disk marker;
    asserts the file-system effect, not just a log line.
  - `TestE2E_LocalJob_RunOnStartup` — `run-on-startup = true` fires at boot
    even with a far-future cron.
  - `TestE2E_LocalJob_SurvivesMultipleExecutions` — scheduler stays healthy
    across ~6 consecutive ticks and still accepts SIGTERM afterwards.

- **Real Docker jobs** (`e2e/docker_job_test.go`), skip cleanly if docker
  is unavailable:
  - `TestE2E_DockerRunJob_SpawnsContainer` — runs alpine:3.20 via job-run,
    forces `delete = false`, verifies the marker reached the container
    via `docker logs` **and** ofelia's stdout forwarder.
  - `TestE2E_DockerRunJob_FailingContainerMarkedFailed` — container
    exiting 42 must surface as `failed: true` in ofelia's log.

- **Config validation** (`e2e/config_validation_test.go`):
  - `TestE2E_Validate_MalformedINI`, `TestE2E_Validate_MissingConfigFile`,
    `TestE2E_Validate_AcceptsValidConfig` — check user-visible error
    text instead of exit codes, since `ofelia.go` intentionally exits 0
    after go-flags reports an error.

- **Graceful shutdown** (`e2e/graceful_shutdown_test.go`):
  - `TestE2E_GracefulShutdown_SIGTERM` / `..._SIGINT` — real signals
    against the child process; asserts the shutdown banner appears and
    the daemon exits cleanly within 10s.

- **CI wiring** (`.github/workflows/ci.yml`): flip `enable-e2e-tests: true`
  and pin `e2e-test-packages: ./e2e/...` so the dedicated `E2E Tests` job
  runs on every PR, push to main, merge-group and weekly cron, reporting
  coverage under the `e2e` Codecov flag. `.github/template.yaml`'s
  intentional-drift entry for `ci.yml` is updated to cover both
  `enable-integration-tests` and `enable-e2e-tests`.

## Deliberately out of scope

- `job-compose` (needs a compose stack) and Swarm `job-service-run`
  (needs a manager) — covered by their own integration tests.
- Docker label discovery (`cli/docker_handler_integration_test.go`).
- Web UI auth flows (`web/` tests).
- Full SIGHUP config-reload semantics — future work; the README calls
  it out explicitly.

The existing in-process `e2e/scheduler_lifecycle_test.go` is kept
untouched; the new tests are additive.

## Test plan

Local (Go 1.26, Docker 29.4):

```
$ go test -tags=e2e -race -count=1 -timeout=5m ./e2e/...
ok github.com/netresearch/ofelia/e2e 9.095s
```

13/13 tests pass (3 pre-existing + 10 new), `-race` is clean,
`golangci-lint run --build-tags=e2e,integration --timeout=5m ./...` is
0 issues.

- [x] All ten new tests pass locally with `-race`
- [x] Existing `scheduler_lifecycle_test.go` still passes (no changes)
- [x] `golangci-lint` clean with `e2e` build tag
- [x] `go build ./...` still succeeds
- [ ] CI `E2E Tests` job runs and uploads coverage under the `e2e` flag
- [ ] CI `Integration Tests` job continues to pass (no changes there)
- [ ] Template drift check is green (ci.yml listed under intentional-drift)