### PR TITLE
fix(docker): bound NegotiateAPIVersion with configurable timeout (#608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Docker API version negotiation at startup is now bounded by a configurable `NegotiateTimeout` (default 30s). Previously `NewClientWithConfig` called `NegotiateAPIVersion` with `context.Background()`, so a reachable-but-wedged Docker daemon (e.g. a socket proxy with a hung upstream) could hang Ofelia at startup with no diagnostic output. The deadline-exceeded path now logs a warning so operators can correlate startup slowness with daemon health ([#611](https://github.com/netresearch/ofelia/pull/611), fixes [#608](https://github.com/netresearch/ofelia/issues/608))
+
 ## [0.24.0] - 2026-05-10
 
 ### Changed

--- a/core/adapters/docker/client.go
+++ b/core/adapters/docker/client.go
@@ -6,7 +6,9 @@ package docker
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"strings"
@@ -16,6 +18,11 @@ import (
 
 	"github.com/netresearch/ofelia/core/ports"
 )
+
+// defaultNegotiateTimeout bounds the initial Docker API version negotiation.
+// Used both as the DefaultConfig value and as the fallback when callers pass
+// a non-positive NegotiateTimeout.
+const defaultNegotiateTimeout = 30 * time.Second
 
 // Client implements ports.DockerClient using the official Docker SDK.
 type Client struct {
@@ -77,7 +84,7 @@ func DefaultConfig() *ClientConfig {
 		IdleConnTimeout:       90 * time.Second,
 		DialTimeout:           30 * time.Second,
 		ResponseHeaderTimeout: 120 * time.Second,
-		NegotiateTimeout:      30 * time.Second,
+		NegotiateTimeout:      defaultNegotiateTimeout,
 	}
 }
 
@@ -126,11 +133,22 @@ func NewClientWithConfig(config *ClientConfig) (*Client, error) {
 	// successful path is unaffected. See https://github.com/netresearch/ofelia/issues/608.
 	negotiateTimeout := config.NegotiateTimeout
 	if negotiateTimeout <= 0 {
-		negotiateTimeout = 30 * time.Second
+		negotiateTimeout = defaultNegotiateTimeout
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), negotiateTimeout)
 	defer cancel()
 	sdk.NegotiateAPIVersion(ctx)
+	// NegotiateAPIVersion swallows ping errors silently. Surface a deadline
+	// hit so operators can correlate startup slowness with daemon health
+	// rather than chasing phantom bugs - context cancellation is the only
+	// observable signal the SDK leaves us.
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		slog.Default().Warn(
+			"Docker API version negotiation timed out; continuing with default API version",
+			"timeout", negotiateTimeout,
+			"hint", "check Docker daemon health and DOCKER_HOST reachability",
+		)
+	}
 
 	return newClientFromSDK(sdk), nil
 }

--- a/core/adapters/docker/client.go
+++ b/core/adapters/docker/client.go
@@ -53,6 +53,19 @@ type ClientConfig struct {
 	// Timeout settings
 	DialTimeout           time.Duration
 	ResponseHeaderTimeout time.Duration
+
+	// NegotiateTimeout bounds the initial Docker API version negotiation that
+	// runs once at client creation. Without a bound, NegotiateAPIVersion uses
+	// context.Background() and can block forever when the Docker daemon is
+	// reachable but unresponsive (e.g. a socket proxy whose upstream is wedged),
+	// hanging Ofelia at startup with no diagnostic output.
+	//
+	// The Docker SDK swallows ping errors silently, so this timeout does not
+	// change correctness on successful paths - it only bounds the failure case.
+	//
+	// Set to 0 to inherit the default (see DefaultConfig). Use a small value
+	// to fail fast in tests; production typically wants 10-30s.
+	NegotiateTimeout time.Duration
 }
 
 // DefaultConfig returns a default configuration.
@@ -64,6 +77,7 @@ func DefaultConfig() *ClientConfig {
 		IdleConnTimeout:       90 * time.Second,
 		DialTimeout:           30 * time.Second,
 		ResponseHeaderTimeout: 120 * time.Second,
+		NegotiateTimeout:      30 * time.Second,
 	}
 }
 
@@ -105,7 +119,18 @@ func NewClientWithConfig(config *ClientConfig) (*Client, error) {
 	// Force early API version negotiation to prevent race conditions.
 	// Without this, concurrent goroutines (e.g., Events and ContainerList) making their
 	// first API calls simultaneously will race on the lazy version negotiation.
-	sdk.NegotiateAPIVersion(context.Background())
+	//
+	// Bound the call so a reachable-but-wedged daemon (e.g. socket proxy with a
+	// hung upstream) cannot hang Ofelia at startup. NegotiateAPIVersion swallows
+	// ping errors silently, so a timeout only bounds the failure case; the
+	// successful path is unaffected. See https://github.com/netresearch/ofelia/issues/608.
+	negotiateTimeout := config.NegotiateTimeout
+	if negotiateTimeout <= 0 {
+		negotiateTimeout = 30 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), negotiateTimeout)
+	defer cancel()
+	sdk.NegotiateAPIVersion(ctx)
 
 	return newClientFromSDK(sdk), nil
 }

--- a/core/adapters/docker/client_negotiate_timeout_test.go
+++ b/core/adapters/docker/client_negotiate_timeout_test.go
@@ -67,11 +67,13 @@ func TestNewClientWithConfig_NegotiateAPIVersionTimeout(t *testing.T) {
 	t.Setenv("DOCKER_TLS_VERIFY", "")
 	t.Setenv("DOCKER_CERT_PATH", "")
 
-	const negotiateTimeout = 200 * time.Millisecond
-	// Generous tolerance to avoid CI flakes: expect return within 5x the configured timeout.
-	const returnWithin = 5 * negotiateTimeout
+	// 500ms gives slow CI runners (GitHub Actions under load can stall scheduling
+	// for hundreds of ms) headroom before the configured timeout fires.
+	const negotiateTimeout = 500 * time.Millisecond
+	// Generous tolerance to avoid CI flakes: expect return within 10x the configured timeout.
+	const returnWithin = 10 * negotiateTimeout
 	// Hard safety net: if even the timeout path hangs, fail the test rather than the suite.
-	const hardDeadline = 5 * time.Second
+	const hardDeadline = 10 * time.Second
 
 	cfg := DefaultConfig()
 	cfg.Host = host
@@ -117,10 +119,66 @@ func TestNewClientWithConfig_NegotiateAPIVersionTimeout(t *testing.T) {
 func TestDefaultConfig_NegotiateTimeout(t *testing.T) {
 	t.Parallel()
 	cfg := DefaultConfig()
-	if cfg.NegotiateTimeout <= 0 {
-		t.Fatalf("DefaultConfig().NegotiateTimeout = %v, want > 0", cfg.NegotiateTimeout)
+	if cfg.NegotiateTimeout != defaultNegotiateTimeout {
+		t.Fatalf("DefaultConfig().NegotiateTimeout = %v, want %v", cfg.NegotiateTimeout, defaultNegotiateTimeout)
 	}
-	if cfg.NegotiateTimeout > 2*time.Minute {
-		t.Fatalf("DefaultConfig().NegotiateTimeout = %v, want a sane upper bound (<=2m)", cfg.NegotiateTimeout)
+}
+
+// TestNewClientWithConfig_NegotiateTimeoutFallback ensures callers that pass a
+// non-positive NegotiateTimeout (e.g. constructed *ClientConfig{} directly,
+// without DefaultConfig()) still get the hang-prevention guarantee. Without
+// this, a value of 0 would create a context with zero duration and effectively
+// short-circuit negotiation; a negative value would do the same.
+func TestNewClientWithConfig_NegotiateTimeoutFallback(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		timeout time.Duration
+	}{
+		{"zero", 0},
+		{"negative", -1 * time.Second},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("listen: %v", err)
+			}
+			t.Cleanup(func() { _ = ln.Close() })
+
+			t.Setenv("DOCKER_HOST", "tcp://"+ln.Addr().String())
+			t.Setenv("DOCKER_TLS_VERIFY", "")
+			t.Setenv("DOCKER_CERT_PATH", "")
+
+			cfg := &ClientConfig{
+				Host:             "tcp://" + ln.Addr().String(),
+				NegotiateTimeout: tc.timeout,
+			}
+
+			start := time.Now()
+			done := make(chan struct{}, 1)
+			go func() {
+				c, _ := NewClientWithConfig(cfg)
+				if c != nil {
+					_ = c.Close()
+				}
+				done <- struct{}{}
+			}()
+
+			// Defaulting to 30s. We do not want to wait the full default in the test;
+			// we only assert the constructor does NOT return effectively-instantly
+			// (which is what would happen if zero/negative bypassed the fallback).
+			select {
+			case <-done:
+				if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+					t.Fatalf("NewClientWithConfig returned in %v - expected fallback to defaultNegotiateTimeout, but the dial appears to have aborted instantly (zero/negative timeout leaked through)", elapsed)
+				}
+				// Note: with the listener never responding, the call will sit until
+				// the 30s default fires. We do NOT wait for that here; below we cancel.
+			case <-time.After(2 * time.Second):
+				// Expected path: constructor is bounded by the (default) 30s timeout
+				// and is still running 2s in. That proves the fallback engaged.
+				_ = ln.Close() // unblock the constructor for cleanup
+				<-done
+			}
+		})
 	}
 }

--- a/core/adapters/docker/client_negotiate_timeout_test.go
+++ b/core/adapters/docker/client_negotiate_timeout_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package docker
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestNewClientWithConfig_NegotiateAPIVersionTimeout verifies that NewClientWithConfig
+// returns within a bounded time when the Docker daemon is reachable but does not
+// respond to API version negotiation (e.g. a wedged socket proxy whose upstream is hung).
+//
+// Regression for https://github.com/netresearch/ofelia/issues/608. Without
+// NegotiateTimeout, sdk.NegotiateAPIVersion is invoked with context.Background() and
+// can block forever, hanging Ofelia at startup with no diagnostic output.
+func TestNewClientWithConfig_NegotiateAPIVersionTimeout(t *testing.T) {
+	// Loopback listener that accepts connections but never reads/writes -
+	// requests to /_ping will hang on the response. This mirrors a wedged
+	// socket-proxy whose upstream is unresponsive.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen on loopback: %v", err)
+	}
+
+	// Drain accepted connections in a goroutine but never serve them.
+	// Hold accepted conns under a mutex so we can close them all on cleanup
+	// without racing with the Accept goroutine. Closing ln makes Accept
+	// return an error and the goroutine exits.
+	var (
+		connsMu sync.Mutex
+		conns   []net.Conn
+	)
+	acceptDone := make(chan struct{})
+	go func() {
+		defer close(acceptDone)
+		for {
+			c, aerr := ln.Accept()
+			if aerr != nil {
+				return
+			}
+			connsMu.Lock()
+			conns = append(conns, c)
+			connsMu.Unlock()
+		}
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+		<-acceptDone
+		connsMu.Lock()
+		for _, c := range conns {
+			_ = c.Close()
+		}
+		connsMu.Unlock()
+	})
+
+	host := "tcp://" + ln.Addr().String()
+
+	// Point DOCKER_HOST at our stalling listener. t.Setenv restores after the test.
+	t.Setenv("DOCKER_HOST", host)
+	// Make sure no TLS env vars from the developer environment leak in.
+	t.Setenv("DOCKER_TLS_VERIFY", "")
+	t.Setenv("DOCKER_CERT_PATH", "")
+
+	const negotiateTimeout = 200 * time.Millisecond
+	// Generous tolerance to avoid CI flakes: expect return within 5x the configured timeout.
+	const returnWithin = 5 * negotiateTimeout
+	// Hard safety net: if even the timeout path hangs, fail the test rather than the suite.
+	const hardDeadline = 5 * time.Second
+
+	cfg := DefaultConfig()
+	cfg.Host = host
+	cfg.NegotiateTimeout = negotiateTimeout
+
+	type result struct {
+		client *Client
+		err    error
+	}
+	done := make(chan result, 1)
+	start := time.Now()
+	go func() {
+		c, e := NewClientWithConfig(cfg)
+		done <- result{client: c, err: e}
+	}()
+
+	select {
+	case r := <-done:
+		elapsed := time.Since(start)
+		if r.client != nil {
+			_ = r.client.Close()
+		}
+		// We do not require an error - NegotiateAPIVersion swallows ping
+		// failures silently. The point is that the call must return.
+		if elapsed > returnWithin {
+			t.Fatalf("NewClientWithConfig returned after %v, expected <= %v (configured timeout %v)",
+				elapsed, returnWithin, negotiateTimeout)
+		}
+		// Sanity check: errors from client.NewClientWithOpts (e.g. bad host) are fine to surface,
+		// but a network ping error should not be propagated by NegotiateAPIVersion.
+		if r.err != nil && !errors.Is(r.err, context.DeadlineExceeded) {
+			t.Logf("NewClientWithConfig returned err=%v (ignored - timeout path is what matters)", r.err)
+		}
+	case <-time.After(hardDeadline):
+		t.Fatalf("NewClientWithConfig did not return within %v (configured NegotiateTimeout=%v); likely hanging on NegotiateAPIVersion",
+			hardDeadline, negotiateTimeout)
+	}
+}
+
+// TestDefaultConfig_NegotiateTimeout asserts the default configuration ships with a
+// sane, non-zero NegotiateTimeout so that operators who use DefaultConfig() inherit
+// the hang-prevention without explicit opt-in.
+func TestDefaultConfig_NegotiateTimeout(t *testing.T) {
+	t.Parallel()
+	cfg := DefaultConfig()
+	if cfg.NegotiateTimeout <= 0 {
+		t.Fatalf("DefaultConfig().NegotiateTimeout = %v, want > 0", cfg.NegotiateTimeout)
+	}
+	if cfg.NegotiateTimeout > 2*time.Minute {
+		t.Fatalf("DefaultConfig().NegotiateTimeout = %v, want a sane upper bound (<=2m)", cfg.NegotiateTimeout)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes [#608](https://github.com/netresearch/ofelia/issues/608). `core/adapters/docker/client.go::NewClientWithConfig` called `sdk.NegotiateAPIVersion(context.Background())` with an unbounded context. If the Docker daemon was reachable but unresponsive (e.g. a socket proxy whose upstream is wedged, or a remote daemon under heavy load), `NewClientWithConfig` blocked forever and Ofelia hung at startup with no diagnostic output.

## Root cause

`NegotiateAPIVersion` issues `/_ping` and waits on the response. With `context.Background()` there is no timeout. The Docker SDK swallows ping errors silently, so a timeout does not change correctness on successful paths — it only bounds the failure case.

## Why this matters more now

This was masked while the dialer hard-coded `/var/run/docker.sock`: the code path only ran against a local socket where the daemon either responded fast or failed the connection quickly. After [#606](https://github.com/netresearch/ofelia/pull/606), TCP setups (including socket proxies) actually reach the daemon, which makes the unbounded-context path far more reachable in practice.

## Fix

- Add `NegotiateTimeout time.Duration` to `ClientConfig` (default `30s` in `DefaultConfig`).
- Wrap the negotiation in `context.WithTimeout(context.Background(), config.NegotiateTimeout)` with a `defer cancel()`.
- Document the field and the rationale inline on `ClientConfig` and at the call site.

No non-negotiation paths were changed.

## Test plan

- [x] New internal test `TestNewClientWithConfig_NegotiateAPIVersionTimeout` starts a loopback `net.Listener` that accepts but never reads/writes (simulating a wedged daemon), points `DOCKER_HOST` at it via `t.Setenv`, sets `NegotiateTimeout=200ms`, and asserts `NewClientWithConfig` returns within 5x the configured timeout, with a 5s hard safety net.
- [x] New `TestDefaultConfig_NegotiateTimeout` asserts the default is non-zero and bounded.
- [x] `go test -race -count=3 ./core/adapters/docker/ ./core/` — all green.
- [x] `golangci-lint run --timeout=3m` — 0 issues.
- [x] TDD: confirmed test failed to compile against current code (field did not exist) before applying the fix; passes in 0.21s after.

## Relationship to #606

[#606](https://github.com/netresearch/ofelia/pull/606) made TCP / socket-proxy paths actually reach the daemon, which unmasked this latent hang. This PR closes that exposure without touching anything in the dialer / transport path.