### PR TITLE
fix(cli)!: do not filter out "com.docker.compose.service" label

### DIFF
--- a/cli/docker-labels.go
+++ b/cli/docker-labels.go
@@ -269,7 +269,7 @@ func (c *Config) splitContainersLabelsIntoJobMapsByType(containers []DockerConta
 		containerExecJobs := make(map[string]map[string]any)
 
 		for k, jobParamValue := range labelSet {
-			if k == requiredLabel || k == serviceLabel {
+			if k == requiredLabel || k == serviceLabel || k == dockerComposeServiceLabel {
 				// Do not track internal labels as global config parameters.
 				continue
 			}

--- a/cli/docker_config_handler.go
+++ b/cli/docker_config_handler.go
@@ -316,7 +316,7 @@ func (c *DockerHandler) GetDockerContainers() ([]DockerContainerInfo, error) {
 		}
 		ofeliaLabels := make(map[string]string)
 		for k, v := range cont.Labels {
-			if strings.HasPrefix(k, labelPrefix) {
+			if strings.HasPrefix(k, labelPrefix) || k == dockerComposeServiceLabel {
 				ofeliaLabels[k] = v
 			}
 		}

--- a/cli/docker_handler_test.go
+++ b/cli/docker_handler_test.go
@@ -217,7 +217,7 @@ func TestGetDockerContainersNoContainers(t *testing.T) {
 	assert.Equal(t, ErrNoContainerWithOfeliaEnabled, err)
 }
 
-// TestGetDockerContainersValid verifies that GetDockerContainers filters and returns only ofelia-prefixed labels
+// TestGetDockerContainersValid verifies that GetDockerContainers filters and returns only ofelia-prefixed labels as well as "com.docker.compose.service"
 func TestGetDockerContainersValid(t *testing.T) {
 	t.Parallel()
 	// Mock provider returning one container with mixed labels
@@ -233,6 +233,7 @@ func TestGetDockerContainersValid(t *testing.T) {
 					"ofelia.job-exec.foo.schedule": "@every 1s",
 					"ofelia.job-run.bar.schedule":  "@every 2s",
 					"other.label":                  "ignore",
+					"com.docker.compose.service":   "test-service",
 				},
 			},
 		},
@@ -249,6 +250,7 @@ func TestGetDockerContainersValid(t *testing.T) {
 			"ofelia.enabled":               "true",
 			"ofelia.job-exec.foo.schedule": "@every 1s",
 			"ofelia.job-run.bar.schedule":  "@every 2s",
+			"com.docker.compose.service":   "test-service",
 		},
 	}}
 	assert.Equal(t, expected, labels)


### PR DESCRIPTION
## Summary

Commit d731c61a53 allows use of Docker Compose service names for job naming, and does it by inspecting container's "com.docker.compose.service" label for existence. But this label is filtered on an earlier stage and never reaches the code that sets job names.

This is a breaking change since some users may rely on ofelia incorrectly naming jobs when using Docker Compose.

This commit changes the behavior to meet the documentation at docs/CONFIGURATION.md "Cross-Container Job References (Docker Compose)".

I believe that a test for this change would be an integration test.

## Type of Change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [x] Breaking change
- [ ] Documentation update
- [ ] Refactoring / code quality
- [ ] CI / build / dependencies

## Checklist

- [x] Commits are signed (`-S`) and signed-off (`--signoff`)
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] Tests added/updated for changed behavior
- [ ] Documentation updated (README, AGENTS.md, CHANGELOG, or inline docs)
- [ ] CI passes (lint, tests, static analysis)

## Test Plan

<!-- How to verify this works? Commands to run, expected output, or manual steps. -->
