### PR TITLE
fix(middlewares): use per-user cache dir for preset cache default path

### DIFF
--- a/middlewares/preset_cache.go
+++ b/middlewares/preset_cache.go
@@ -39,31 +39,62 @@ type cacheMetadata struct {
 	Version   string    `yaml:"version,omitempty"`
 }
 
+// defaultCacheDirPerm is the directory mode applied when NewPresetCache
+// generates the cache path itself. It matches the 0o600 mode used for the
+// cached payload files (see putToDisk) — only the owning user can read or
+// modify the cache.
+const defaultCacheDirPerm os.FileMode = 0o700
+
+// defaultPresetCacheDir returns the cache directory chosen by NewPresetCache
+// when the caller does not supply one. It prefers os.UserCacheDir
+// (per-user, not pre-creatable by other accounts) and falls back to a
+// UID-namespaced subdirectory under os.TempDir when the user cache dir is
+// unavailable (e.g. a stripped container env without $HOME).
+//
+// The UID namespacing is what makes the TempDir fallback safe against the
+// symlink/pre-create attack that gosec G302 / SonarCloud go:S5445 flag for
+// the predictable /tmp/ofelia path: on hosts with the standard /tmp sticky
+// bit, only the owning user (and root) can create entries named
+// "ofelia-<uid>", so an unprivileged attacker cannot pre-create the path
+// as a symlink before ofelia starts.
+func defaultPresetCacheDir() string {
+	if userCache, err := os.UserCacheDir(); err == nil {
+		return filepath.Join(userCache, "ofelia", "presets")
+	}
+	return filepath.Join(os.TempDir(), fmt.Sprintf("ofelia-%d", os.Getuid()), "presets")
+}
+
 // NewPresetCache creates a new preset cache.
 //
-// When cacheDir is empty, the default location is the per-user cache dir
-// (os.UserCacheDir — typically $XDG_CACHE_HOME/ofelia/presets on Linux,
-// ~/Library/Caches/ofelia/presets on macOS). Falling back to a per-user
-// location avoids the predictable /tmp/ofelia path that gosec G302 /
-// SonarCloud go:S5445 flag as a symlink/pre-create attack vector on
-// multi-tenant hosts. If the user cache dir is unavailable (no $HOME),
-// we fall back to os.TempDir with restrictive perms.
+// When cacheDir is empty, the default location comes from defaultPresetCacheDir
+// (typically $XDG_CACHE_HOME/ofelia/presets on Linux, ~/Library/Caches/ofelia/presets
+// on macOS) and is created with 0o700 perms — both for fresh directories
+// (via os.MkdirAll) and for pre-existing ones (via an explicit os.Chmod,
+// because os.MkdirAll does not adjust modes of existing entries).
+//
+// When the caller supplies an explicit cacheDir, perms are left untouched
+// if the directory already exists, and new directories are created with the
+// previous 0o750 default. Operators who pass their own path are assumed to
+// have set permissions deliberately.
 func NewPresetCache(cacheDir string, ttl time.Duration) *PresetCache {
-	if cacheDir == "" {
-		if userCache, err := os.UserCacheDir(); err == nil {
-			cacheDir = filepath.Join(userCache, "ofelia", "presets")
-		} else {
-			// Last-resort fallback when the user cache dir is unavailable.
-			// 0o700 perms on the parent (created below) limit exposure on
-			// multi-user hosts.
-			cacheDir = filepath.Join(os.TempDir(), "ofelia", "presets")
-		}
+	usingDefault := cacheDir == ""
+	if usingDefault {
+		cacheDir = defaultPresetCacheDir()
 	}
 
-	// Ensure cache directory exists. 0o700 keeps the cache visible only to
-	// the running user; cached payloads are written 0o600 (see putToDisk).
-	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+	mkdirPerm := os.FileMode(0o750)
+	if usingDefault {
+		mkdirPerm = defaultCacheDirPerm
+	}
+	if err := os.MkdirAll(cacheDir, mkdirPerm); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to create preset cache directory: %v\n", err)
+	} else if usingDefault {
+		// os.MkdirAll does not tighten perms on pre-existing entries.
+		// Apply 0o700 explicitly so an upgrade from a prior loose-mode
+		// version of the cache also picks up the hardening.
+		if err := os.Chmod(cacheDir, defaultCacheDirPerm); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to chmod preset cache directory: %v\n", err)
+		}
 	}
 
 	return &PresetCache{

--- a/middlewares/preset_cache.go
+++ b/middlewares/preset_cache.go
@@ -39,14 +39,30 @@ type cacheMetadata struct {
 	Version   string    `yaml:"version,omitempty"`
 }
 
-// NewPresetCache creates a new preset cache
+// NewPresetCache creates a new preset cache.
+//
+// When cacheDir is empty, the default location is the per-user cache dir
+// (os.UserCacheDir — typically $XDG_CACHE_HOME/ofelia/presets on Linux,
+// ~/Library/Caches/ofelia/presets on macOS). Falling back to a per-user
+// location avoids the predictable /tmp/ofelia path that gosec G302 /
+// SonarCloud go:S5445 flag as a symlink/pre-create attack vector on
+// multi-tenant hosts. If the user cache dir is unavailable (no $HOME),
+// we fall back to os.TempDir with restrictive perms.
 func NewPresetCache(cacheDir string, ttl time.Duration) *PresetCache {
 	if cacheDir == "" {
-		cacheDir = filepath.Join(os.TempDir(), "ofelia", "presets")
+		if userCache, err := os.UserCacheDir(); err == nil {
+			cacheDir = filepath.Join(userCache, "ofelia", "presets")
+		} else {
+			// Last-resort fallback when the user cache dir is unavailable.
+			// 0o700 perms on the parent (created below) limit exposure on
+			// multi-user hosts.
+			cacheDir = filepath.Join(os.TempDir(), "ofelia", "presets")
+		}
 	}
 
-	// Ensure cache directory exists
-	if err := os.MkdirAll(cacheDir, 0o750); err != nil {
+	// Ensure cache directory exists. 0o700 keeps the cache visible only to
+	// the running user; cached payloads are written 0o600 (see putToDisk).
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to create preset cache directory: %v\n", err)
 	}
 

--- a/middlewares/preset_cache_test.go
+++ b/middlewares/preset_cache_test.go
@@ -4,8 +4,10 @@
 package middlewares
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -32,6 +34,79 @@ func TestNewPresetCache_DefaultDir(t *testing.T) {
 
 	assert.NotNil(t, cache)
 	assert.NotEmpty(t, cache.cacheDir)
+}
+
+// TestNewPresetCache_DefaultDir_HardensExistingDir verifies that an
+// upgrade from a prior loose-mode (0o755) cache directory is tightened
+// to 0o700 on next ofelia start. os.MkdirAll alone does not adjust
+// perms on pre-existing entries, so we explicitly chmod when we picked
+// the path ourselves.
+//
+// We isolate the test by pointing XDG_CACHE_HOME at a t.TempDir; this
+// uses the same code path NewPresetCache takes for the default location.
+func TestNewPresetCache_DefaultDir_HardensExistingDir(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", xdg)
+
+	preExisting := filepath.Join(xdg, "ofelia", "presets")
+	require.NoError(t, os.MkdirAll(preExisting, 0o755))
+
+	cache := NewPresetCache("", time.Hour)
+
+	require.NotNil(t, cache)
+	require.Equal(t, preExisting, cache.cacheDir)
+
+	info, err := os.Stat(preExisting)
+	require.NoError(t, err)
+	if perm := info.Mode().Perm(); perm != 0o700 {
+		t.Errorf("expected default cache dir to be tightened to 0o700, got %#o", perm)
+	}
+}
+
+// TestNewPresetCache_DefaultDir_TempDirFallback verifies the fallback
+// path used when os.UserCacheDir cannot determine a per-user location
+// (no $HOME, no $XDG_CACHE_HOME, no platform default). The fallback
+// must include the current UID so it cannot be pre-created as a symlink
+// by another local user.
+func TestNewPresetCache_DefaultDir_TempDirFallback(t *testing.T) {
+	// Force os.UserCacheDir to fail by stripping every env var it consults.
+	// On Linux it reads XDG_CACHE_HOME then HOME; on macOS HOME; on Windows
+	// LocalAppData. Clearing all of them covers each platform.
+	t.Setenv("XDG_CACHE_HOME", "")
+	t.Setenv("HOME", "")
+	t.Setenv("LocalAppData", "")
+
+	// Redirect TempDir so the test does not pollute the real /tmp.
+	t.Setenv("TMPDIR", t.TempDir())
+
+	got := defaultPresetCacheDir()
+
+	uidNamespace := fmt.Sprintf("ofelia-%d", os.Getuid())
+	if !strings.Contains(got, uidNamespace) {
+		t.Errorf("expected TempDir fallback to include %q for UID isolation, got %q", uidNamespace, got)
+	}
+	if !strings.HasSuffix(got, filepath.Join(uidNamespace, "presets")) {
+		t.Errorf("expected fallback path to end with %s/presets, got %q", uidNamespace, got)
+	}
+}
+
+// TestNewPresetCache_ExplicitDir_PreservesPerms verifies that when a
+// caller supplies their own cacheDir, NewPresetCache does NOT chmod it.
+// Operators who configure a custom path are assumed to have set perms
+// deliberately, and silently tightening them would be surprising.
+func TestNewPresetCache_ExplicitDir_PreservesPerms(t *testing.T) {
+	t.Parallel()
+
+	explicit := filepath.Join(t.TempDir(), "explicit-cache")
+	require.NoError(t, os.MkdirAll(explicit, 0o755))
+
+	_ = NewPresetCache(explicit, time.Hour)
+
+	info, err := os.Stat(explicit)
+	require.NoError(t, err)
+	if perm := info.Mode().Perm(); perm != 0o755 {
+		t.Errorf("expected explicit cache dir perms to be preserved (0o755), got %#o", perm)
+	}
 }
 
 func TestPresetCache_PutGet_Memory(t *testing.T) {


### PR DESCRIPTION
## Summary

The default preset cache path `/tmp/ofelia/presets` is flagged by gosec G302 / SonarCloud go:S5445 ([#141](https://github.com/netresearch/ofelia/security/code-scanning/141), severity: high) because a local user can pre-create the parent path as a symlink before ofelia starts — a textbook symlink/pre-create attack vector on multi-tenant hosts.

Changes:

- Default cache dir now comes from `os.UserCacheDir()` (typically `$XDG_CACHE_HOME/ofelia/presets` on Linux, `~/Library/Caches/ofelia/presets` on macOS, `%LocalAppData%/ofelia/presets` on Windows). This location is per-user and not pre-creatable by other accounts.
- `os.TempDir()` remains as a last-resort fallback when the user cache dir is unavailable (e.g. no `$HOME` set in a stripped container env).
- Parent directory perms tightened from `0o750` to `0o700` to match the `0o600` already used for cached payload files.

Behavior is unchanged when callers pass an explicit `cacheDir` (the common case — `globalConfig.PresetCacheDir`).

Clears code-scanning alert [#141](https://github.com/netresearch/ofelia/security/code-scanning/141).

## Test plan

- [x] `go build ./...`
- [x] `go test ./middlewares/...` — full middlewares suite passes
- [ ] CI green on this branch