### PR TITLE
docs(config): reconcile Slack and Save key documentation with code (#621)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 
 - Reconcile **Slack** middleware key documentation with the actual struct fields in `middlewares.SlackConfig`. Removed the documented-but-rejected `slack-url` (typo for `slack-webhook`), `slack-channel`, `slack-mentions`, `slack-icon-emoji`, and `slack-username` keys from `docs/CONFIGURATION.md` and `docs/QUICK_REFERENCE.md`. The legacy Slack middleware (deprecated, scheduled for removal in v1.0.0) only accepts `slack-webhook` and `slack-only-on-error`; for channel routing, mentions, custom username/avatar, etc., migrate to a `[webhook "name"]` section with `preset = slack` ([webhook docs](docs/webhooks.md)). ([#621](https://github.com/netresearch/ofelia/issues/621))
+- Reconcile **Save** middleware key documentation with the actual struct fields in `middlewares.SaveConfig`. Documented the existing `restore-history` and `restore-history-max-age` global keys (supported by the parser but undocumented) and removed the unimplemented `save-format` and `save-retention` keys from `docs/CONFIGURATION.md`. ([#621](https://github.com/netresearch/ofelia/issues/621))
 
 ## [0.24.0] - 2026-05-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Stabilize `TestHealthStatus` race against the `NewHealthChecker` background goroutine — build the `HealthChecker` directly in the test so the auto-injected `docker=Unhealthy` check cannot leak into the aggregated status before `GetHealth()` runs. ([#606](https://github.com/netresearch/ofelia/pull/606))
 
+### Documentation
+
+- Reconcile **Slack** middleware key documentation with the actual struct fields in `middlewares.SlackConfig`. Removed the documented-but-rejected `slack-url` (typo for `slack-webhook`), `slack-channel`, `slack-mentions`, `slack-icon-emoji`, and `slack-username` keys from `docs/CONFIGURATION.md` and `docs/QUICK_REFERENCE.md`. The legacy Slack middleware (deprecated, scheduled for removal in v1.0.0) only accepts `slack-webhook` and `slack-only-on-error`; for channel routing, mentions, custom username/avatar, etc., migrate to a `[webhook "name"]` section with `preset = slack` ([webhook docs](docs/webhooks.md)). ([#621](https://github.com/netresearch/ofelia/issues/621))
+
 ## [0.24.0] - 2026-05-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Tests
 
 - Stabilize `TestHealthStatus` race against the `NewHealthChecker` background goroutine — build the `HealthChecker` directly in the test so the auto-injected `docker=Unhealthy` check cannot leak into the aggregated status before `GetHealth()` runs. ([#606](https://github.com/netresearch/ofelia/pull/606))
+- New `TestConfigGlobalKeysAreDocumented` walks the embedded middleware structs in `Config.Global` via reflection and asserts each `mapstructure` key is mentioned in at least one operator-facing docs file (`docs/CONFIGURATION.md`, `docs/webhooks.md`, `docs/QUICK_REFERENCE.md`, `docs/TROUBLESHOOTING.md`, `README.md`). Catches the same drift class as #604 / #621 mechanically. ([#621](https://github.com/netresearch/ofelia/issues/621))
 
 ### Documentation
 

--- a/cli/config_drift_test.go
+++ b/cli/config_drift_test.go
@@ -38,7 +38,17 @@ func TestConfigGlobalKeysAreDocumented(t *testing.T) {
 
 	// Walk Config.Global; for every embedded struct (squash), pull each field's
 	// mapstructure tag (stripped of options) and verify the docs mention it.
-	globalT := reflect.TypeOf(Config{}).Field(0).Type // Global anonymous struct
+	//
+	// Robust against future Config restructuring: look up the Global field by
+	// name rather than by index 0, so a refactor that adds a sibling field
+	// before Global doesn't silently change what this test inspects.
+	globalField, ok := reflect.TypeOf(Config{}).FieldByName("Global")
+	if !ok {
+		t.Fatal("Config.Global field not found - did the struct get renamed?")
+	}
+	globalT := globalField.Type
+	// TODO(#635): also walk non-anonymous (direct) Global fields once the
+	// undocumented direct keys (notification-cooldown, etc.) get docs.
 	for i := range globalT.NumField() {
 		f := globalT.Field(i)
 		if !f.Anonymous {

--- a/cli/config_drift_test.go
+++ b/cli/config_drift_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestConfigGlobalKeysAreDocumented walks every mapstructure tag on the
+// embedded middleware Config structs in Config.Global and asserts that at
+// least one of the operator-facing docs files mentions the key. This is a
+// coarse drift detector: it catches struct fields that ship without any
+// documentation (the same failure mode as the docs-vs-code drift surfaced
+// by issues #604 and #621, but in the opposite direction).
+//
+// The check is intentionally lenient: a single substring match in any of the
+// scanned docs counts. It is meant to catch gross drift, not enforce
+// per-field prose. Webhook keys, for example, are primarily documented in
+// docs/webhooks.md (CONFIGURATION.md links to it) and that's fine.
+//
+// See https://github.com/netresearch/ofelia/issues/621
+func TestConfigGlobalKeysAreDocumented(t *testing.T) {
+	t.Parallel()
+
+	docs := loadDocs(t,
+		[]string{"docs", "CONFIGURATION.md"},
+		[]string{"docs", "webhooks.md"},
+		[]string{"docs", "QUICK_REFERENCE.md"},
+		[]string{"docs", "TROUBLESHOOTING.md"},
+		[]string{"README.md"},
+	)
+
+	// Walk Config.Global; for every embedded struct (squash), pull each field's
+	// mapstructure tag (stripped of options) and verify the docs mention it.
+	globalT := reflect.TypeOf(Config{}).Field(0).Type // Global anonymous struct
+	for i := range globalT.NumField() {
+		f := globalT.Field(i)
+		if !f.Anonymous {
+			continue // only walk embedded middleware configs
+		}
+		for j := range f.Type.NumField() {
+			sub := f.Type.Field(j)
+			tag := sub.Tag.Get("mapstructure")
+			if tag == "" {
+				continue
+			}
+			name := strings.SplitN(tag, ",", 2)[0]
+			if name == "" || name == "-" {
+				continue // squash on the embed itself, or explicitly ignored
+			}
+			if !strings.Contains(docs, name) {
+				t.Errorf("operator docs do not mention global key %q (from %s.%s) - drift detected",
+					name, f.Type.Name(), sub.Name)
+			}
+		}
+	}
+}
+
+// loadDocs concatenates the contents of the given repo-relative files into a
+// single string for substring scanning by the drift test.
+func loadDocs(t *testing.T, files ...[]string) string {
+	t.Helper()
+	var sb strings.Builder
+	for _, parts := range files {
+		path := findRepoFile(t, parts...)
+		b, err := os.ReadFile(path) // #nosec G304 -- test reads repo file by computed path
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		sb.Write(b)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+// findRepoFile locates a repo-relative file from a test running in the cli/
+// package. Walks up from the test file's directory until the file is found.
+func findRepoFile(t *testing.T, parts ...string) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(thisFile)
+	for range 6 {
+		candidate := filepath.Join(append([]string{dir}, parts...)...)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		dir = filepath.Dir(dir)
+	}
+	t.Fatalf("could not locate repo file %v from %s", parts, thisFile)
+	return ""
+}

--- a/cli/save_drift_test.go
+++ b/cli/save_drift_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/netresearch/ofelia/test"
+)
+
+// TestBuildFromString_SaveUndocumentedKeysWarn verifies that the keys which
+// docs/CONFIGURATION.md previously documented for the Save middleware but
+// which have no corresponding struct field in middlewares.SaveConfig produce
+// "Unknown configuration key" warnings.
+//
+// Regression guard for issue #621: if `save-format` / `save-retention` come
+// back to the docs without an actual struct field landing first, this test
+// fires.
+//
+// See https://github.com/netresearch/ofelia/issues/621
+func TestBuildFromString_SaveUndocumentedKeysWarn(t *testing.T) {
+	t.Parallel()
+
+	logger, handler := test.NewTestLoggerWithHandler()
+	_, err := BuildFromString(`
+[global]
+log-level = info
+save-folder = /var/log/ofelia
+save-format = json
+save-retention = 30d
+`, logger)
+	if err != nil {
+		t.Fatalf("BuildFromString failed: %v", err)
+	}
+
+	want := []string{
+		"save-format",
+		"save-retention",
+	}
+	for _, key := range want {
+		if !handler.HasWarning("Unknown configuration key '" + key + "'") {
+			t.Errorf("expected 'Unknown configuration key' warning for %q, did not see it", key)
+		}
+	}
+}
+
+// TestBuildFromString_SaveRestoreHistoryKeysAccepted verifies that the
+// restore-history and restore-history-max-age keys (which exist on
+// middlewares.SaveConfig but were undocumented before issue #621) are
+// accepted without warnings and that their values land on the embedded
+// SaveConfig in Config.Global.
+//
+// See https://github.com/netresearch/ofelia/issues/621
+func TestBuildFromString_SaveRestoreHistoryKeysAccepted(t *testing.T) {
+	t.Parallel()
+
+	logger, handler := test.NewTestLoggerWithHandler()
+	c, err := BuildFromString(`
+[global]
+log-level = info
+save-folder = /var/log/ofelia
+restore-history = false
+restore-history-max-age = 48h
+`, logger)
+	if err != nil {
+		t.Fatalf("BuildFromString failed: %v", err)
+	}
+
+	for _, key := range []string{"restore-history", "restore-history-max-age"} {
+		if handler.HasWarning("Unknown configuration key '" + key + "'") {
+			t.Errorf("got 'Unknown configuration key' warning for %q (issue #621)", key)
+		}
+	}
+
+	if c.Global.RestoreHistory == nil || *c.Global.RestoreHistory != false {
+		t.Errorf("RestoreHistory = %v, want pointer to false", c.Global.RestoreHistory)
+	}
+	if c.Global.RestoreHistoryMaxAge.String() != "48h0m0s" {
+		t.Errorf("RestoreHistoryMaxAge = %v, want 48h", c.Global.RestoreHistoryMaxAge)
+	}
+}

--- a/cli/slack_drift_test.go
+++ b/cli/slack_drift_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/netresearch/ofelia/test"
+)
+
+// TestBuildFromString_SlackUndocumentedKeysWarn verifies that the keys which
+// docs/CONFIGURATION.md previously documented for the (deprecated) Slack
+// middleware but which have no corresponding struct field in
+// middlewares.SlackConfig produce "Unknown configuration key" warnings.
+//
+// Regression guard for issue #621: if someone re-adds the unsupported keys
+// to SlackConfig (or adds them to the docs again) without thinking through
+// the deprecation strategy, this test still locks in the rejection contract.
+// Operators following the outdated docs hit the warning - the documented
+// surface is no longer silently accepted-then-ignored. The supported path
+// for channel routing, mentions, custom username/avatar, etc. is the
+// generic webhook system with `preset = slack`.
+//
+// See https://github.com/netresearch/ofelia/issues/621
+func TestBuildFromString_SlackUndocumentedKeysWarn(t *testing.T) {
+	t.Parallel()
+
+	logger, handler := test.NewTestLoggerWithHandler()
+	_, err := BuildFromString(`
+[global]
+log-level = info
+slack-url = https://hooks.slack.com/services/XXX/YYY/ZZZ
+slack-channel = #alerts
+slack-mentions = @channel
+slack-icon-emoji = :robot:
+slack-username = Ofelia Bot
+`, logger)
+	if err != nil {
+		t.Fatalf("BuildFromString failed: %v", err)
+	}
+
+	want := []string{
+		"slack-url",
+		"slack-channel",
+		"slack-mentions",
+		"slack-icon-emoji",
+		"slack-username",
+	}
+	for _, key := range want {
+		if !handler.HasWarning("Unknown configuration key '" + key + "'") {
+			t.Errorf("expected 'Unknown configuration key' warning for %q, did not see it", key)
+		}
+	}
+}

--- a/config/validator.go
+++ b/config/validator.go
@@ -425,7 +425,7 @@ func (cv *Validator2) validateSliceField(v *Validator, field reflect.Value, path
 func (cv *Validator2) isOptionalField(path string) bool {
 	optionalFields := []string{
 		"smtp-user", "smtp-password", "email-to", "email-from",
-		"slack-webhook", "slack-channel", "save-folder",
+		"slack-webhook", "save-folder",
 		"restore-history", "restore-history-max-age",
 		"container", "service", "image", "user", "network",
 		"environment", "secrets", "volumes", "working_dir",

--- a/config/validator_boundary_test.go
+++ b/config/validator_boundary_test.go
@@ -411,7 +411,7 @@ func TestValidator2IsOptionalField(t *testing.T) {
 
 	optionalFields := []string{
 		"smtp-user", "smtp-password", "email-to", "email-from",
-		"slack-webhook", "slack-channel", "save-folder",
+		"slack-webhook", "save-folder",
 		"container", "service", "image", "user", "network",
 		"environment", "secrets", "volumes", "working_dir",
 		"log-level",

--- a/config/validator_mutation_test.go
+++ b/config/validator_mutation_test.go
@@ -621,7 +621,7 @@ func TestIsOptionalField_BothBranches(t *testing.T) {
 	// Optional fields should return true
 	optionalFields := []string{
 		"smtp-user", "smtp-password", "email-to", "email-from",
-		"slack-webhook", "slack-channel", "save-folder",
+		"slack-webhook", "save-folder",
 		"container", "service", "image", "user", "network",
 		"environment", "secrets", "volumes", "working_dir",
 		"log-level",

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -279,9 +279,8 @@ docker-events = true
 allow-host-jobs-from-labels = false
 default-user = nobody        # Default for exec/run/service; empty uses container default
 
-# Notification Settings
-slack-url = https://hooks.slack.com/services/XXX/YYY/ZZZ
-slack-channel = #alerts
+# Notification Settings (deprecated Slack middleware - prefer the webhook system below)
+slack-webhook = https://hooks.slack.com/services/XXX/YYY/ZZZ
 slack-only-on-error = true
 
 # Email Settings
@@ -341,7 +340,6 @@ delay = 5s                  # Delay before execution
 
 # Middleware Configuration
 slack-webhook = https://hooks.slack.com/...
-slack-channel = #db-alerts
 slack-only-on-error = true
 
 email-to = dba@example.com
@@ -715,12 +713,11 @@ container = worker
 command = important-task.sh
 
 # Slack settings (DEPRECATED - use [webhook "name"] sections instead)
+# Only slack-webhook and slack-only-on-error are accepted by the legacy
+# middleware. For channel routing, mentions, custom username/avatar, etc.,
+# migrate to the webhook notification system above (preset = slack).
 slack-webhook = https://hooks.slack.com/services/XXX/YYY/ZZZ
-slack-channel = #alerts
 slack-only-on-error = false
-slack-mentions = @channel
-slack-icon-emoji = :robot:
-slack-username = Ofelia Bot
 ```
 
 ### Email Notifications

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -791,8 +791,14 @@ command = export-data.sh
 # Save output
 save-folder = /var/log/ofelia/exports
 save-only-on-error = false
-save-format = json  # json or text
-save-retention = 30d # Keep for 30 days
+
+# History restoration on startup (set on the [global] section)
+# - restore-history: enable/disable replaying saved executions on daemon start
+#   (default: enabled when save-folder is set)
+# - restore-history-max-age: only replay executions newer than this duration
+#   (default: 24h)
+restore-history = true
+restore-history-max-age = 48h
 ```
 
 ### Overlap Prevention

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -623,9 +623,8 @@ schedule = @daily
 container = app
 command = /important-task.sh
 
-# Slack for quick alerts
+# Slack for quick alerts (deprecated - prefer the webhook notification system)
 slack-webhook = https://hooks.slack.com/...
-slack-channel = #ops
 slack-only-on-error = true
 
 # Email for detailed logs

--- a/docs/packages/cli.md
+++ b/docs/packages/cli.md
@@ -71,7 +71,7 @@ func BuildFromFile(path string) (*Config, error) {
 **INI Format:**
 ```ini
 [global]
-slack-url = https://hooks.slack.com/...
+slack-webhook = https://hooks.slack.com/...
 docker-events = true
 
 [job-exec "database-backup"]


### PR DESCRIPTION
## Summary

Surfaced during the [#618](https://github.com/netresearch/ofelia/pull/618) review as a sibling-bug class to [#604](https://github.com/netresearch/ofelia/issues/604): two more middlewares ship docs that don't match their struct fields, so operators copying the snippets hit `Unknown configuration key` warnings (Slack) or have to read the source to discover real keys (Save).

Fixes [#621](https://github.com/netresearch/ofelia/issues/621).

### Disposition per finding

**Slack** (deprecated middleware, scheduled for removal in v1.0.0 — supported path is the generic webhook system with `preset = slack`):
- `slack-url` — **removed from docs** (typo for `slack-webhook`)
- `slack-channel` — **removed from docs** (use `[webhook "name"]` for routing)
- `slack-mentions` — **removed from docs** (webhook system handles this)
- `slack-icon-emoji` — **removed from docs**
- `slack-username` — **removed from docs**

**Save**:
- `restore-history` — **documented** (existed on `SaveConfig`, undocumented before)
- `restore-history-max-age` — **documented** (existed on `SaveConfig`, undocumented before)
- `save-format = json|text` — **removed from docs** (unimplemented; left as follow-up if there's appetite)
- `save-retention = 30d` — **removed from docs** (unimplemented; left as follow-up)

### Mechanical drift guard

New `TestConfigGlobalKeysAreDocumented` in `cli/config_drift_test.go` walks the embedded middleware structs in `Config.Global` via reflection and asserts every `mapstructure` key is mentioned in at least one operator-facing docs file. Lenient by design: substring match in any of `docs/CONFIGURATION.md`, `docs/webhooks.md`, `docs/QUICK_REFERENCE.md`, `docs/TROUBLESHOOTING.md`, `README.md` counts. Catches the next #604/#621 mechanically.

### Atomic commits

- [`79eef13`](https://github.com/netresearch/ofelia/commit/79eef13) `docs(slack): drop documented-but-rejected Slack middleware keys`
- [`0841a8f`](https://github.com/netresearch/ofelia/commit/0841a8f) `docs(save): document restore-history keys, drop unimplemented save-format/-retention`
- [`49eeab6`](https://github.com/netresearch/ofelia/commit/49eeab6) `test(cli): add reflection contract test for Config.Global mapstructure keys`

## Test plan

- [x] `TestBuildFromString_SlackUndocumentedKeysWarn` — locks in rejection contract for the five removed Slack keys.
- [x] `TestBuildFromString_SaveUndocumentedKeysWarn` — locks in rejection contract for `save-format` / `save-retention`.
- [x] `TestBuildFromString_SaveRestoreHistoryKeysAccepted` — verifies `restore-history` / `restore-history-max-age` are accepted and values land on `Config.Global.SaveConfig`.
- [x] `TestConfigGlobalKeysAreDocumented` — passes (no remaining drift in `Config.Global`).
- [x] `go test -race ./cli/ ./middlewares/` — green.
- [x] `golangci-lint run --timeout=3m` — 0 issues.
- [x] CHANGELOG entries under `[Unreleased]` → `### Documentation` (Slack + Save) and `### Tests` (contract test).