### PR TITLE
ci(scorecard): drop top-level read-all permissions

### DIFF
--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -7,3 +7,8 @@ intentional-drift:
   reason: "enable-integration-tests: true and enable-e2e-tests: true \u2014 repo has\
     \ integration tests (12 files, -tags=integration) and e2e tests (10 tests under\
     \ ./e2e/..., -tags=e2e) that run in CI."
+- path: .github/workflows/scorecard.yml
+  reason: "Top-level permissions narrowed from read-all to contents: read for Sonar\
+    \ githubactions:S8234 (code-scanning alert #142). Upstream template carries the\
+    \ same fix in netresearch/.github#126; this drift entry is temporary until that\
+    \ merges and the template syncs back."

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,7 +7,8 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   scorecard:


### PR DESCRIPTION
## Summary

Replace `permissions: read-all` at the top of `.github/workflows/scorecard.yml` with the minimal `contents: read`. The job already redefines per-permission scopes (`contents`, `security-events`, `id-token`, `actions`), so the top-level only needs the minimum required to perform the checkout.

Clears code-scanning alert [#142](https://github.com/netresearch/ofelia/security/code-scanning/142) (Sonar `githubactions:S8234`, "Read-all and Write-all permissions should not be used").

## Test plan

- [ ] CI green on this branch
- [ ] Scorecard workflow continues to run successfully on next scheduled execution