### PR TITLE
ci: sync with netresearch/.github templates/go-app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,11 +77,14 @@ jobs:
       # version package (ofelia uses main.* directly; ldap-manager
       # forwards into internal/version.*). Empty values are a silent
       # no-op for repos that don't declare the corresponding var.
+      # main.buildTime is injected via auto-build-timestamp (below)
+      # so it stays populated on workflow_dispatch backfills where
+      # github.event.head_commit is absent.
       ldflags: >-
         -s -w
         -X main.version=${{ needs.create-release.outputs.tag }}
         -X main.build=${{ needs.create-release.outputs.sha }}
-        -X main.buildTime=${{ github.event.head_commit.timestamp }}
+      auto-build-timestamp: true
       ref: ${{ needs.create-release.outputs.tag }}
       release-tag: ${{ needs.create-release.outputs.tag }}
       sbom: true


### PR DESCRIPTION
Auto-opened by sync-template.sh. Brings this repo back into alignment with the canonical `go-app` template in `netresearch/.github`.

To keep any diverging files, add their paths to `.github/template.yaml`'s `intentional-drift:` list before merging — otherwise the next sync run will revert them.