### PR TITLE
fix(container): grant security-events: write to satisfy reusable

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -22,3 +22,4 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      security-events: write


### PR DESCRIPTION
## Summary

ofelia's \`container.yml\` caller was startup_failure'ing on every main push because it granted \`contents/packages/id-token/attestations\` but **not** \`security-events: write\` — which the \`build-container.yml\` reusable job declares (it needs it to upload trivy SARIF scan results). GitHub Actions rejects a reusable-workflow caller that grants fewer permissions than the reusable requires, so the whole workflow never started.

The go-app template was updated in netresearch/.github#60 to grant this permission, but ofelia has \`container.yml\` marked as intentional-drift (to keep the short \`image-name: ofelia\` form instead of \`netresearch/ofelia\`), so the sync wouldn't overwrite the file — this fix goes in manually. The short image-name stays as is.

## Test plan

- [x] YAML parses.
- [ ] After merge the next main push must show Container completing (or at least past startup_failure).