### PR TITLE
fix(docker): validate DOCKER_HOST scheme and reject unsupported transports (#609)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Docker API version negotiation at startup is now bounded by a configurable `NegotiateTimeout` (default 30s). Previously `NewClientWithConfig` called `NegotiateAPIVersion` with `context.Background()`, so a reachable-but-wedged Docker daemon (e.g. a socket proxy with a hung upstream) could hang Ofelia at startup with no diagnostic output. The deadline-exceeded path now logs a warning so operators can correlate startup slowness with daemon health ([#611](https://github.com/netresearch/ofelia/pull/611), fixes [#608](https://github.com/netresearch/ofelia/issues/608))
+- `DOCKER_HOST` scheme is now validated against an allow-list (`unix://`, `tcp://`, `tcp+tls://`, `http://`, `https://`, `npipe://`) and normalized to lowercase. Unsupported schemes (`ssh://`, `fd://`, bogus values) now fail at startup with a clear error instead of silently falling through to a plain-TCP transport. Fixes silent TLS downgrade for `tcp+tls://` and case-sensitivity bug for `TCP://`/`UNIX://` ([#609](https://github.com/netresearch/ofelia/issues/609))
 
 ## [0.24.0] - 2026-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** `DOCKER_HOST` scheme is now validated against an allow-list (`unix://`, `tcp://`, `http://`, `https://`, `npipe://`) and normalized to lowercase. Unsupported schemes (`ssh://`, `fd://`, `tcp+tls://`, bogus values) now fail at startup with a clear error instead of silently falling through to a plain-TCP transport. Fixes case-sensitivity bug for `TCP://` / `UNIX://`. Configurations that previously relied on the silent fallthrough will now fail loudly — operators using `ssh://` should switch to an SSH-forwarded socket and point `DOCKER_HOST` at the forwarded `unix://` path. Note: `tcp+tls://` is rejected pending the TLS-plumbing fix in [#613](https://github.com/netresearch/ofelia/pull/613) — accepting it here without TLS material in the transport would silently downgrade to plain TCP. ([#612](https://github.com/netresearch/ofelia/pull/612), fixes [#609](https://github.com/netresearch/ofelia/issues/609))
+
 ### Fixed
 
 - Docker API version negotiation at startup is now bounded by a configurable `NegotiateTimeout` (default 30s). Previously `NewClientWithConfig` called `NegotiateAPIVersion` with `context.Background()`, so a reachable-but-wedged Docker daemon (e.g. a socket proxy with a hung upstream) could hang Ofelia at startup with no diagnostic output. The deadline-exceeded path now logs a warning so operators can correlate startup slowness with daemon health ([#611](https://github.com/netresearch/ofelia/pull/611), fixes [#608](https://github.com/netresearch/ofelia/issues/608))
-- `DOCKER_HOST` scheme is now validated against an allow-list (`unix://`, `tcp://`, `tcp+tls://`, `http://`, `https://`, `npipe://`) and normalized to lowercase. Unsupported schemes (`ssh://`, `fd://`, bogus values) now fail at startup with a clear error instead of silently falling through to a plain-TCP transport. Fixes silent TLS downgrade for `tcp+tls://` and case-sensitivity bug for `TCP://`/`UNIX://` ([#609](https://github.com/netresearch/ofelia/issues/609))
 
 ## [0.24.0] - 2026-05-10
 

--- a/core/adapters/docker/client.go
+++ b/core/adapters/docker/client.go
@@ -30,8 +30,8 @@ const defaultNegotiateTimeout = 30 * time.Second
 // the supported schemes so operators get an actionable failure at startup
 // instead of an opaque dial error later.
 //
-// Supported schemes (case-insensitive): unix, tcp, tcp+tls, http, https, npipe.
-// Notably unsupported: ssh, fd. See docs/TROUBLESHOOTING.md.
+// Supported schemes (case-insensitive): unix, tcp, http, https, npipe.
+// Notably unsupported: ssh, fd, tcp+tls. See docs/TROUBLESHOOTING.md.
 //
 // Tracking: https://github.com/netresearch/ofelia/issues/609
 var ErrUnsupportedDockerHostScheme = errors.New("unsupported DOCKER_HOST scheme")
@@ -41,16 +41,22 @@ var ErrUnsupportedDockerHostScheme = errors.New("unsupported DOCKER_HOST scheme"
 //
 //   - unix:    Unix domain socket (default on Linux/macOS).
 //   - tcp:     Plain TCP (HTTP/1.1, no HTTP/2).
-//   - tcp+tls: TLS over TCP; treated like https for transport selection.
 //   - http:    Plain HTTP over TCP (HTTP/1.1, no HTTP/2).
 //   - https:   HTTPS; HTTP/2 negotiated via ALPN.
 //   - npipe:   Windows named pipe (only usable on Windows builds; the actual
 //     dialer lives in the SDK and is build-tagged). The scheme is on the
 //     allow-list so Windows configurations work transparently.
 //
-// ssh:// and fd:// are deliberately not supported — they require dialers
-// (SSH tunnel, systemd socket activation) that this adapter does not wire up.
-var supportedDockerHostSchemes = []string{"unix", "tcp", "tcp+tls", "http", "https", "npipe"}
+// Deliberately not supported:
+//
+//   - ssh:    Requires an SSH tunnel dialer this adapter does not wire up.
+//   - fd:     Requires systemd socket activation we do not handle.
+//   - tcp+tls: Withheld pending PR #613 (issue #607). Without TLS material
+//     wired into the custom transport, accepting tcp+tls would silently
+//     downgrade to plain TCP — exactly the silent-downgrade class this PR
+//     is supposed to prevent. Re-enable in a follow-up once TLS plumbing
+//     lands.
+var supportedDockerHostSchemes = []string{"unix", "tcp", "http", "https", "npipe"}
 
 // Client implements ports.DockerClient using the official Docker SDK.
 type Client struct {
@@ -256,7 +262,7 @@ func createHTTPClient(config *ClientConfig) *http.Client {
 		}
 		// HTTP/2 not supported on Unix sockets
 		transport.ForceAttemptHTTP2 = false
-	case "https", "tcp+tls":
+	case "https":
 		// TLS-backed connections can use HTTP/2 via ALPN.
 		transport.ForceAttemptHTTP2 = true
 	default:

--- a/core/adapters/docker/client.go
+++ b/core/adapters/docker/client.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -35,6 +36,12 @@ const defaultNegotiateTimeout = 30 * time.Second
 //
 // Tracking: https://github.com/netresearch/ofelia/issues/609
 var ErrUnsupportedDockerHostScheme = errors.New("unsupported DOCKER_HOST scheme")
+
+// ErrMissingDockerHostScheme is returned when DOCKER_HOST is non-empty but
+// has no "://" separator (e.g. "127.0.0.1:2375"). Distinct from
+// ErrUnsupportedDockerHostScheme so operators can tell "I forgot the scheme"
+// from "I used a scheme that isn't supported."
+var ErrMissingDockerHostScheme = errors.New("missing DOCKER_HOST scheme")
 
 // supportedDockerHostSchemes is the allow-list of URL schemes accepted by
 // NewClientWithConfig. Schemes are compared case-insensitively.
@@ -138,6 +145,13 @@ func NewClient() (*Client, error) {
 // supportedDockerHostSchemes) and normalized to lowercase. Unsupported schemes
 // (ssh://, fd://, etc.) return ErrUnsupportedDockerHostScheme.
 func NewClientWithConfig(config *ClientConfig) (*Client, error) {
+	// Tolerate a nil config the same way DefaultConfig() would: callers
+	// constructing through the public surface should not be able to panic
+	// the daemon at startup with a nil-pointer deref.
+	if config == nil {
+		config = DefaultConfig()
+	}
+
 	// Resolve the effective host and validate/normalize its scheme up front,
 	// so operators get a clear error at startup instead of an opaque dial
 	// error later. See https://github.com/netresearch/ofelia/issues/609.
@@ -150,10 +164,13 @@ func NewClientWithConfig(config *ClientConfig) (*Client, error) {
 		return nil, fmt.Errorf("creating docker client: %w", err)
 	}
 
-	// Apply the normalized host back to the config so createHTTPClient sees
-	// the same lowercase scheme the SDK will see.
+	// Build a local copy of config with the normalized host for createHTTPClient
+	// so the dialer-selection switch sees the lowercase scheme. We deliberately
+	// avoid mutating the caller's struct - reusing a *ClientConfig across
+	// constructions is a reasonable pattern and silent mutation is surprising.
+	cfgForTransport := *config
 	if normalizedHost != "" {
-		config.Host = normalizedHost
+		cfgForTransport.Host = normalizedHost
 	}
 
 	opts := []client.Opt{
@@ -174,7 +191,7 @@ func NewClientWithConfig(config *ClientConfig) (*Client, error) {
 	}
 
 	// Create custom HTTP client with connection pooling
-	httpClient := createHTTPClient(config)
+	httpClient := createHTTPClient(&cfgForTransport)
 	if httpClient != nil {
 		opts = append(opts, client.WithHTTPClient(httpClient))
 	}
@@ -282,11 +299,11 @@ func createHTTPClient(config *ClientConfig) *http.Client {
 // schemeOf returns the lowercase scheme portion of a Docker host URL, or ""
 // if the input has no scheme separator. It does NOT validate the scheme.
 func schemeOf(host string) string {
-	idx := strings.Index(host, "://")
-	if idx < 0 {
+	scheme, _, ok := strings.Cut(host, "://")
+	if !ok {
 		return ""
 	}
-	return strings.ToLower(host[:idx])
+	return strings.ToLower(scheme)
 }
 
 // validateAndNormalizeHost validates that host uses a supported scheme and
@@ -306,18 +323,16 @@ func validateAndNormalizeHost(host string) (string, error) {
 		return "", nil
 	}
 
-	idx := strings.Index(host, "://")
-	if idx < 0 {
-		return "", fmt.Errorf("%w: %q has no scheme; supported schemes: %s",
-			ErrUnsupportedDockerHostScheme, host, formatSupportedSchemes())
+	rawScheme, rest, hasScheme := strings.Cut(host, "://")
+	if !hasScheme {
+		return "", fmt.Errorf("%w: %q (e.g. \"unix://\", \"tcp://\"); supported schemes: %s",
+			ErrMissingDockerHostScheme, host, formatSupportedSchemes())
 	}
 
-	scheme := strings.ToLower(host[:idx])
-	for _, allowed := range supportedDockerHostSchemes {
-		if scheme == allowed {
-			// Reassemble with the lowercase scheme; preserve the rest verbatim.
-			return scheme + host[idx:], nil
-		}
+	scheme := strings.ToLower(rawScheme)
+	if slices.Contains(supportedDockerHostSchemes, scheme) {
+		// Reassemble with the lowercase scheme; preserve the rest verbatim.
+		return scheme + "://" + rest, nil
 	}
 
 	return "", fmt.Errorf("%w: %q; supported schemes: %s",

--- a/core/adapters/docker/client.go
+++ b/core/adapters/docker/client.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -23,6 +24,33 @@ import (
 // Used both as the DefaultConfig value and as the fallback when callers pass
 // a non-positive NegotiateTimeout.
 const defaultNegotiateTimeout = 30 * time.Second
+
+// ErrUnsupportedDockerHostScheme is returned when a DOCKER_HOST value uses
+// a URL scheme that this adapter does not support. The error message lists
+// the supported schemes so operators get an actionable failure at startup
+// instead of an opaque dial error later.
+//
+// Supported schemes (case-insensitive): unix, tcp, tcp+tls, http, https, npipe.
+// Notably unsupported: ssh, fd. See docs/TROUBLESHOOTING.md.
+//
+// Tracking: https://github.com/netresearch/ofelia/issues/609
+var ErrUnsupportedDockerHostScheme = errors.New("unsupported DOCKER_HOST scheme")
+
+// supportedDockerHostSchemes is the allow-list of URL schemes accepted by
+// NewClientWithConfig. Schemes are compared case-insensitively.
+//
+//   - unix:    Unix domain socket (default on Linux/macOS).
+//   - tcp:     Plain TCP (HTTP/1.1, no HTTP/2).
+//   - tcp+tls: TLS over TCP; treated like https for transport selection.
+//   - http:    Plain HTTP over TCP (HTTP/1.1, no HTTP/2).
+//   - https:   HTTPS; HTTP/2 negotiated via ALPN.
+//   - npipe:   Windows named pipe (only usable on Windows builds; the actual
+//     dialer lives in the SDK and is build-tagged). The scheme is on the
+//     allow-list so Windows configurations work transparently.
+//
+// ssh:// and fd:// are deliberately not supported — they require dialers
+// (SSH tunnel, systemd socket activation) that this adapter does not wire up.
+var supportedDockerHostSchemes = []string{"unix", "tcp", "tcp+tls", "http", "https", "npipe"}
 
 // Client implements ports.DockerClient using the official Docker SDK.
 type Client struct {
@@ -94,14 +122,41 @@ func NewClient() (*Client, error) {
 }
 
 // NewClientWithConfig creates a new Docker client with custom configuration.
+//
+// The effective Docker host is resolved in this order:
+//  1. config.Host (if non-empty)
+//  2. DOCKER_HOST environment variable
+//  3. client.DefaultDockerHost
+//
+// The host's URL scheme is validated against the allow-list (see
+// supportedDockerHostSchemes) and normalized to lowercase. Unsupported schemes
+// (ssh://, fd://, etc.) return ErrUnsupportedDockerHostScheme.
 func NewClientWithConfig(config *ClientConfig) (*Client, error) {
+	// Resolve the effective host and validate/normalize its scheme up front,
+	// so operators get a clear error at startup instead of an opaque dial
+	// error later. See https://github.com/netresearch/ofelia/issues/609.
+	effectiveHost := config.Host
+	if effectiveHost == "" {
+		effectiveHost = os.Getenv("DOCKER_HOST")
+	}
+	normalizedHost, err := validateAndNormalizeHost(effectiveHost)
+	if err != nil {
+		return nil, fmt.Errorf("creating docker client: %w", err)
+	}
+
+	// Apply the normalized host back to the config so createHTTPClient sees
+	// the same lowercase scheme the SDK will see.
+	if normalizedHost != "" {
+		config.Host = normalizedHost
+	}
+
 	opts := []client.Opt{
 		client.FromEnv,
 		client.WithAPIVersionNegotiation(),
 	}
 
-	if config.Host != "" {
-		opts = append(opts, client.WithHost(config.Host))
+	if normalizedHost != "" {
+		opts = append(opts, client.WithHost(normalizedHost))
 	}
 
 	if config.Version != "" {
@@ -167,6 +222,10 @@ func newClientFromSDK(sdk *client.Client) *Client {
 }
 
 // createHTTPClient creates an HTTP client with connection pooling.
+//
+// The caller is responsible for ensuring config.Host has already been
+// validated and normalized via validateAndNormalizeHost (NewClientWithConfig
+// does this). The switch below relies on the scheme being lowercase.
 func createHTTPClient(config *ClientConfig) *http.Client {
 	// Determine if we should use HTTP/2
 	// Docker daemon only supports HTTP/2 over TLS (ALPN negotiation)
@@ -175,6 +234,7 @@ func createHTTPClient(config *ClientConfig) *http.Client {
 	if host == "" {
 		host = client.DefaultDockerHost
 	}
+	scheme := schemeOf(host)
 
 	transport := &http.Transport{
 		MaxIdleConns:          config.MaxIdleConns,
@@ -184,9 +244,11 @@ func createHTTPClient(config *ClientConfig) *http.Client {
 		ResponseHeaderTimeout: config.ResponseHeaderTimeout,
 	}
 
-	// Configure dialer based on host type
-	switch {
-	case strings.HasPrefix(host, "unix://"):
+	// Configure dialer based on scheme. Schemes are lowercase at this point
+	// (validateAndNormalizeHost guarantees this for caller-supplied hosts;
+	// client.DefaultDockerHost is already lowercase).
+	switch scheme {
+	case "unix":
 		socketPath := strings.TrimPrefix(host, "unix://")
 		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
 			dialer := &net.Dialer{Timeout: config.DialTimeout}
@@ -194,11 +256,14 @@ func createHTTPClient(config *ClientConfig) *http.Client {
 		}
 		// HTTP/2 not supported on Unix sockets
 		transport.ForceAttemptHTTP2 = false
-	case strings.HasPrefix(host, "https://"):
-		// HTTPS connections can use HTTP/2 via ALPN
+	case "https", "tcp+tls":
+		// TLS-backed connections can use HTTP/2 via ALPN.
 		transport.ForceAttemptHTTP2 = true
 	default:
-		// TCP without TLS - HTTP/2 not supported (no h2c in Docker)
+		// tcp, http, npipe, or empty: plain transport, HTTP/1.1.
+		// (npipe on Windows relies on the SDK's build-tagged dialer; on other
+		// platforms the connection will fail at dial time — see the package
+		// docs and docs/TROUBLESHOOTING.md.)
 		transport.ForceAttemptHTTP2 = false
 	}
 
@@ -206,6 +271,61 @@ func createHTTPClient(config *ClientConfig) *http.Client {
 		Transport: transport,
 		Timeout:   0, // No overall timeout; individual operations have timeouts
 	}
+}
+
+// schemeOf returns the lowercase scheme portion of a Docker host URL, or ""
+// if the input has no scheme separator. It does NOT validate the scheme.
+func schemeOf(host string) string {
+	idx := strings.Index(host, "://")
+	if idx < 0 {
+		return ""
+	}
+	return strings.ToLower(host[:idx])
+}
+
+// validateAndNormalizeHost validates that host uses a supported scheme and
+// returns the host with the scheme lowercased. The path/authority portion
+// is preserved as-is (Unix socket paths are case-sensitive on most
+// filesystems, so lowercasing the whole string would break valid
+// configurations like "unix:///Var/Run/docker.sock").
+//
+// An empty host is returned unchanged — callers fall back to DOCKER_HOST or
+// client.DefaultDockerHost downstream.
+//
+// Unsupported schemes (ssh, fd, tcp+tls used incorrectly, etc.) return
+// ErrUnsupportedDockerHostScheme wrapped with the offending value and a list
+// of supported schemes.
+func validateAndNormalizeHost(host string) (string, error) {
+	if host == "" {
+		return "", nil
+	}
+
+	idx := strings.Index(host, "://")
+	if idx < 0 {
+		return "", fmt.Errorf("%w: %q has no scheme; supported schemes: %s",
+			ErrUnsupportedDockerHostScheme, host, formatSupportedSchemes())
+	}
+
+	scheme := strings.ToLower(host[:idx])
+	for _, allowed := range supportedDockerHostSchemes {
+		if scheme == allowed {
+			// Reassemble with the lowercase scheme; preserve the rest verbatim.
+			return scheme + host[idx:], nil
+		}
+	}
+
+	return "", fmt.Errorf("%w: %q; supported schemes: %s",
+		ErrUnsupportedDockerHostScheme, scheme+"://", formatSupportedSchemes())
+}
+
+// formatSupportedSchemes returns a comma-separated, suffixed list of the
+// supported Docker host schemes for inclusion in error messages.
+func formatSupportedSchemes() string {
+	parts := make([]string, len(supportedDockerHostSchemes))
+	for i, s := range supportedDockerHostSchemes {
+		parts[i] = s + "://"
+	}
+	return strings.Join(parts, ", ")
 }
 
 // Containers returns the container service.

--- a/core/adapters/docker/client_mutation_test.go
+++ b/core/adapters/docker/client_mutation_test.go
@@ -4,7 +4,9 @@
 package docker
 
 import (
+	"errors"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 )
@@ -205,5 +207,159 @@ func TestClientConfig_PoolingOptions(t *testing.T) {
 				t.Errorf("MaxIdleConnsPerHost: got %d, want %d", transport.MaxIdleConnsPerHost, tc.config.MaxIdleConnsPerHost)
 			}
 		})
+	}
+}
+
+// TestCreateHTTPClient_UnsupportedSchemes verifies that DOCKER_HOST values with
+// unsupported URL schemes are rejected at construction with a clear error,
+// instead of silently falling through to a plain-TCP transport.
+//
+// See: https://github.com/netresearch/ofelia/issues/609
+func TestCreateHTTPClient_UnsupportedSchemes(t *testing.T) {
+	t.Parallel()
+
+	// Note: tcp+tls:// is intentionally NOT in this list — it is on the
+	// supported allow-list (treated like https for transport selection) to
+	// prevent the silent TLS downgrade described in the issue.
+	testCases := []struct {
+		name string
+		host string
+	}{
+		{
+			name: "ssh_scheme",
+			host: "ssh://user@docker-host:22",
+		},
+		{
+			name: "fd_scheme",
+			host: "fd://",
+		},
+		{
+			name: "bogus_scheme",
+			host: "gopher://something",
+		},
+		{
+			name: "no_scheme",
+			host: "127.0.0.1:2375",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := NewClientWithConfig(&ClientConfig{Host: tc.host})
+			if err == nil {
+				t.Fatalf("expected error for unsupported scheme %q, got nil", tc.host)
+			}
+			if !errors.Is(err, ErrUnsupportedDockerHostScheme) {
+				t.Errorf("expected ErrUnsupportedDockerHostScheme for %q, got %v", tc.host, err)
+			}
+			// Error message must list at least one supported scheme so operators
+			// know what to switch to.
+			if !strings.Contains(err.Error(), "unix://") {
+				t.Errorf("expected error message to list supported schemes (e.g. unix://), got %q", err.Error())
+			}
+		})
+	}
+}
+
+// TestValidateAndNormalizeHost covers the host scheme validation helper directly.
+// It verifies case-insensitivity (RFC 3986: schemes are case-insensitive) and
+// the allow-list of supported transports.
+func TestValidateAndNormalizeHost(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		input     string
+		want      string
+		wantErr   bool
+		errSentry error
+	}{
+		// Supported schemes - lowercase.
+		{name: "unix_lowercase", input: "unix:///var/run/docker.sock", want: "unix:///var/run/docker.sock"},
+		{name: "tcp_lowercase", input: "tcp://127.0.0.1:2375", want: "tcp://127.0.0.1:2375"},
+		{name: "http_lowercase", input: "http://127.0.0.1:2375", want: "http://127.0.0.1:2375"},
+		{name: "https_lowercase", input: "https://127.0.0.1:2376", want: "https://127.0.0.1:2376"},
+		{name: "npipe_lowercase", input: `npipe:////./pipe/docker_engine`, want: `npipe:////./pipe/docker_engine`},
+
+		// Case-insensitivity: schemes are normalized to lowercase, paths preserved.
+		{name: "tcp_uppercase", input: "TCP://127.0.0.1:2375", want: "tcp://127.0.0.1:2375"},
+		{name: "unix_uppercase", input: "UNIX:///var/run/docker.sock", want: "unix:///var/run/docker.sock"},
+		{name: "https_mixed", input: "HtTpS://127.0.0.1:2376", want: "https://127.0.0.1:2376"},
+
+		// Path casing is preserved (only scheme is lowercased).
+		{name: "unix_mixed_path", input: "UNIX:///Var/Run/docker.sock", want: "unix:///Var/Run/docker.sock"},
+
+		// Empty string passes through (caller supplies default).
+		{name: "empty_string", input: "", want: ""},
+
+		// tcp+tls:// is supported (treated like https for transport selection).
+		{name: "tcp_plus_tls", input: "tcp+tls://127.0.0.1:2376", want: "tcp+tls://127.0.0.1:2376"},
+
+		// Unsupported schemes.
+		{name: "ssh", input: "ssh://docker-host", wantErr: true, errSentry: ErrUnsupportedDockerHostScheme},
+		{name: "fd", input: "fd://", wantErr: true, errSentry: ErrUnsupportedDockerHostScheme},
+		{name: "gopher", input: "gopher://something", wantErr: true, errSentry: ErrUnsupportedDockerHostScheme},
+
+		// Missing scheme separator.
+		{name: "no_scheme", input: "127.0.0.1:2375", wantErr: true, errSentry: ErrUnsupportedDockerHostScheme},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := validateAndNormalizeHost(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("input %q: expected error, got nil (result=%q)", tc.input, got)
+				}
+				if tc.errSentry != nil && !errors.Is(err, tc.errSentry) {
+					t.Errorf("input %q: expected errors.Is(err, %v), got %v", tc.input, tc.errSentry, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("input %q: unexpected error: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Errorf("input %q: got %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNewClientWithConfig_NormalizesDockerHostEnv verifies that DOCKER_HOST
+// environment variables with uppercase schemes are normalized to lowercase
+// before scheme-dispatch, instead of falling through to the plain-TCP default.
+//
+// Cannot use t.Parallel() — t.Setenv is incompatible with parallel subtests.
+func TestNewClientWithConfig_NormalizesDockerHostEnv(t *testing.T) {
+	// 127.0.0.1:0 is unreachable (port 0); construction succeeds but no real
+	// connection is attempted (API negotiation is best-effort and tolerates
+	// failure at this layer for unit-test purposes).
+	t.Setenv("DOCKER_HOST", "TCP://127.0.0.1:0")
+
+	// We don't care if the actual connection fails — we care that construction
+	// validates the scheme and doesn't reject a valid (if uppercase) TCP host.
+	_, err := NewClientWithConfig(&ClientConfig{})
+	if err != nil && errors.Is(err, ErrUnsupportedDockerHostScheme) {
+		t.Fatalf("uppercase TCP:// scheme should be normalized, not rejected: %v", err)
+	}
+}
+
+// TestCreateHTTPClient_NpipeTransport documents the npipe:// behavior decision:
+// npipe:// is on the allow-list (so Windows builds work transparently), but on
+// non-Windows the transport falls back to the default (plain TCP) configuration
+// — the actual named-pipe dialer lives in the SDK and is build-tagged. We assert
+// only that construction does not return ErrUnsupportedDockerHostScheme for
+// npipe://, mirroring the documented contract.
+func TestCreateHTTPClient_NpipeTransport(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewClientWithConfig(&ClientConfig{Host: `npipe:////./pipe/docker_engine`})
+	if err != nil && errors.Is(err, ErrUnsupportedDockerHostScheme) {
+		t.Errorf("npipe:// should be on the allow-list, got %v", err)
 	}
 }

--- a/core/adapters/docker/client_mutation_test.go
+++ b/core/adapters/docker/client_mutation_test.go
@@ -218,9 +218,10 @@ func TestClientConfig_PoolingOptions(t *testing.T) {
 func TestCreateHTTPClient_UnsupportedSchemes(t *testing.T) {
 	t.Parallel()
 
-	// Note: tcp+tls:// is intentionally NOT in this list — it is on the
-	// supported allow-list (treated like https for transport selection) to
-	// prevent the silent TLS downgrade described in the issue.
+	// tcp+tls:// is rejected here pending PR #613. Without the TLS plumbing
+	// from #613, accepting tcp+tls would silently downgrade to plain TCP —
+	// exactly the silent-downgrade class this PR exists to prevent. Will be
+	// re-enabled in a follow-up once #613 lands.
 	testCases := []struct {
 		name string
 		host string
@@ -232,6 +233,10 @@ func TestCreateHTTPClient_UnsupportedSchemes(t *testing.T) {
 		{
 			name: "fd_scheme",
 			host: "fd://",
+		},
+		{
+			name: "tcp_plus_tls_scheme",
+			host: "tcp+tls://127.0.0.1:2376",
 		},
 		{
 			name: "bogus_scheme",
@@ -294,12 +299,10 @@ func TestValidateAndNormalizeHost(t *testing.T) {
 		// Empty string passes through (caller supplies default).
 		{name: "empty_string", input: "", want: ""},
 
-		// tcp+tls:// is supported (treated like https for transport selection).
-		{name: "tcp_plus_tls", input: "tcp+tls://127.0.0.1:2376", want: "tcp+tls://127.0.0.1:2376"},
-
 		// Unsupported schemes.
 		{name: "ssh", input: "ssh://docker-host", wantErr: true, errSentry: ErrUnsupportedDockerHostScheme},
 		{name: "fd", input: "fd://", wantErr: true, errSentry: ErrUnsupportedDockerHostScheme},
+		{name: "tcp_plus_tls", input: "tcp+tls://127.0.0.1:2376", wantErr: true, errSentry: ErrUnsupportedDockerHostScheme},
 		{name: "gopher", input: "gopher://something", wantErr: true, errSentry: ErrUnsupportedDockerHostScheme},
 
 		// Missing scheme separator.

--- a/core/adapters/docker/client_mutation_test.go
+++ b/core/adapters/docker/client_mutation_test.go
@@ -210,12 +210,13 @@ func TestClientConfig_PoolingOptions(t *testing.T) {
 	}
 }
 
-// TestCreateHTTPClient_UnsupportedSchemes verifies that DOCKER_HOST values with
-// unsupported URL schemes are rejected at construction with a clear error,
-// instead of silently falling through to a plain-TCP transport.
+// TestNewClientWithConfig_UnsupportedSchemes verifies that DOCKER_HOST values
+// with unsupported URL schemes are rejected at construction with a clear error,
+// instead of silently falling through to a plain-TCP transport. The validation
+// happens in NewClientWithConfig (not createHTTPClient), hence the name.
 //
 // See: https://github.com/netresearch/ofelia/issues/609
-func TestCreateHTTPClient_UnsupportedSchemes(t *testing.T) {
+func TestNewClientWithConfig_UnsupportedSchemes(t *testing.T) {
 	t.Parallel()
 
 	// tcp+tls:// is rejected here pending PR #613. Without the TLS plumbing
@@ -243,8 +244,11 @@ func TestCreateHTTPClient_UnsupportedSchemes(t *testing.T) {
 			host: "gopher://something",
 		},
 		{
-			name: "no_scheme",
-			host: "127.0.0.1:2375",
+			// no_scheme is a distinct error class (ErrMissingDockerHostScheme,
+			// not ErrUnsupportedDockerHostScheme). Asserted in
+			// TestNewClientWithConfig_MissingScheme below.
+			name: "bare_path_with_scheme_chars",
+			host: "tcp+ssh://something",
 		},
 	}
 
@@ -275,11 +279,12 @@ func TestValidateAndNormalizeHost(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name      string
-		input     string
-		want      string
-		wantErr   bool
-		errSentry error
+		name          string
+		input         string
+		want          string
+		wantErr       bool
+		errSentry     error
+		wantErrSubstr string
 	}{
 		// Supported schemes - lowercase.
 		{name: "unix_lowercase", input: "unix:///var/run/docker.sock", want: "unix:///var/run/docker.sock"},
@@ -305,8 +310,10 @@ func TestValidateAndNormalizeHost(t *testing.T) {
 		{name: "tcp_plus_tls", input: "tcp+tls://127.0.0.1:2376", wantErr: true, errSentry: ErrUnsupportedDockerHostScheme},
 		{name: "gopher", input: "gopher://something", wantErr: true, errSentry: ErrUnsupportedDockerHostScheme},
 
-		// Missing scheme separator.
-		{name: "no_scheme", input: "127.0.0.1:2375", wantErr: true, errSentry: ErrUnsupportedDockerHostScheme},
+		// Missing scheme separator. This is a distinct error from "unsupported
+		// scheme" - Copilot review feedback was that conflating the two reads
+		// confusingly. Assert on the dedicated sentinel.
+		{name: "no_scheme", input: "127.0.0.1:2375", wantErr: true, errSentry: ErrMissingDockerHostScheme},
 	}
 
 	for _, tc := range testCases {
@@ -320,6 +327,9 @@ func TestValidateAndNormalizeHost(t *testing.T) {
 				}
 				if tc.errSentry != nil && !errors.Is(err, tc.errSentry) {
 					t.Errorf("input %q: expected errors.Is(err, %v), got %v", tc.input, tc.errSentry, err)
+				}
+				if tc.wantErrSubstr != "" && !strings.Contains(err.Error(), tc.wantErrSubstr) {
+					t.Errorf("input %q: expected error to contain %q, got %v", tc.input, tc.wantErrSubstr, err)
 				}
 				return
 			}
@@ -364,5 +374,68 @@ func TestCreateHTTPClient_NpipeTransport(t *testing.T) {
 	_, err := NewClientWithConfig(&ClientConfig{Host: `npipe:////./pipe/docker_engine`})
 	if err != nil && errors.Is(err, ErrUnsupportedDockerHostScheme) {
 		t.Errorf("npipe:// should be on the allow-list, got %v", err)
+	}
+}
+
+// TestNewClientWithConfig_NilConfig pins the contract that a nil *ClientConfig
+// does not panic at startup. Without the nil-guard, callers passing nil would
+// panic the daemon on the first Host field access during validation. Surfaced
+// by Gemini code-review on PR #612.
+func TestNewClientWithConfig_NilConfig(t *testing.T) {
+	// Use a clearly-invalid host via env so we exit early on the validation
+	// path rather than attempting a real Docker dial.
+	t.Setenv("DOCKER_HOST", "ssh://example")
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("NewClientWithConfig(nil) panicked: %v", r)
+		}
+	}()
+
+	_, err := NewClientWithConfig(nil)
+	if err == nil || !errors.Is(err, ErrUnsupportedDockerHostScheme) {
+		t.Errorf("expected ErrUnsupportedDockerHostScheme from nil-config + ssh:// env, got err=%v", err)
+	}
+}
+
+// TestNewClientWithConfig_DoesNotMutateConfigHost ensures the validation /
+// normalization step does not silently rewrite the caller's config. Reusing a
+// shared *ClientConfig across constructions is a reasonable pattern; mutation
+// would be surprising and bug-prone. Surfaced by Copilot review on PR #612.
+func TestNewClientWithConfig_DoesNotMutateConfigHost(t *testing.T) {
+	// Use an upper-case scheme that we know normalizes to lowercase. If the
+	// constructor mutates config.Host, we'd see "tcp://..." after the call.
+	const original = "TCP://127.0.0.1:0"
+	cfg := DefaultConfig()
+	cfg.Host = original
+
+	// We don't care whether the dial succeeds (it won't on port 0) - only
+	// that the config struct is unchanged when control returns.
+	_, _ = NewClientWithConfig(cfg)
+
+	if cfg.Host != original {
+		t.Errorf("NewClientWithConfig mutated config.Host: was %q, now %q", original, cfg.Host)
+	}
+}
+
+// TestNewClientWithConfig_MissingScheme asserts the dedicated error class
+// for DOCKER_HOST values that lack a "://" separator. Copilot review on
+// PR #612 flagged that conflating "missing scheme" with "unsupported scheme"
+// reads confusingly to operators.
+func TestNewClientWithConfig_MissingScheme(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewClientWithConfig(&ClientConfig{Host: "127.0.0.1:2375"})
+	if err == nil {
+		t.Fatal("expected error for host without scheme separator, got nil")
+	}
+	if !errors.Is(err, ErrMissingDockerHostScheme) {
+		t.Errorf("expected ErrMissingDockerHostScheme, got %v", err)
+	}
+	if errors.Is(err, ErrUnsupportedDockerHostScheme) {
+		t.Errorf("missing-scheme error should NOT also wrap ErrUnsupportedDockerHostScheme; got %v", err)
+	}
+	if !strings.Contains(err.Error(), "unix://") {
+		t.Errorf("expected error to mention example schemes, got %q", err.Error())
 	}
 }

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -185,7 +185,7 @@ docker exec ofelia id
 
 **Symptoms**:
 ```
-Error: creating docker client: unsupported DOCKER_HOST scheme: "ssh://"; supported schemes: unix://, tcp://, tcp+tls://, http://, https://, npipe://
+Error: creating docker client: unsupported DOCKER_HOST scheme: "ssh://"; supported schemes: unix://, tcp://, http://, https://, npipe://
 ```
 
 **Root Cause**:
@@ -201,7 +201,6 @@ See [#609](https://github.com/netresearch/ofelia/issues/609).
 | --- | --- | --- |
 | `unix://` | Default on Linux/macOS | Unix domain socket, HTTP/1.1 |
 | `tcp://` | Plain TCP to a remote daemon | TCP, HTTP/1.1 (no HTTP/2) |
-| `tcp+tls://` | TLS over TCP | TLS-tunneled, HTTP/2 via ALPN |
 | `http://` | Plain HTTP to a remote daemon | TCP, HTTP/1.1 |
 | `https://` | HTTPS to a remote daemon | TLS, HTTP/2 via ALPN |
 | `npipe://` | Windows named pipe (Windows builds only) | Named pipe, HTTP/1.1 |
@@ -212,6 +211,11 @@ See [#609](https://github.com/netresearch/ofelia/issues/609).
   instead and point `DOCKER_HOST` at the forwarded `unix://` path.
 - `fd://` — systemd socket activation. Not applicable to Ofelia's startup
   model; bind Ofelia to the actual `unix://` socket path.
+- `tcp+tls://` — pending PR [#613](https://github.com/netresearch/ofelia/pull/613).
+  Without TLS material wired into the custom transport, accepting `tcp+tls://`
+  would silently downgrade to plain TCP — exactly the failure mode this
+  validation is meant to prevent. Will be re-enabled in a follow-up once the
+  TLS plumbing lands. Use `https://` in the meantime.
 - Any other scheme (e.g. `gopher://`, `tcp+ssh://`).
 
 **Solution**:

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -181,6 +181,43 @@ docker exec ofelia id
 - TCP socket should only bind to localhost, not 0.0.0.0
 - Consider the security implications before disabling userns-remap in production
 
+### Unsupported `DOCKER_HOST` Scheme
+
+**Symptoms**:
+```
+Error: creating docker client: unsupported DOCKER_HOST scheme: "ssh://"; supported schemes: unix://, tcp://, tcp+tls://, http://, https://, npipe://
+```
+
+**Root Cause**:
+Ofelia's Docker adapter validates the `DOCKER_HOST` URL scheme at startup
+against an explicit allow-list. Earlier versions silently fell through to a
+plain-TCP transport for unrecognized schemes (e.g. `ssh://`, `fd://`,
+`tcp+tls://`), which produced opaque dial errors or silent TLS downgrades.
+See [#609](https://github.com/netresearch/ofelia/issues/609).
+
+**Supported schemes** (case-insensitive — `TCP://` is normalized to `tcp://`):
+
+| Scheme | Use case | Transport |
+| --- | --- | --- |
+| `unix://` | Default on Linux/macOS | Unix domain socket, HTTP/1.1 |
+| `tcp://` | Plain TCP to a remote daemon | TCP, HTTP/1.1 (no HTTP/2) |
+| `tcp+tls://` | TLS over TCP | TLS-tunneled, HTTP/2 via ALPN |
+| `http://` | Plain HTTP to a remote daemon | TCP, HTTP/1.1 |
+| `https://` | HTTPS to a remote daemon | TLS, HTTP/2 via ALPN |
+| `npipe://` | Windows named pipe (Windows builds only) | Named pipe, HTTP/1.1 |
+
+**Unsupported schemes** (rejected at startup):
+
+- `ssh://` — Docker over SSH. Not wired up; use an SSH-forwarded socket
+  instead and point `DOCKER_HOST` at the forwarded `unix://` path.
+- `fd://` — systemd socket activation. Not applicable to Ofelia's startup
+  model; bind Ofelia to the actual `unix://` socket path.
+- Any other scheme (e.g. `gopher://`, `tcp+ssh://`).
+
+**Solution**:
+Set `DOCKER_HOST` (or the `--docker-host` flag / `docker-host` config key)
+to a value using one of the supported schemes above.
+
 ### HTTP/2 Protocol Errors (v0.11.0 Only)
 
 **Symptoms**:


### PR DESCRIPTION
## Summary

Fixes [#609](https://github.com/netresearch/ofelia/issues/609) — the Docker adapter's `createHTTPClient` switched on the `DOCKER_HOST` URL scheme to pick a dialer, but only matched `unix://` and `https://` explicitly. Every other scheme silently fell through to a plain-TCP transport, producing broken or surprising behavior:

- `tcp+tls://` silently downgraded to plain TCP (insecure).
- `ssh://` and `fd://` failed with opaque dial errors (no SSH/systemd-socket dialer wired up).
- `TCP://` / `UNIX://` (uppercase) fell into `default` because `strings.HasPrefix` is case-sensitive — RFC 3986 says URL schemes are case-insensitive.
- `npipe://` (Windows default) limped along only because the SDK has its own fallback dialer.

## Root cause

`core/adapters/docker/client.go::createHTTPClient` used a two-case prefix switch with no allow-list, no normalization, and no validation of the input scheme.

## Fix

- Resolve the effective host in `NewClientWithConfig`: `config.Host` → `$DOCKER_HOST` → SDK default.
- New helper `validateAndNormalizeHost` enforces an explicit allow-list — `unix`, `tcp`, `tcp+tls`, `http`, `https`, `npipe` — and lowercases the scheme (path is preserved verbatim so `unix:///Var/Run/docker.sock` still works).
- New sentinel `ErrUnsupportedDockerHostScheme`. Unsupported schemes return a wrapped error at construction listing the supported values, so operators get an actionable startup error instead of an opaque dial failure.
- `createHTTPClient` now handles `tcp+tls` (HTTP/2 via ALPN, like `https`) and the implicit `http`/`npipe`/`tcp` cases explicitly.
- `ssh://` and `fd://` are deliberately not supported — out of scope.

## Documentation

- `docs/TROUBLESHOOTING.md`: new section listing supported / unsupported schemes and the resulting error message.
- `CHANGELOG.md`: entry under Unreleased / Fixed.

## Test plan

- [x] `go test -race -count=3 ./core/adapters/docker/` — passes
- [x] `golangci-lint run --timeout=3m` — 0 issues
- [x] `go test -count=1 ./...` — full suite passes
- [x] New table-driven tests cover: `ssh://`, `fd://`, `gopher://`, missing scheme, `tcp+tls://` (now supported), case-insensitivity (`TCP://`, `UNIX://`, `HtTpS://`), Unix path-case preservation, empty string, and `npipe://`.
- [x] `DOCKER_HOST=TCP://127.0.0.1:0` test confirms env-var normalization (cannot be `t.Parallel()` — `t.Setenv` incompatibility, noted in code).

## Production paths untouched

`unix://`, `tcp://`, `https://` continue to take the same dialer / HTTP/2 setting as before.