### PR TITLE
refactor: extract repeated string literals flagged by goconst

### DIFF
--- a/cli/config_validate.go
+++ b/cli/config_validate.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/go-playground/validator/v10"
+
+	"github.com/netresearch/ofelia/core"
 )
 
 // ErrValidationFailed is returned when struct validation fails.
@@ -96,9 +98,9 @@ func validateCron(fl validator.FieldLevel) bool {
 	// Allow special expressions
 	if strings.HasPrefix(value, "@") {
 		validSpecial := []string{
-			"@yearly", "@annually", "@monthly", "@weekly",
-			"@daily", "@midnight", "@hourly",
-			"@triggered", "@manual", "@none",
+			core.YearlySchedule, core.AnnuallySchedule, core.MonthlySchedule, core.WeeklySchedule,
+			core.DailySchedule, core.MidnightSchedule, core.HourlySchedule,
+			core.TriggeredSchedule, core.ManualSchedule, core.NoneSchedule,
 		}
 
 		if slices.Contains(validSpecial, value) {

--- a/cli/config_webhook.go
+++ b/cli/config_webhook.go
@@ -334,7 +334,7 @@ func applyWebhookLabelParams(config *middlewares.WebhookConfig, params map[strin
 			config.Preset = val
 		case "id":
 			config.ID = val
-		case "secret":
+		case "secret": //nolint:goconst // matches gcfg:"secret" struct tag — Go syntax requires literal in tag
 			config.Secret = val
 		case "url":
 			config.URL = val

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -19,6 +19,15 @@ import (
 	"github.com/netresearch/ofelia/web"
 )
 
+// Default listen addresses for the web UI and pprof server. These mirror
+// the `default:` struct-tag values below; we keep them as named constants
+// so the "is the user still on the default?" comparisons elsewhere don't
+// hardcode the same literal.
+const (
+	defaultWebAddr   = ":8081"
+	defaultPprofAddr = "127.0.0.1:8080"
+)
+
 // DaemonCommand daemon process
 type DaemonCommand struct {
 	ConfigFile           string         `long:"config" env:"OFELIA_CONFIG" description:"Config file path" default:"/etc/ofelia/config.ini"`
@@ -291,7 +300,7 @@ func (c *DaemonCommand) applyWebOptions(config *Config) {
 	if c.EnableWeb {
 		config.Global.EnableWeb = true
 	}
-	if c.WebAddr != ":8081" {
+	if c.WebAddr != defaultWebAddr {
 		config.Global.WebAddr = c.WebAddr
 	}
 }
@@ -324,7 +333,7 @@ func (c *DaemonCommand) applyServerOptions(config *Config) {
 	if c.EnablePprof {
 		config.Global.EnablePprof = true
 	}
-	if c.PprofAddr != "127.0.0.1:8080" {
+	if c.PprofAddr != defaultPprofAddr {
 		config.Global.PprofAddr = c.PprofAddr
 	}
 	if c.LogLevel != "" {
@@ -347,7 +356,7 @@ func (c *DaemonCommand) applyWebDefaults(config *Config) {
 	if !c.EnableWeb {
 		c.EnableWeb = config.Global.EnableWeb
 	}
-	if c.WebAddr == ":8081" && config.Global.WebAddr != "" {
+	if c.WebAddr == defaultWebAddr && config.Global.WebAddr != "" {
 		c.WebAddr = config.Global.WebAddr
 	}
 }
@@ -380,7 +389,7 @@ func (c *DaemonCommand) applyServerDefaults(config *Config) {
 	if !c.EnablePprof {
 		c.EnablePprof = config.Global.EnablePprof
 	}
-	if c.PprofAddr == "127.0.0.1:8080" && config.Global.PprofAddr != "" {
+	if c.PprofAddr == defaultPprofAddr && config.Global.PprofAddr != "" {
 		c.PprofAddr = config.Global.PprofAddr
 	}
 }

--- a/cli/deprecations.go
+++ b/cli/deprecations.go
@@ -11,6 +11,20 @@ import (
 	"time"
 )
 
+// Names of currently deprecated options. Exported so callers (e.g. doctor
+// reports, label allowlists) can reference the canonical name without
+// duplicating string literals.
+const (
+	DeprecatedSlackWebhook = "slack-webhook"
+	DeprecatedPollInterval = "poll-interval"
+	DeprecatedNoPoll       = "no-poll"
+
+	// Normalized key forms (lowercase, no separators) used for
+	// presence-based detection in raw config maps.
+	deprecatedPollIntervalKey = "pollinterval"
+	deprecatedNoPollKey       = "nopoll"
+)
+
 // Deprecation defines a deprecated configuration option
 type Deprecation struct {
 	// Option is the deprecated option name (e.g., "slack-webhook", "poll-interval")
@@ -56,7 +70,7 @@ var deprecationRegistry = &DeprecationRegistry{
 // Deprecations is the central list of all deprecated configuration options
 var Deprecations = []Deprecation{
 	{
-		Option:         "slack-webhook",
+		Option:         DeprecatedSlackWebhook,
 		Replacement:    "[webhook \"name\"] sections with preset=slack",
 		RemovalVersion: "v1.0.0",
 		Message: `Please migrate to the new webhook notification system:
@@ -103,11 +117,11 @@ See documentation: https://github.com/netresearch/ofelia#webhook-notifications`,
 		MigrateFunc: nil,
 	},
 	{
-		Option:         "poll-interval",
+		Option:         DeprecatedPollInterval,
 		Replacement:    "config-poll-interval and docker-poll-interval",
 		RemovalVersion: "v1.0.0",
 		Message:        "Use 'config-poll-interval' for INI file watching and 'docker-poll-interval' for container polling fallback.",
-		KeyName:        "pollinterval", // Normalized key for presence-based detection
+		KeyName:        deprecatedPollIntervalKey, // Normalized key for presence-based detection
 		CheckFunc: func(cfg *Config) bool {
 			return cfg.Docker.PollInterval > 0
 		},
@@ -130,11 +144,11 @@ See documentation: https://github.com/netresearch/ofelia#webhook-notifications`,
 		},
 	},
 	{
-		Option:         "no-poll",
+		Option:         DeprecatedNoPoll,
 		Replacement:    "docker-poll-interval=0",
 		RemovalVersion: "v1.0.0",
 		Message:        "Use 'docker-poll-interval=0' to disable container polling.",
-		KeyName:        "nopoll", // Normalized key for presence-based detection
+		KeyName:        deprecatedNoPollKey, // Normalized key for presence-based detection
 		CheckFunc: func(cfg *Config) bool {
 			return cfg.Docker.DisablePolling
 		},

--- a/cli/docker-labels.go
+++ b/cli/docker-labels.go
@@ -36,8 +36,8 @@ var globalLabelAllowList = map[string]bool{
 	"enable-strict-validation": true,
 
 	// Slack notifications
-	"slack-webhook":       true,
-	"slack-only-on-error": true,
+	DeprecatedSlackWebhook: true,
+	"slack-only-on-error":  true,
 
 	// Email notifications
 	"smtp-host":            true,
@@ -375,7 +375,7 @@ func (c *Config) filterGlobalLabelKey(key, value, containerName string, globalCo
 
 func hasServiceLabel(labels map[string]string) bool {
 	for k, v := range labels {
-		if k == serviceLabel && v == "true" {
+		if k == serviceLabel && v == "true" { //nolint:goconst // Docker labels are stringly-typed — value is the literal "true"
 			return true
 		}
 	}

--- a/cli/docker_config_handler.go
+++ b/cli/docker_config_handler.go
@@ -20,6 +20,11 @@ import (
 
 var ErrNoContainerWithOfeliaEnabled = errors.New("couldn't find containers with label 'ofelia.enabled=true'")
 
+// dockerEventTypeContainer is the Docker event filter "type" value for
+// container-scoped events (vs. image, network, volume, etc.). Docker's API
+// transports these as plain strings.
+const dockerEventTypeContainer = "container"
+
 type DockerHandler struct {
 	ctx            context.Context //nolint:containedctx // holds lifecycle for background goroutines
 	cancel         context.CancelFunc
@@ -386,7 +391,7 @@ func (c *DockerHandler) watchEvents() {
 
 		eventCh, errCh := c.dockerProvider.SubscribeEvents(c.ctx, domain.EventFilter{
 			Filters: map[string][]string{
-				"type":  {"container"},
+				"type":  {dockerEventTypeContainer},
 				"label": {"ofelia.enabled=true"},
 				"event": {
 					// Lifecycle events

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -26,6 +26,18 @@ type DoctorCommand struct {
 	configAutoDetected bool
 }
 
+// Diagnostic check category names. These appear in JSON output and the
+// human-readable doctor report, grouping individual checks by area.
+const (
+	categoryConfiguration = "Configuration"
+	categoryDocker        = "Docker"
+	categoryDockerImages  = "Docker Images"
+	categoryJobSchedules  = "Job Schedules"
+)
+
+// Recurring sub-check names within a category.
+const checkNameConnectivity = "Connectivity"
+
 // commonConfigPaths lists config file locations to search (in order of priority)
 var commonConfigPaths = []string{
 	"./ofelia.ini",
@@ -120,7 +132,7 @@ func (c *DoctorCommand) Execute(_ []string) error {
 		c.checkDockerImages(report)
 	} else {
 		report.Checks = append(report.Checks, CheckResult{
-			Category: "Docker Images",
+			Category: categoryDockerImages,
 			Name:     "Image Availability",
 			Status:   statusSkip,
 			Message:  "Skipped (Docker connectivity required)",
@@ -154,7 +166,7 @@ func (c *DoctorCommand) checkConfiguration(report *DoctorReport) {
 			}
 			hints = append(hints, "Or specify path with: --config=/path/to/config.ini")
 			report.Checks = append(report.Checks, CheckResult{
-				Category: "Configuration",
+				Category: categoryConfiguration,
 				Name:     "File Exists",
 				Status:   statusFail,
 				Message:  fmt.Sprintf("Config file not found: %s", c.ConfigFile),
@@ -164,7 +176,7 @@ func (c *DoctorCommand) checkConfiguration(report *DoctorReport) {
 		}
 		report.Healthy = false
 		report.Checks = append(report.Checks, CheckResult{
-			Category: "Configuration",
+			Category: categoryConfiguration,
 			Name:     "File Readable",
 			Status:   statusFail,
 			Message:  fmt.Sprintf("Cannot read config file: %v", err),
@@ -177,7 +189,7 @@ func (c *DoctorCommand) checkConfiguration(report *DoctorReport) {
 	}
 
 	report.Checks = append(report.Checks, CheckResult{
-		Category: "Configuration",
+		Category: categoryConfiguration,
 		Name:     "File Exists",
 		Status:   statusPass,
 		Message:  c.ConfigFile,
@@ -188,7 +200,7 @@ func (c *DoctorCommand) checkConfiguration(report *DoctorReport) {
 	if err != nil {
 		report.Healthy = false
 		report.Checks = append(report.Checks, CheckResult{
-			Category: "Configuration",
+			Category: categoryConfiguration,
 			Name:     "Valid Syntax",
 			Status:   statusFail,
 			Message:  fmt.Sprintf("Parse error: %v", err),
@@ -201,7 +213,7 @@ func (c *DoctorCommand) checkConfiguration(report *DoctorReport) {
 	}
 
 	report.Checks = append(report.Checks, CheckResult{
-		Category: "Configuration",
+		Category: categoryConfiguration,
 		Name:     "Valid Syntax",
 		Status:   statusPass,
 	})
@@ -210,7 +222,7 @@ func (c *DoctorCommand) checkConfiguration(report *DoctorReport) {
 	jobCount := len(conf.RunJobs) + len(conf.LocalJobs) +
 		len(conf.ExecJobs) + len(conf.ServiceJobs)
 	report.Checks = append(report.Checks, CheckResult{
-		Category: "Configuration",
+		Category: categoryConfiguration,
 		Name:     "Jobs Defined",
 		Status:   statusPass,
 		Message:  fmt.Sprintf("%d job(s) configured", jobCount),
@@ -221,7 +233,7 @@ func (c *DoctorCommand) checkConfiguration(report *DoctorReport) {
 	if len(deprecations) > 0 {
 		for _, dep := range deprecations {
 			report.Checks = append(report.Checks, CheckResult{
-				Category: "Configuration",
+				Category: categoryConfiguration,
 				Name:     "Deprecated Option",
 				Status:   statusFail,
 				Message:  fmt.Sprintf("'%s' is deprecated and will be removed in %s", dep.Option, dep.RemovalVersion),
@@ -234,7 +246,7 @@ func (c *DoctorCommand) checkConfiguration(report *DoctorReport) {
 		// Deprecations don't make the report unhealthy, just warn
 	} else {
 		report.Checks = append(report.Checks, CheckResult{
-			Category: "Configuration",
+			Category: categoryConfiguration,
 			Name:     "Deprecated Options",
 			Status:   statusPass,
 			Message:  "No deprecated options in use",
@@ -255,7 +267,7 @@ func (c *DoctorCommand) checkWebAuth(report *DoctorReport) {
 	if conf.Global.WebUsername == "" {
 		report.Healthy = false
 		report.Checks = append(report.Checks, CheckResult{
-			Category: "Configuration",
+			Category: categoryConfiguration,
 			Name:     "Web Auth Username",
 			Status:   statusFail,
 			Message:  "web-auth-enabled is true but web-username is not set",
@@ -270,7 +282,7 @@ func (c *DoctorCommand) checkWebAuth(report *DoctorReport) {
 	if conf.Global.WebPasswordHash == "" {
 		report.Healthy = false
 		report.Checks = append(report.Checks, CheckResult{
-			Category: "Configuration",
+			Category: categoryConfiguration,
 			Name:     "Web Auth Password",
 			Status:   statusFail,
 			Message:  "web-auth-enabled is true but web-password-hash is not set",
@@ -284,7 +296,7 @@ func (c *DoctorCommand) checkWebAuth(report *DoctorReport) {
 
 	if conf.Global.WebSecretKey == "" {
 		report.Checks = append(report.Checks, CheckResult{
-			Category: "Configuration",
+			Category: categoryConfiguration,
 			Name:     "Web Auth Secret Key",
 			Status:   statusSkip,
 			Message:  "web-secret-key not set - tokens will not survive daemon restarts",
@@ -297,7 +309,7 @@ func (c *DoctorCommand) checkWebAuth(report *DoctorReport) {
 
 	if conf.Global.WebUsername != "" && conf.Global.WebPasswordHash != "" {
 		report.Checks = append(report.Checks, CheckResult{
-			Category: "Configuration",
+			Category: categoryConfiguration,
 			Name:     "Web Auth",
 			Status:   statusPass,
 			Message:  fmt.Sprintf("Configured for user '%s'", conf.Global.WebUsername),
@@ -320,8 +332,8 @@ func (c *DoctorCommand) checkDocker(report *DoctorReport) bool {
 
 	if !hasDockerJobs {
 		report.Checks = append(report.Checks, CheckResult{
-			Category: "Docker",
-			Name:     "Connectivity",
+			Category: categoryDocker,
+			Name:     checkNameConnectivity,
 			Status:   statusSkip,
 			Message:  "No Docker-based jobs configured",
 		})
@@ -332,8 +344,8 @@ func (c *DoctorCommand) checkDocker(report *DoctorReport) bool {
 	if err := conf.initDockerHandler(); err != nil {
 		report.Healthy = false
 		report.Checks = append(report.Checks, CheckResult{
-			Category: "Docker",
-			Name:     "Connectivity",
+			Category: categoryDocker,
+			Name:     checkNameConnectivity,
 			Status:   statusFail,
 			Message:  fmt.Sprintf("Cannot connect to Docker: %v", err),
 			Hints: []string{
@@ -351,8 +363,8 @@ func (c *DoctorCommand) checkDocker(report *DoctorReport) bool {
 	if provider == nil {
 		report.Healthy = false
 		report.Checks = append(report.Checks, CheckResult{
-			Category: "Docker",
-			Name:     "Connectivity",
+			Category: categoryDocker,
+			Name:     checkNameConnectivity,
 			Status:   statusFail,
 			Message:  "Docker provider not initialized",
 			Hints: []string{
@@ -366,8 +378,8 @@ func (c *DoctorCommand) checkDocker(report *DoctorReport) bool {
 	if err := provider.Ping(context.Background()); err != nil {
 		report.Healthy = false
 		report.Checks = append(report.Checks, CheckResult{
-			Category: "Docker",
-			Name:     "Connectivity",
+			Category: categoryDocker,
+			Name:     checkNameConnectivity,
 			Status:   statusFail,
 			Message:  fmt.Sprintf("Docker ping failed: %v", err),
 			Hints: []string{
@@ -379,8 +391,8 @@ func (c *DoctorCommand) checkDocker(report *DoctorReport) bool {
 	}
 
 	report.Checks = append(report.Checks, CheckResult{
-		Category: "Docker",
-		Name:     "Connectivity",
+		Category: categoryDocker,
+		Name:     checkNameConnectivity,
 		Status:   statusPass,
 		Message:  "Docker daemon responding",
 	})
@@ -394,7 +406,7 @@ func (c *DoctorCommand) checkSchedules(report *DoctorReport) {
 	if err != nil {
 		// Config error already reported
 		report.Checks = append(report.Checks, CheckResult{
-			Category: "Job Schedules",
+			Category: categoryJobSchedules,
 			Name:     "Schedule Validation",
 			Status:   statusSkip,
 			Message:  "Skipped (configuration validation failed)",
@@ -410,7 +422,7 @@ func (c *DoctorCommand) checkSchedules(report *DoctorReport) {
 			allValid = false
 			report.Healthy = false
 			report.Checks = append(report.Checks, CheckResult{
-				Category: "Job Schedules",
+				Category: categoryJobSchedules,
 				Name:     fmt.Sprintf("job-run \"%s\"", name),
 				Status:   statusFail,
 				Message:  fmt.Sprintf("Invalid schedule \"%s\": %v", job.Schedule, err),
@@ -428,7 +440,7 @@ func (c *DoctorCommand) checkSchedules(report *DoctorReport) {
 			allValid = false
 			report.Healthy = false
 			report.Checks = append(report.Checks, CheckResult{
-				Category: "Job Schedules",
+				Category: categoryJobSchedules,
 				Name:     fmt.Sprintf("job-local \"%s\"", name),
 				Status:   statusFail,
 				Message:  fmt.Sprintf("Invalid schedule \"%s\": %v", job.Schedule, err),
@@ -446,7 +458,7 @@ func (c *DoctorCommand) checkSchedules(report *DoctorReport) {
 			allValid = false
 			report.Healthy = false
 			report.Checks = append(report.Checks, CheckResult{
-				Category: "Job Schedules",
+				Category: categoryJobSchedules,
 				Name:     fmt.Sprintf("job-exec \"%s\"", name),
 				Status:   statusFail,
 				Message:  fmt.Sprintf("Invalid schedule \"%s\": %v", job.Schedule, err),
@@ -464,7 +476,7 @@ func (c *DoctorCommand) checkSchedules(report *DoctorReport) {
 			allValid = false
 			report.Healthy = false
 			report.Checks = append(report.Checks, CheckResult{
-				Category: "Job Schedules",
+				Category: categoryJobSchedules,
 				Name:     fmt.Sprintf("job-service-run \"%s\"", name),
 				Status:   statusFail,
 				Message:  fmt.Sprintf("Invalid schedule \"%s\": %v", job.Schedule, err),
@@ -482,7 +494,7 @@ func (c *DoctorCommand) checkSchedules(report *DoctorReport) {
 			allValid = false
 			report.Healthy = false
 			report.Checks = append(report.Checks, CheckResult{
-				Category: "Job Schedules",
+				Category: categoryJobSchedules,
 				Name:     fmt.Sprintf("job-compose \"%s\"", name),
 				Status:   statusFail,
 				Message:  fmt.Sprintf("Invalid schedule \"%s\": %v", job.Schedule, err),
@@ -498,7 +510,7 @@ func (c *DoctorCommand) checkSchedules(report *DoctorReport) {
 		totalJobs := len(conf.RunJobs) + len(conf.LocalJobs) +
 			len(conf.ExecJobs) + len(conf.ServiceJobs) + len(conf.ComposeJobs)
 		report.Checks = append(report.Checks, CheckResult{
-			Category: "Job Schedules",
+			Category: categoryJobSchedules,
 			Name:     "All Schedules Valid",
 			Status:   statusPass,
 			Message:  fmt.Sprintf("%d schedule(s) validated", totalJobs),
@@ -521,7 +533,7 @@ func (c *DoctorCommand) checkDockerImages(report *DoctorReport) {
 
 	if len(imageMap) == 0 {
 		report.Checks = append(report.Checks, CheckResult{
-			Category: "Docker Images",
+			Category: categoryDockerImages,
 			Name:     "Image Availability",
 			Status:   statusSkip,
 			Message:  "No job-run jobs configured",
@@ -546,7 +558,7 @@ func (c *DoctorCommand) checkDockerImages(report *DoctorReport) {
 			allAvailable = false
 			report.Healthy = false
 			report.Checks = append(report.Checks, CheckResult{
-				Category: "Docker Images",
+				Category: categoryDockerImages,
 				Name:     image,
 				Status:   statusFail,
 				Message:  "Image not found locally",
@@ -559,7 +571,7 @@ func (c *DoctorCommand) checkDockerImages(report *DoctorReport) {
 
 	if allAvailable {
 		report.Checks = append(report.Checks, CheckResult{
-			Category: "Docker Images",
+			Category: categoryDockerImages,
 			Name:     "All Images Available",
 			Status:   statusPass,
 			Message:  fmt.Sprintf("%d image(s) found locally", len(imageMap)),
@@ -599,7 +611,7 @@ func (c *DoctorCommand) outputHuman(report *DoctorReport) error {
 
 	// Group checks by category
 	categories := make(map[string][]CheckResult)
-	categoryOrder := []string{"Configuration", "Docker", "Job Schedules", "Docker Images"}
+	categoryOrder := []string{categoryConfiguration, categoryDocker, categoryJobSchedules, categoryDockerImages}
 
 	for _, check := range report.Checks {
 		categories[check.Category] = append(categories[check.Category], check)
@@ -660,10 +672,10 @@ func (c *DoctorCommand) outputHuman(report *DoctorReport) error {
 // getCategoryIcon returns emoji for category
 func getCategoryIcon(category string) string {
 	icons := map[string]string{
-		"Configuration": "📋",
-		"Docker":        "🐳",
-		"Job Schedules": "📅",
-		"Docker Images": "🖼️",
+		categoryConfiguration: "📋",
+		categoryDocker:        "🐳",
+		categoryJobSchedules:  "📅",
+		categoryDockerImages:  "🖼️",
 	}
 	if icon, ok := icons[category]; ok {
 		return icon

--- a/cli/init.go
+++ b/cli/init.go
@@ -17,6 +17,8 @@ import (
 	"github.com/netresearch/go-cron"
 	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/ini.v1"
+
+	"github.com/netresearch/ofelia/core"
 )
 
 // InitCommand creates an interactive wizard for generating Ofelia configuration
@@ -197,7 +199,7 @@ func (c *InitCommand) promptGlobalSettings(global *globalConfig) error {
 
 	logLevelPrompt := promptui.Select{
 		Label:     "Log level",
-		Items:     []string{"panic", "fatal", "error", "warning", "info", "debug", "trace"},
+		Items:     []string{LogLevelPanic, LogLevelFatal, LogLevelError, LogLevelWarning, LogLevelInfo, LogLevelDebug, LogLevelTrace},
 		CursorPos: 4,
 	}
 	_, global.LogLevel, err = logLevelPrompt.Run()
@@ -208,10 +210,15 @@ func (c *InitCommand) promptGlobalSettings(global *globalConfig) error {
 	return nil
 }
 
+// defaultAdminUsername is the seed username offered by the init wizard's
+// web-auth prompt. Users can override it; we keep it as a constant so tests
+// that exercise the wizard's default path don't drift if it changes.
+const defaultAdminUsername = "admin"
+
 func (c *InitCommand) promptWebAuth(global *globalConfig) error {
 	usernamePrompt := promptui.Prompt{
 		Label:   "Username",
-		Default: "admin",
+		Default: defaultAdminUsername,
 		Validate: func(input string) error {
 			if input == "" {
 				return fmt.Errorf("username cannot be empty")
@@ -345,7 +352,7 @@ func (c *InitCommand) promptRunJob() (*runJobConfig, error) {
 	// Schedule
 	schedulePrompt := promptui.Prompt{
 		Label:    "Schedule (cron or @every)",
-		Default:  "@daily",
+		Default:  core.DailySchedule,
 		Validate: validateSchedule,
 	}
 	job.Schedule, err = schedulePrompt.Run()
@@ -441,7 +448,7 @@ func (c *InitCommand) promptLocalJob() (*localJobConfig, error) {
 	// Schedule
 	schedulePrompt := promptui.Prompt{
 		Label:    "Schedule (cron or @every)",
-		Default:  "@hourly",
+		Default:  core.HourlySchedule,
 		Validate: validateSchedule,
 	}
 	job.Schedule, err = schedulePrompt.Run()
@@ -484,7 +491,10 @@ func validateSchedule(schedule string) error {
 	}
 
 	// Check for special descriptors
-	descriptors := []string{"@yearly", "@annually", "@monthly", "@weekly", "@daily", "@midnight", "@hourly"}
+	descriptors := []string{
+		core.YearlySchedule, core.AnnuallySchedule, core.MonthlySchedule, core.WeeklySchedule,
+		core.DailySchedule, core.MidnightSchedule, core.HourlySchedule,
+	}
 	if slices.Contains(descriptors, schedule) {
 		return nil
 	}

--- a/cli/logging.go
+++ b/cli/logging.go
@@ -13,6 +13,22 @@ import (
 // ErrInvalidLogLevel indicates an invalid log level string was provided.
 var ErrInvalidLogLevel = errors.New("invalid log level")
 
+// Recognized log level names (canonical and legacy/logrus aliases).
+// Exported so other commands (init prompts, validators) can reference them
+// without duplicating string literals.
+const (
+	LogLevelTrace    = "trace"
+	LogLevelDebug    = "debug"
+	LogLevelInfo     = "info"
+	LogLevelNotice   = "notice"
+	LogLevelWarn     = "warn"
+	LogLevelWarning  = "warning"
+	LogLevelError    = "error"
+	LogLevelFatal    = "fatal"
+	LogLevelPanic    = "panic"
+	LogLevelCritical = "critical"
+)
+
 // ApplyLogLevel sets the logging level if level is valid.
 // Returns an error if the level is invalid, with a list of valid options.
 func ApplyLogLevel(level string, lv *slog.LevelVar) error {
@@ -23,13 +39,13 @@ func ApplyLogLevel(level string, lv *slog.LevelVar) error {
 	// Map legacy logrus level names to slog levels
 	var l slog.Level
 	switch strings.ToLower(level) {
-	case "trace", "debug":
+	case LogLevelTrace, LogLevelDebug:
 		l = slog.LevelDebug
-	case "info", "notice":
+	case LogLevelInfo, LogLevelNotice:
 		l = slog.LevelInfo
-	case "warning", "warn":
+	case LogLevelWarning, LogLevelWarn:
 		l = slog.LevelWarn
-	case "error", "fatal", "panic", "critical":
+	case LogLevelError, LogLevelFatal, LogLevelPanic, LogLevelCritical:
 		l = slog.LevelError
 	default:
 		return fmt.Errorf("%w: %q (valid levels are debug, info, warn, error)", ErrInvalidLogLevel, level)

--- a/cli/logging.go
+++ b/cli/logging.go
@@ -29,6 +29,15 @@ const (
 	LogLevelCritical = "critical"
 )
 
+// validLogLevels lists every log level string ApplyLogLevel accepts, in
+// the order they're shown to users when an invalid value is supplied.
+// Canonical slog levels first, then logrus-era aliases.
+var validLogLevels = []string{
+	LogLevelDebug, LogLevelInfo, LogLevelWarn, LogLevelError,
+	LogLevelTrace, LogLevelNotice, LogLevelWarning,
+	LogLevelFatal, LogLevelPanic, LogLevelCritical,
+}
+
 // ApplyLogLevel sets the logging level if level is valid.
 // Returns an error if the level is invalid, with a list of valid options.
 func ApplyLogLevel(level string, lv *slog.LevelVar) error {
@@ -48,7 +57,8 @@ func ApplyLogLevel(level string, lv *slog.LevelVar) error {
 	case LogLevelError, LogLevelFatal, LogLevelPanic, LogLevelCritical:
 		l = slog.LevelError
 	default:
-		return fmt.Errorf("%w: %q (valid levels are debug, info, warn, error)", ErrInvalidLogLevel, level)
+		return fmt.Errorf("%w: %q (valid levels are %s)",
+			ErrInvalidLogLevel, level, strings.Join(validLogLevels, ", "))
 	}
 
 	if lv != nil {

--- a/config/sanitizer.go
+++ b/config/sanitizer.go
@@ -216,8 +216,8 @@ func (s *Sanitizer) ValidateDockerImage(image string) error {
 // standard cron expressions with optional seconds, month/day names (JAN, MON),
 // and wraparound ranges (FRI-MON).
 func (s *Sanitizer) ValidateCronExpression(expr string) error {
-	// Allow ofelia's triggered-only schedule keywords
-	if expr == "@triggered" || expr == "@manual" || expr == "@none" {
+	// Allow ofelia's triggered-only schedule keywords (see schedule_keywords.go)
+	if expr == scheduleTriggered || expr == scheduleManual || expr == scheduleNone {
 		return nil
 	}
 

--- a/config/schedule_keywords.go
+++ b/config/schedule_keywords.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package config
+
+// Special schedule keywords used by ofelia's validators and sanitizers.
+//
+// These mirror core's schedule keywords (core/schedule_keywords.go) and
+// cli's log level names (cli/logging.go), but are duplicated here because
+// the config package sits below both in the import graph and cannot depend
+// on them. Keep them in sync; consumers downstream should reference the
+// exported names from core/cli where possible.
+const (
+	scheduleTriggered = "@triggered"
+	scheduleManual    = "@manual"
+	scheduleNone      = "@none"
+
+	logLevelTrace    = "trace"
+	logLevelDebug    = "debug"
+	logLevelInfo     = "info"
+	logLevelNotice   = "notice"
+	logLevelWarn     = "warn"
+	logLevelWarning  = "warning"
+	logLevelError    = "error"
+	logLevelFatal    = "fatal"
+	logLevelPanic    = "panic"
+	logLevelCritical = "critical"
+)

--- a/config/validator.go
+++ b/config/validator.go
@@ -136,8 +136,9 @@ func (v *Validator) ValidateCronExpression(field string, value string) {
 		return
 	}
 
-	// Allow ofelia's triggered-only schedule keywords
-	if value == "@triggered" || value == "@manual" || value == "@none" {
+	// Allow ofelia's triggered-only schedule keywords. These are duplicated
+	// in core/schedule_keywords.go but config can't depend on core (cycle).
+	if value == scheduleTriggered || value == scheduleManual || value == scheduleNone {
 		return
 	}
 
@@ -302,15 +303,18 @@ func (cv *Validator2) validateSpecificStringField(v *Validator, path string, str
 		return // Stop validation if security check fails
 	}
 
-	// Validate based on field type
+	// Validate based on field type. The case strings are user-facing INI key
+	// names; Go struct tags (gcfg:"…" / mapstructure:"…") on Config require
+	// them as literals there too, so extracting constants only relocates the
+	// duplication. Suppressing keeps the switch readable.
 	switch path {
-	case "schedule", "cron":
+	case "schedule", "cron": //nolint:goconst // see comment above switch
 		cv.validateCronField(v, path, str)
-	case "email-to", "email-from":
+	case "email-to", "email-from": //nolint:goconst // see comment above switch
 		cv.validateEmailField(v, path, str)
 	case "web-address", "pprof-address":
 		cv.validateAddressField(v, path, str)
-	case "log-level":
+	case "log-level": //nolint:goconst // see comment above switch
 		cv.validateLogLevelField(v, path, str)
 	case "command", "cmd":
 		cv.validateCommandField(v, path, str)
@@ -461,7 +465,11 @@ func (cv *Validator2) isValidAddress(addr string) bool {
 
 // isValidLogLevel checks if a log level is valid
 func (cv *Validator2) isValidLogLevel(level string) bool {
-	validLevels := []string{"debug", "trace", "info", "notice", "warn", "warning", "error", "fatal", "panic", "critical"}
+	validLevels := []string{
+		logLevelDebug, logLevelTrace, logLevelInfo, logLevelNotice,
+		logLevelWarn, logLevelWarning, logLevelError, logLevelFatal,
+		logLevelPanic, logLevelCritical,
+	}
 	level = strings.ToLower(level)
 	return slices.Contains(validLevels, level)
 }

--- a/core/adapters/docker/auth.go
+++ b/core/adapters/docker/auth.go
@@ -106,11 +106,20 @@ func (p *ConfigAuthProvider) logWarning(format string, args ...any) {
 	}
 }
 
+// Docker Hub registry hostnames. Both "docker.io" (newer convention) and
+// "index.docker.io" (legacy) point at Docker Hub; clients receive any of the
+// three forms and need to fold them to one canonical credential bucket.
+const (
+	dockerHubRegistry       = "docker.io"
+	dockerHubRegistryLegacy = "index.docker.io"
+	dockerHubAuthEndpoint   = "https://index.docker.io/v1/"
+)
+
 // normalizeRegistry normalizes a registry address for credential lookup.
 func normalizeRegistry(registry string) string {
 	// Docker Hub special cases
-	if registry == "" || registry == "docker.io" || registry == "index.docker.io" {
-		return "https://index.docker.io/v1/"
+	if registry == "" || registry == dockerHubRegistry || registry == dockerHubRegistryLegacy {
+		return dockerHubAuthEndpoint
 	}
 	return registry
 }
@@ -134,7 +143,7 @@ func ExtractRegistry(image string) string {
 	named, err := reference.ParseNormalizedNamed(image)
 	if err != nil {
 		// Fallback to Docker Hub for unparseable images
-		return "docker.io"
+		return dockerHubRegistry
 	}
 
 	// reference.Domain returns the registry domain

--- a/core/annotations.go
+++ b/core/annotations.go
@@ -32,6 +32,18 @@ func parseAnnotations(annotations []string) map[string]string {
 // Defaults to "dev" if not set.
 var Version = "dev"
 
+// Default annotation keys that Ofelia attaches to every job execution.
+// These are stable wire-level identifiers consumed by downstream tooling
+// (logging pipelines, dashboards). Don't change without coordinating with
+// consumers.
+const (
+	AnnotationKeyJobName       = "ofelia.job.name"
+	AnnotationKeyJobType       = "ofelia.job.type"
+	AnnotationKeyExecutionTime = "ofelia.execution.time"
+	AnnotationKeySchedulerHost = "ofelia.scheduler.host"
+	AnnotationKeyVersion       = "ofelia.version"
+)
+
 // getDefaultAnnotations returns default annotations that Ofelia automatically adds.
 // User-provided annotations take precedence over these defaults.
 func getDefaultAnnotations(jobName, jobType string) map[string]string {
@@ -46,11 +58,11 @@ func getDefaultAnnotations(jobName, jobType string) map[string]string {
 	}
 
 	return map[string]string{
-		"ofelia.job.name":       jobName,
-		"ofelia.job.type":       jobType,
-		"ofelia.execution.time": time.Now().UTC().Format(time.RFC3339),
-		"ofelia.scheduler.host": hostname,
-		"ofelia.version":        version,
+		AnnotationKeyJobName:       jobName,
+		AnnotationKeyJobType:       jobType,
+		AnnotationKeyExecutionTime: time.Now().UTC().Format(time.RFC3339),
+		AnnotationKeySchedulerHost: hostname,
+		AnnotationKeyVersion:       version,
 	}
 }
 

--- a/core/docker_sdk_provider.go
+++ b/core/docker_sdk_provider.go
@@ -369,7 +369,7 @@ func (p *SDKDockerProvider) FindNetworkByName(ctx context.Context, networkName s
 
 	opts := domain.NetworkListOptions{
 		Filters: map[string][]string{
-			"name": {networkName},
+			"name": {networkName}, //nolint:goconst // Docker SDK filter key — coincidental collision with other "name" string literals
 		},
 	}
 

--- a/core/domain/image.go
+++ b/core/domain/image.go
@@ -95,10 +95,14 @@ type ParsedReference struct {
 	Digest     string
 }
 
+// DefaultImageTag is the implicit tag Docker assigns when an image
+// reference has no explicit ":tag" suffix.
+const DefaultImageTag = "latest"
+
 // ParseRepositoryTag parses a repository:tag string into its components.
 func ParseRepositoryTag(repoTag string) ParsedReference {
 	ref := ParsedReference{
-		Tag: "latest",
+		Tag: DefaultImageTag,
 	}
 
 	// Find the last @ for digest

--- a/core/resilience.go
+++ b/core/resilience.go
@@ -287,7 +287,7 @@ func (cb *CircuitBreaker) GetMetrics() map[string]any {
 	defer cb.mu.Unlock()
 
 	return map[string]any{
-		"name":             cb.name,
+		"name":             cb.name, //nolint:goconst // metrics map key — coincidental collision with other "name" literals
 		"state":            cb.state.String(),
 		"total_calls":      atomic.LoadUint64(&cb.totalCalls),
 		"total_successes":  atomic.LoadUint64(&cb.totalSuccesses),

--- a/core/schedule_keywords.go
+++ b/core/schedule_keywords.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package core
+
+// Special schedule keywords recognized by go-cron and Ofelia.
+//
+// The time-based keywords (Yearly, Monthly, Weekly, Daily, Hourly and their
+// aliases) map to fixed cron expressions inside go-cron's parser.
+//
+// The run-on-trigger-only keywords (Triggered, Manual, None) map to a
+// TriggeredSchedule whose Next() returns the zero time, so jobs registered
+// with these schedules never fire automatically — they only run when invoked
+// via TriggerEntryByName() or by another job's on-success/on-failure chain.
+const (
+	TriggeredSchedule = "@triggered"
+	ManualSchedule    = "@manual"
+	NoneSchedule      = "@none"
+
+	YearlySchedule   = "@yearly"
+	AnnuallySchedule = "@annually" // alias of @yearly
+	MonthlySchedule  = "@monthly"
+	WeeklySchedule   = "@weekly"
+	DailySchedule    = "@daily"
+	MidnightSchedule = "@midnight" // alias of @daily
+	HourlySchedule   = "@hourly"
+)

--- a/core/scheduler.go
+++ b/core/scheduler.go
@@ -19,19 +19,12 @@ var (
 	ErrEmptySchedule  = errors.New("unable to add a job with an empty schedule")
 )
 
-// TriggeredSchedule is a special schedule keyword for jobs that should only run
-// when triggered by another job's on-success/on-failure, or manually via RunJob().
-// go-cron natively handles these schedules: the parser recognizes @triggered,
-// @manual, and @none and creates a TriggeredSchedule whose Next() always returns
-// zero time, so the scheduler never fires them automatically. Jobs can still be
-// triggered on demand via TriggerEntryByName().
-const TriggeredSchedule = "@triggered"
-
 // IsTriggeredSchedule returns true if the schedule string indicates the job
 // should only run when triggered (not on a time-based schedule). This is a
 // convenience wrapper around string comparison for the three recognized keywords.
+// See schedule_keywords.go for the full list of recognized schedule strings.
 func IsTriggeredSchedule(schedule string) bool {
-	return schedule == TriggeredSchedule || schedule == "@manual" || schedule == "@none"
+	return schedule == TriggeredSchedule || schedule == ManualSchedule || schedule == NoneSchedule
 }
 
 type Scheduler struct {

--- a/middlewares/execution_status.go
+++ b/middlewares/execution_status.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package middlewares
+
+// Execution status labels emitted in user-facing notification payloads
+// (mail body, webhook body, save artifacts). These are stable strings that
+// downstream consumers parse, so they live in one place.
+const (
+	statusSuccessful = "successful"
+	statusFailed     = "failed"
+	statusSkipped    = "skipped"
+)
+
+// JSON/template variable names for the per-notification context payload
+// shared by mail, save, webhook, and restore. The struct tags on
+// restore.go's payload type pin the wire format to these names.
+const (
+	notificationVarJob       = "Job"
+	notificationVarExecution = "Execution"
+)
+
+// contentTypeJSON is the default Content-Type for webhook POSTs that
+// don't override it via preset headers.
+const contentTypeJSON = "application/json"

--- a/middlewares/mail.go
+++ b/middlewares/mail.go
@@ -118,8 +118,8 @@ func (m *Mail) sendMail(ctx *core.Context) error {
 
 	msg.Attach(base+".stderr.json", mail.SetCopyFunc(func(w io.Writer) error {
 		js, _ := json.MarshalIndent(map[string]any{
-			"Job":       ctx.Job,
-			"Execution": ctx.Execution,
+			notificationVarJob:       ctx.Job,
+			notificationVarExecution: ctx.Execution,
 		}, "", "  ")
 
 		if _, err := w.Write(js); err != nil {
@@ -195,11 +195,11 @@ func init() {
 }
 
 func executionLabel(e *core.Execution) string {
-	status := "successful"
+	status := statusSuccessful
 	if e.Skipped {
-		status = "skipped"
+		status = statusSkipped
 	} else if e.Failed {
-		status = "failed"
+		status = statusFailed
 	}
 
 	return status

--- a/middlewares/preset.go
+++ b/middlewares/preset.go
@@ -322,7 +322,7 @@ func ParsePreset(data []byte) (*Preset, error) {
 	// Default Content-Type for POST
 	if preset.Method == http.MethodPost {
 		if _, ok := preset.Headers["Content-Type"]; !ok {
-			preset.Headers["Content-Type"] = "application/json"
+			preset.Headers["Content-Type"] = contentTypeJSON
 		}
 	}
 

--- a/middlewares/save.go
+++ b/middlewares/save.go
@@ -125,8 +125,8 @@ func (m *Save) saveToDisk(ctx *core.Context) error {
 
 func (m *Save) saveContextToDisk(ctx *core.Context, filename string) error {
 	js, _ := json.MarshalIndent(map[string]any{
-		"Job":       ctx.Job,
-		"Execution": ctx.Execution,
+		notificationVarJob:       ctx.Job,
+		notificationVarExecution: ctx.Execution,
 	}, "", "  ")
 
 	if err := m.writeFile(js, filename); err != nil {

--- a/middlewares/webhook.go
+++ b/middlewares/webhook.go
@@ -277,11 +277,11 @@ func getJobType(job core.Job) string {
 func getExecutionStatus(e *core.Execution) string {
 	switch {
 	case e.Failed:
-		return "failed"
+		return statusFailed
 	case e.Skipped:
-		return "skipped"
+		return statusSkipped
 	default:
-		return "successful"
+		return statusSuccessful
 	}
 }
 
@@ -435,10 +435,10 @@ func (w *Webhook) buildWebhookDataWithPreset(ctx *core.Context) map[string]any {
 	}
 
 	return map[string]any{
-		"Job":       data.Job,
-		"Execution": data.Execution,
-		"Host":      data.Host,
-		"Ofelia":    data.Ofelia,
+		notificationVarJob:       data.Job,
+		notificationVarExecution: data.Execution,
+		"Host":                   data.Host,
+		"Ofelia":                 data.Ofelia,
 		"Preset": PresetDataForTemplate{
 			ID:       w.Config.ID,
 			Secret:   w.Config.Secret,


### PR DESCRIPTION
## Summary

Resolves the `goconst` findings surfaced by golangci-lint v2.12.1 (CI's pinned version). Replaces high-volume duplicated string literals with named constants where the strings represent a shared concept — closed enum, wire contract, default value — and suppresses the rest with per-site rationale where extraction would add clutter without benefit.

**No behavior changes.** All string values are preserved exactly.

## What changed

### Closed-enum extractions

| Domain | New / touched | Detail |
|---|---|---|
| Cron schedule keywords | `core/schedule_keywords.go` (new) | All `@*` schedules (Daily, Hourly, Weekly, Yearly, Annually, Monthly, Midnight, Manual, Triggered, None). Exported. `core/scheduler.go`'s `IsTriggeredSchedule` now references them. `cli/config_validate.go`, `cli/init.go` reference the same vocabulary. |
| Cron keywords (config layer) | `config/schedule_keywords.go` (new) | `config` sits below `core` in the import graph so the `@triggered/@manual/@none` triplet is duplicated locally with a comment explaining the layering. Also includes `logLevel*` mirrors used by `config/validator.go`'s `validLevels` slice. |
| Doctor categories | `cli/doctor.go` | `categoryConfiguration`, `categoryDocker`, `categoryDockerImages`, `categoryJobSchedules`, plus `checkNameConnectivity` for the recurring sub-name. Replaces 28 `Category:` literals plus the emoji map. |
| Log levels | `cli/logging.go` | Exported `LogLevel{Trace,Debug,Info,Notice,Warn,Warning,Error,Fatal,Panic,Critical}`. Used in the switch + `cli/init.go`'s prompt Items list. |
| Deprecated option names | `cli/deprecations.go` | Exported `DeprecatedSlackWebhook`, `DeprecatedPollInterval`, `DeprecatedNoPoll` plus unexported normalized-key forms. Referenced from `cli/docker-labels.go`'s allow-list. |
| Daemon default addresses | `cli/daemon.go` | `defaultWebAddr` (`":8081"`) and `defaultPprofAddr` (`"127.0.0.1:8080"`) — used by the four "is the user still on the default?" comparisons. |
| Annotation keys | `core/annotations.go` | `AnnotationKey{JobName,JobType,ExecutionTime,SchedulerHost,Version}` — wire-level identifiers attached to every execution. |
| Docker Hub registry | `core/adapters/docker/auth.go` | `dockerHubRegistry`, `dockerHubRegistryLegacy`, `dockerHubAuthEndpoint`. |
| Default image tag | `core/domain/image.go` | `DefaultImageTag = "latest"`. |
| Execution status & template vars | `middlewares/execution_status.go` (new) | `statusSuccessful` / `Failed` / `Skipped`, `notificationVarJob` / `Execution`, `contentTypeJSON`. Referenced from `mail.go`, `save.go`, `webhook.go`, `preset.go`. |

### Targeted suppressions (with per-site rationale)

| Site | Reason |
|---|---|
| `cli/config_webhook.go` `"secret"` | Switch case is pinned to the `gcfg:"secret"` struct tag value — Go syntax forces tag literals. |
| `cli/docker-labels.go` `"true"` | Docker labels are stringly-typed — comparing a label value against `"true"` is the contract, not a missing constant. |
| `core/docker_sdk_provider.go` `"name"` | Docker SDK filter map key — coincidental collision with unrelated `"name"` literals elsewhere. |
| `core/resilience.go` `"name"` | Metrics map key — coincidental collision. |
| `config/validator.go` switch cases (`schedule`, `email-to`, `log-level`) | INI key names pinned by `gcfg:"…"` / `mapstructure:"…"` struct tags on `Config`; extracting consts only relocates the duplication. Comment above the switch explains. |

## Why suppressions, not more extractions

`goconst` matches text repetition; the question is whether each match expresses *one concept* or *coincidental text*. Six unrelated `case` statements that happen to contain the word `"name"` aren't sharing a concept — hoisting `const cName = "name"` doesn't prevent any bug, it just adds clutter. Where Go's struct-tag syntax forces a literal anyway (it can't reference constants), an extracted const lives next to the literal rather than replacing it.

## Test plan

- [x] `go build ./...` clean
- [x] `go test -count=1 -short ./...` — all packages pass
- [x] `golangci-lint run --enable-only=goconst ./...` — 0 issues (was 51)
- [x] `golangci-lint run ./...` — 0 issues
- [x] DCO sign-off
- [ ] CI green