### PR TITLE
fix(make): install golangci-lint via v2 module path so make lint works

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -56,7 +56,7 @@ check_tool() {
 }
 
 echo -e "${BLUE}🛠️  Checking required tools...${NC}"
-check_tool "golangci-lint" "go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest"
+check_tool "golangci-lint" "go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest"
 check_tool "gosec" "go install github.com/securego/gosec/v2/cmd/gosec@latest"
 check_tool "docker" "https://docs.docker.com/get-docker/"
 

--- a/Makefile
+++ b/Makefile
@@ -54,14 +54,14 @@ tidy:
 .PHONY: lint
 lint:
 	@mkdir -p $(BUILD_PATH)/.tools
-	@GOTOOLCHAIN=go1.26.2 GOBIN=$(BUILD_PATH)/.tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@GOTOOLCHAIN=go1.26.2 GOBIN=$(BUILD_PATH)/.tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	@$(BUILD_PATH)/.tools/golangci-lint version || true
 	@$(BUILD_PATH)/.tools/golangci-lint run --timeout=5m
 
 .PHONY: lint-fix
 lint-fix:
 	@mkdir -p $(BUILD_PATH)/.tools
-	@GOTOOLCHAIN=go1.26.2 GOBIN=$(BUILD_PATH)/.tools go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@GOTOOLCHAIN=go1.26.2 GOBIN=$(BUILD_PATH)/.tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	@$(BUILD_PATH)/.tools/golangci-lint run --fix --timeout=5m
 
 .PHONY: lint-full
@@ -208,7 +208,7 @@ setup: dev-setup
 dev-setup:
 	@echo "🔧 Setting up development environment..."
 	@echo "📦 Installing required tools..."
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	@echo "✅ golangci-lint installed"
 	@if command -v gosec >/dev/null 2>&1; then \
 		echo "✅ gosec already available"; \


### PR DESCRIPTION
## Summary

`Makefile`'s lint, lint-fix, and dev-setup targets pinned `github.com/golangci/golangci-lint/cmd/golangci-lint@latest` — the **v1** module path. Since the v2 release, `@latest` from this path resolves to the last v1.x tag (v1.64.8). The project's `.golangci.yml` uses `version: "2"`, so v1 errors out with:

> Error: you are using a configuration file for golangci-lint v2 with golangci-lint v1: please use golangci-lint v2

CI was unaffected because `netresearch/.github`'s `go-check` workflow installs golangci-lint via a path that already targets v2. Only `make lint` was broken locally.

Surfaced by [a review comment on #597](https://github.com/netresearch/ofelia/pull/597).

## Changes

- `Makefile:57,64,211` — three install lines now pin `github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`.
- `.envrc:59` — `check_tool` install hint mirrors the v2 path so users seeing the "missing" message install the correct version.

## Verification

```
$ rm -rf build/.tools && make lint
golangci-lint has version 2.12.1 built with go1.26.2 …
0 issues.
```

Matches the v2.12.1 that CI runs (`netresearch/.github`'s go-check installs via `go: downloading github.com/golangci/golangci-lint/v2 v2.12.1` per the workflow logs).

## Test plan

- [x] `make lint` from clean state installs v2 and runs cleanly
- [x] Commit signed off (DCO)
- [ ] CI green