### PR TITLE
ci(scorecard): sync to upstream permissions: {} pattern

### DIFF
--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -7,8 +7,3 @@ intentional-drift:
   reason: "enable-integration-tests: true and enable-e2e-tests: true \u2014 repo has\
     \ integration tests (12 files, -tags=integration) and e2e tests (10 tests under\
     \ ./e2e/..., -tags=e2e) that run in CI."
-- path: .github/workflows/scorecard.yml
-  reason: "Top-level permissions narrowed from read-all to contents: read for Sonar\
-    \ githubactions:S8234 (code-scanning alert #142). Upstream template carries the\
-    \ same fix in netresearch/.github#126; this drift entry is temporary until that\
-    \ merges and the template syncs back."

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,8 +7,7 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   scorecard:


### PR DESCRIPTION
## Summary

Follow-up to [#664](https://github.com/netresearch/ofelia/pull/664) and [netresearch/.github#126](https://github.com/netresearch/.github/pull/126).

When #664 landed, I had to set workflow-level permissions to `contents: read` because the upstream template still used `permissions: read-all`. Round-1 review on the upstream PR pointed out that every other template workflow (`codeql.yml`, `gitleaks.yml`, `dependency-review.yml`, `labeler.yml`, `pr-quality.yml`) uses `permissions: {}` at the workflow level — workflow grants nothing, the single job declares what it needs. The upstream merged with that pattern.

This PR:

- Switches ofelia's `scorecard.yml` to `permissions: {}` to match the now-merged upstream template
- Drops the temporary `intentional-drift` entry that #664 added — drift now resolves naturally

Net effect: workflow-level permissions stay least-privilege (now empty rather than `contents: read`), and the template-drift check has nothing to flag.

## Test plan

- [ ] Drift check (`drift / Template drift`) passes — file should match upstream byte-for-byte once the template propagates
- [ ] Scorecard workflow continues to run successfully on next scheduled execution