### PR TITLE
feat(docker): re-enable tcp+tls:// scheme now that TLS plumbing has landed (#616)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `tcp+tls://` is back on the `DOCKER_HOST` allow-list now that the TLS plumbing from [#613](https://github.com/netresearch/ofelia/pull/613) wires `DOCKER_CERT_PATH` / `DOCKER_TLS_VERIFY` (and the equivalent `ClientConfig.TLSCertPath` / `TLSVerify` overrides) into the custom HTTP transport. PR [#612](https://github.com/netresearch/ofelia/pull/612) had withheld it to avoid a silent plain-TCP downgrade; that risk is now closed by the existing `TestCreateHTTPClient_TCPPlusTLSEnablesTLS` regression test plus the new `TestNewClientWithConfig_TCPPlusTLSScheme` allow-list assertion. ([#620](https://github.com/netresearch/ofelia/pull/620), fixes [#616](https://github.com/netresearch/ofelia/issues/616))
+- `tcp+tls://` is back on the `DOCKER_HOST` allow-list now that the TLS plumbing from [#613](https://github.com/netresearch/ofelia/pull/613) wires `DOCKER_CERT_PATH` / `DOCKER_TLS_VERIFY` (and the equivalent `ClientConfig.TLSCertPath` / `TLSVerify` overrides) into the custom HTTP transport. PR [#612](https://github.com/netresearch/ofelia/pull/612) had withheld it to avoid a silent plain-TCP downgrade; that risk is now closed by the existing `TestCreateHTTPClient_TCPPlusTLSEnablesTLS` regression test plus the new `TestNewClientWithConfig_TCPPlusTLSScheme` allow-list assertion. ([#625](https://github.com/netresearch/ofelia/pull/625), fixes [#616](https://github.com/netresearch/ofelia/issues/616))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `tcp+tls://` is back on the `DOCKER_HOST` allow-list now that the TLS plumbing from [#613](https://github.com/netresearch/ofelia/pull/613) wires `DOCKER_CERT_PATH` / `DOCKER_TLS_VERIFY` (and the equivalent `ClientConfig.TLSCertPath` / `TLSVerify` overrides) into the custom HTTP transport. PR [#612](https://github.com/netresearch/ofelia/pull/612) had withheld it to avoid a silent plain-TCP downgrade; that risk is now closed by the existing `TestCreateHTTPClient_TCPPlusTLSEnablesTLS` regression test plus the new `TestNewClientWithConfig_TCPPlusTLSScheme` allow-list assertion. ([#620](https://github.com/netresearch/ofelia/pull/620), fixes [#616](https://github.com/netresearch/ofelia/issues/616))
+
 ### Changed
 
-- **BREAKING:** `DOCKER_HOST` scheme is now validated against an allow-list (`unix://`, `tcp://`, `http://`, `https://`, `npipe://`) and normalized to lowercase. Unsupported schemes (`ssh://`, `fd://`, `tcp+tls://`, bogus values) now fail at startup with a clear error instead of silently falling through to a plain-TCP transport. Fixes case-sensitivity bug for `TCP://` / `UNIX://`. Configurations that previously relied on the silent fallthrough will now fail loudly — operators using `ssh://` should switch to an SSH-forwarded socket and point `DOCKER_HOST` at the forwarded `unix://` path. Note: `tcp+tls://` is rejected pending the TLS-plumbing fix in [#613](https://github.com/netresearch/ofelia/pull/613) — accepting it here without TLS material in the transport would silently downgrade to plain TCP. ([#612](https://github.com/netresearch/ofelia/pull/612), fixes [#609](https://github.com/netresearch/ofelia/issues/609))
+- **BREAKING:** `DOCKER_HOST` scheme is now validated against an allow-list (`unix://`, `tcp://`, `tcp+tls://`, `http://`, `https://`, `npipe://`) and normalized to lowercase. Unsupported schemes (`ssh://`, `fd://`, bogus values) now fail at startup with a clear error instead of silently falling through to a plain-TCP transport. Fixes case-sensitivity bug for `TCP://` / `UNIX://`. Configurations that previously relied on the silent fallthrough will now fail loudly — operators using `ssh://` should switch to an SSH-forwarded socket and point `DOCKER_HOST` at the forwarded `unix://` path. ([#612](https://github.com/netresearch/ofelia/pull/612), fixes [#609](https://github.com/netresearch/ofelia/issues/609))
 
 ### Security
 

--- a/core/adapters/docker/client.go
+++ b/core/adapters/docker/client.go
@@ -34,8 +34,8 @@ const defaultNegotiateTimeout = 30 * time.Second
 // the supported schemes so operators get an actionable failure at startup
 // instead of an opaque dial error later.
 //
-// Supported schemes (case-insensitive): unix, tcp, http, https, npipe.
-// Notably unsupported: ssh, fd, tcp+tls. See docs/TROUBLESHOOTING.md.
+// Supported schemes (case-insensitive): unix, tcp, tcp+tls, http, https, npipe.
+// Notably unsupported: ssh, fd. See docs/TROUBLESHOOTING.md.
 //
 // Tracking: https://github.com/netresearch/ofelia/issues/609
 var ErrUnsupportedDockerHostScheme = errors.New("unsupported DOCKER_HOST scheme")
@@ -50,7 +50,13 @@ var ErrMissingDockerHostScheme = errors.New("missing DOCKER_HOST scheme")
 // NewClientWithConfig. Schemes are compared case-insensitively.
 //
 //   - unix:    Unix domain socket (default on Linux/macOS).
-//   - tcp:     Plain TCP (HTTP/1.1, no HTTP/2).
+//   - tcp:     Plain TCP (HTTP/1.1, no HTTP/2). Auto-upgrades to TLS when
+//     DOCKER_TLS_VERIFY / DOCKER_CERT_PATH are set, mirroring the Docker
+//     CLI/SDK precedent.
+//   - tcp+tls: Explicit TLS over TCP. Requires TLS material via
+//     DOCKER_CERT_PATH / DOCKER_TLS_VERIFY (or ClientConfig.TLSCertPath /
+//     TLSVerify). Re-enabled in #616 now that the TLS plumbing from #613
+//     wires the cert material into the custom transport.
 //   - http:    Plain HTTP over TCP (HTTP/1.1, no HTTP/2).
 //   - https:   HTTPS; HTTP/2 negotiated via ALPN.
 //   - npipe:   Windows named pipe (only usable on Windows builds; the actual
@@ -61,12 +67,7 @@ var ErrMissingDockerHostScheme = errors.New("missing DOCKER_HOST scheme")
 //
 //   - ssh:    Requires an SSH tunnel dialer this adapter does not wire up.
 //   - fd:     Requires systemd socket activation we do not handle.
-//   - tcp+tls: Withheld pending PR #613 (issue #607). Without TLS material
-//     wired into the custom transport, accepting tcp+tls would silently
-//     downgrade to plain TCP — exactly the silent-downgrade class this PR
-//     is supposed to prevent. Re-enable in a follow-up once TLS plumbing
-//     lands.
-var supportedDockerHostSchemes = []string{"unix", "tcp", "http", "https", "npipe"}
+var supportedDockerHostSchemes = []string{"unix", "tcp", "tcp+tls", "http", "https", "npipe"}
 
 // Client implements ports.DockerClient using the official Docker SDK.
 type Client struct {
@@ -305,9 +306,9 @@ func createHTTPClient(config *ClientConfig) *http.Client {
 		transport.ForceAttemptHTTP2 = false
 	case "https", "tcp+tls":
 		// HTTPS / tcp+tls connections can use HTTP/2 via ALPN.
-		// tcp+tls is matched here defensively even though PR #612 currently
-		// rejects it at validateAndNormalizeHost; if that allow-list is
-		// re-enabled, this branch ensures the connection actually gets TLS.
+		// tcp+tls was re-enabled on the allow-list in #616 once the TLS
+		// plumbing from #613 was confirmed to wire cert material into the
+		// custom transport via applyDockerTLS.
 		transport.ForceAttemptHTTP2 = true
 		applyDockerTLS(transport, config)
 	case "tcp":

--- a/core/adapters/docker/client_mutation_test.go
+++ b/core/adapters/docker/client_mutation_test.go
@@ -228,10 +228,9 @@ func TestClientConfig_PoolingOptions(t *testing.T) {
 func TestNewClientWithConfig_UnsupportedSchemes(t *testing.T) {
 	t.Parallel()
 
-	// tcp+tls:// is rejected here pending PR #613. Without the TLS plumbing
-	// from #613, accepting tcp+tls would silently downgrade to plain TCP —
-	// exactly the silent-downgrade class this PR exists to prevent. Will be
-	// re-enabled in a follow-up once #613 lands.
+	// tcp+tls:// was re-enabled in #616 once the TLS plumbing from #613
+	// landed; it is asserted as a positive case in
+	// TestNewClientWithConfig_TCPPlusTLSScheme below.
 	testCases := []struct {
 		name string
 		host string
@@ -243,10 +242,6 @@ func TestNewClientWithConfig_UnsupportedSchemes(t *testing.T) {
 		{
 			name: "fd_scheme",
 			host: "fd://",
-		},
-		{
-			name: "tcp_plus_tls_scheme",
-			host: "tcp+tls://127.0.0.1:2376",
 		},
 		{
 			name: "bogus_scheme",
@@ -281,6 +276,30 @@ func TestNewClientWithConfig_UnsupportedSchemes(t *testing.T) {
 	}
 }
 
+// TestNewClientWithConfig_TCPPlusTLSScheme asserts that DOCKER_HOST values
+// using the tcp+tls:// scheme are accepted by NewClientWithConfig now that the
+// TLS plumbing from #613 wires cert material into the custom transport.
+//
+// Construction must NOT fail with ErrUnsupportedDockerHostScheme. We use port
+// 0 so no real network connection is attempted; an unrelated dial / negotiate
+// error is acceptable - the only thing this test pins is that the scheme
+// passes the allow-list. See https://github.com/netresearch/ofelia/issues/616.
+func TestNewClientWithConfig_TCPPlusTLSScheme(t *testing.T) {
+	// Not parallel: mutates DOCKER_HOST / DOCKER_TLS_VERIFY / DOCKER_CERT_PATH
+	// via t.Setenv to avoid leaking ambient env into createHTTPClient's
+	// FromEnv-style fallbacks.
+	t.Setenv("DOCKER_HOST", "")
+	t.Setenv("DOCKER_TLS_VERIFY", "")
+	t.Setenv("DOCKER_CERT_PATH", "")
+
+	_, err := NewClientWithConfig(&ClientConfig{Host: "tcp+tls://127.0.0.1:0"})
+	if errors.Is(err, ErrUnsupportedDockerHostScheme) {
+		t.Fatalf("tcp+tls:// must be on the allow-list (#616), got ErrUnsupportedDockerHostScheme: %v", err)
+	}
+	// Any other error (dial / negotiate failure against 127.0.0.1:0) is fine
+	// - this test only pins scheme acceptance, not connectivity.
+}
+
 // TestValidateAndNormalizeHost covers the host scheme validation helper directly.
 // It verifies case-insensitivity (RFC 3986: schemes are case-insensitive) and
 // the allow-list of supported transports.
@@ -298,6 +317,7 @@ func TestValidateAndNormalizeHost(t *testing.T) {
 		// Supported schemes - lowercase.
 		{name: "unix_lowercase", input: "unix:///var/run/docker.sock", want: "unix:///var/run/docker.sock"},
 		{name: "tcp_lowercase", input: "tcp://127.0.0.1:2375", want: "tcp://127.0.0.1:2375"},
+		{name: "tcp_plus_tls_lowercase", input: "tcp+tls://127.0.0.1:2376", want: "tcp+tls://127.0.0.1:2376"},
 		{name: "http_lowercase", input: "http://127.0.0.1:2375", want: "http://127.0.0.1:2375"},
 		{name: "https_lowercase", input: "https://127.0.0.1:2376", want: "https://127.0.0.1:2376"},
 		{name: "npipe_lowercase", input: `npipe:////./pipe/docker_engine`, want: `npipe:////./pipe/docker_engine`},
@@ -306,6 +326,7 @@ func TestValidateAndNormalizeHost(t *testing.T) {
 		{name: "tcp_uppercase", input: "TCP://127.0.0.1:2375", want: "tcp://127.0.0.1:2375"},
 		{name: "unix_uppercase", input: "UNIX:///var/run/docker.sock", want: "unix:///var/run/docker.sock"},
 		{name: "https_mixed", input: "HtTpS://127.0.0.1:2376", want: "https://127.0.0.1:2376"},
+		{name: "tcp_plus_tls_uppercase", input: "TCP+TLS://127.0.0.1:2376", want: "tcp+tls://127.0.0.1:2376"},
 
 		// Path casing is preserved (only scheme is lowercased).
 		{name: "unix_mixed_path", input: "UNIX:///Var/Run/docker.sock", want: "unix:///Var/Run/docker.sock"},
@@ -316,7 +337,6 @@ func TestValidateAndNormalizeHost(t *testing.T) {
 		// Unsupported schemes.
 		{name: "ssh", input: "ssh://docker-host", wantErr: true, errSentry: ErrUnsupportedDockerHostScheme},
 		{name: "fd", input: "fd://", wantErr: true, errSentry: ErrUnsupportedDockerHostScheme},
-		{name: "tcp_plus_tls", input: "tcp+tls://127.0.0.1:2376", wantErr: true, errSentry: ErrUnsupportedDockerHostScheme},
 		{name: "gopher", input: "gopher://something", wantErr: true, errSentry: ErrUnsupportedDockerHostScheme},
 
 		// Missing scheme separator. This is a distinct error from "unsupported

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -244,14 +244,17 @@ networks:
 
 **Symptoms**:
 ```
-Error: creating docker client: unsupported DOCKER_HOST scheme: "ssh://"; supported schemes: unix://, tcp://, http://, https://, npipe://
+Error: creating docker client: unsupported DOCKER_HOST scheme: "ssh://"; supported schemes: unix://, tcp://, tcp+tls://, http://, https://, npipe://
 ```
 
 **Root Cause**:
 Ofelia's Docker adapter validates the `DOCKER_HOST` URL scheme at startup
 against an explicit allow-list. Earlier versions silently fell through to a
-plain-TCP transport for unrecognized schemes (e.g. `ssh://`, `fd://`,
-`tcp+tls://`), which produced opaque dial errors or silent TLS downgrades.
+plain-TCP transport for unrecognized schemes (e.g. `ssh://`, `fd://`),
+which produced opaque dial errors. `tcp+tls://` was historically in the
+same boat but is now supported (see the table below — the TLS plumbing
+landed in [#613](https://github.com/netresearch/ofelia/pull/613) and the
+allow-list was re-opened in [#625](https://github.com/netresearch/ofelia/pull/625)).
 See [#609](https://github.com/netresearch/ofelia/issues/609).
 
 **Supported schemes** (case-insensitive — `TCP://` is normalized to `tcp://`):

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -259,7 +259,8 @@ See [#609](https://github.com/netresearch/ofelia/issues/609).
 | Scheme | Use case | Transport |
 | --- | --- | --- |
 | `unix://` | Default on Linux/macOS | Unix domain socket, HTTP/1.1 |
-| `tcp://` | Plain TCP to a remote daemon | TCP, HTTP/1.1 (no HTTP/2) |
+| `tcp://` | Plain TCP to a remote daemon (auto-upgrades to TLS when `DOCKER_TLS_VERIFY` / `DOCKER_CERT_PATH` are set) | TCP, HTTP/1.1 (HTTP/2 over TLS via ALPN) |
+| `tcp+tls://` | Explicit TLS over TCP (requires `DOCKER_CERT_PATH` / `DOCKER_TLS_VERIFY`) | TLS, HTTP/2 via ALPN |
 | `http://` | Plain HTTP to a remote daemon | TCP, HTTP/1.1 |
 | `https://` | HTTPS to a remote daemon | TLS, HTTP/2 via ALPN |
 | `npipe://` | Windows named pipe (Windows builds only) | Named pipe, HTTP/1.1 |
@@ -270,11 +271,6 @@ See [#609](https://github.com/netresearch/ofelia/issues/609).
   instead and point `DOCKER_HOST` at the forwarded `unix://` path.
 - `fd://` — systemd socket activation. Not applicable to Ofelia's startup
   model; bind Ofelia to the actual `unix://` socket path.
-- `tcp+tls://` — pending PR [#613](https://github.com/netresearch/ofelia/pull/613).
-  Without TLS material wired into the custom transport, accepting `tcp+tls://`
-  would silently downgrade to plain TCP — exactly the failure mode this
-  validation is meant to prevent. Will be re-enabled in a follow-up once the
-  TLS plumbing lands. Use `https://` in the meantime.
 - Any other scheme (e.g. `gopher://`, `tcp+ssh://`).
 
 **Solution**:


### PR DESCRIPTION
## Summary

Re-enables the `tcp+tls://` `DOCKER_HOST` scheme that was dropped from the allow-list by [#612](https://github.com/netresearch/ofelia/pull/612) while waiting for the TLS-plumbing fix. The plumbing landed in [#613](https://github.com/netresearch/ofelia/pull/613) — `createHTTPClient` already routes `"https"` and `"tcp+tls"` through the same TLS-aware arm via `applyDockerTLS`, and `TestCreateHTTPClient_TCPPlusTLSEnablesTLS` (#613) pins that contract. The silent-downgrade risk that justified the temporary rejection is therefore closed.

## Changes

- `core/adapters/docker/client.go`: re-add `"tcp+tls"` to `supportedDockerHostSchemes`; refresh the allow-list / switch-arm comments to reflect the new state.
- `core/adapters/docker/client_mutation_test.go`:
  - Drop `tcp_plus_tls_scheme` from `TestNewClientWithConfig_UnsupportedSchemes`.
  - Add `tcp_plus_tls_lowercase` and `tcp_plus_tls_uppercase` (case-normalization) to the accept table in `TestValidateAndNormalizeHost`.
  - New `TestNewClientWithConfig_TCPPlusTLSScheme`: asserts that `NewClientWithConfig(Host: "tcp+tls://127.0.0.1:0")` does NOT return `ErrUnsupportedDockerHostScheme` (any unrelated dial / negotiate error is acceptable — the test only pins scheme acceptance).
- `docs/TROUBLESHOOTING.md`: `tcp+tls://` row added back to the supported schemes table; pending-PR note removed from the unsupported list.
- `CHANGELOG.md`: new `### Added` entry under `[Unreleased]`; remove the now-stale "tcp+tls:// rejected pending #613" note from the existing #612 `### Changed` entry.

Pure additive — no other code paths touched, `validateAndNormalizeHost` signature unchanged.

Fixes [#616](https://github.com/netresearch/ofelia/issues/616).

## Test plan

- [x] `go test -race ./core/adapters/docker/` — passes locally (5.6s)
- [x] `golangci-lint run --timeout=3m` — 0 issues (full project)
- [x] New positive test `TestNewClientWithConfig_TCPPlusTLSScheme` exercises the allow-list change
- [x] Existing `TestCreateHTTPClient_TCPPlusTLSEnablesTLS` (from #613) still asserts the TLS material is wired
- [ ] CI green