### PR TITLE
ci: sync with netresearch/.github templates/go-app

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -13,3 +13,4 @@ jobs:
     uses: netresearch/.github/.github/workflows/gitleaks.yml@main
     permissions:
       contents: read
+      security-events: write


### PR DESCRIPTION
Auto-opened by sync-template.sh. Brings this repo back into alignment with the canonical `go-app` template in `netresearch/.github`.

To keep any diverging files, add their paths to `.github/template.yaml`'s `intentional-drift:` list before merging — otherwise the next sync run will revert them.