### PR TITLE
docs(webhooks): add lifecycle flowchart

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -2,6 +2,78 @@
 
 Ofelia supports sending webhook notifications when jobs complete. You can configure multiple named webhooks and assign them to specific jobs, allowing flexible notification routing.
 
+## Lifecycle at a glance
+
+Three asymmetries are easy to miss when reading the sections below in
+isolation: (1) webhook *definitions* are operator-controlled and only
+processed from a service container or from INI, while *references* can
+come from any container; (2) INI definitions override label definitions on
+name collision; (3) at dispatch time the per-webhook `url` field
+short-circuits the preset's `url_scheme`. The diagram below traces the
+full flow from "where do definitions come from" to "what hits the wire".
+
+```mermaid
+flowchart TD
+    subgraph Sources["📝 Define webhooks (operator-controlled)"]
+        direction LR
+        INI["<b>INI</b><br/><code>[webhook &quot;NAME&quot;]</code><br/>preset = …<br/>url = …<br/>id / secret / trigger / …"]
+        Labels["<b>Docker labels</b><br/><code>ofelia.webhook.NAME.preset</code><br/><code>ofelia.webhook.NAME.url</code><br/>… on a container with<br/><code>ofelia.service: &quot;true&quot;</code> only"]
+    end
+
+    INI ==>|"INI wins on<br/>name collision<br/>(warn-logged)"| Registry
+    Labels ==> Registry
+
+    Registry[("<b>Webhook registry</b><br/>keyed by name<br/>(WebhookConfigs.Webhooks)")]
+
+    subgraph Refs["🔗 Reference webhooks by name (any container)"]
+        direction LR
+        JobRef["<b>Per job</b><br/><code>ofelia.job-exec.JOB.webhooks: a, b</code><br/>or <code>webhooks = a, b</code> in INI"]
+        GlobalRef["<b>Global selector</b><br/><code>[global] webhook-webhooks = c</code><br/>or <code>ofelia.webhook-webhooks</code> label"]
+    end
+
+    JobRef --> Union
+    GlobalRef --> Union
+    Union{{"Per-job union<br/>(deduped by name)"}}
+    Registry -.->|"name lookup<br/>(unknown → attach error)"| Union
+
+    Union --> Fallback{"<code>preset</code> on<br/>this webhook empty?"}
+    Fallback -->|no| Attach
+    Fallback -->|yes| DefaultPreset{"<code>webhook-default-preset</code><br/>set?"}
+    DefaultPreset -->|"<b>nil</b> = unset<br/>(default)"| FillJSONPost["fill with bundled<br/><code>json-post</code>"]
+    DefaultPreset -->|"<b>non-empty</b><br/>operator's choice"| FillCustom["fill with operator's<br/>chosen preset name"]
+    DefaultPreset -->|"<b>empty string</b><br/>(explicit opt-out)"| AttachError["<b>Attach error</b><br/>names <code>webhook-default-preset</code><br/>for grep-ability"]
+    FillJSONPost --> Attach
+    FillCustom --> Attach
+
+    Attach["<b>Composite middleware</b><br/>attached once per job"]
+
+    Attach --> Dispatch["<b>On job run, per inner webhook:</b><br/>1. <code>ShouldNotify(trigger)</code><br/>2. <code>BuildURL</code> — <code>url</code> overrides <code>url_scheme</code><br/>3. <code>ValidateWebhookURL</code> (allow-list)<br/>4. HTTP send + retry"]
+
+    classDef src fill:#fef3c7,stroke:#d97706
+    classDef ref fill:#dbeafe,stroke:#2563eb
+    classDef reg fill:#dcfce7,stroke:#16a34a
+    classDef err fill:#fee2e2,stroke:#dc2626
+    class Sources src
+    class Refs ref
+    class Registry reg
+    class AttachError err
+```
+
+Where to read next:
+
+- **Source authoring** — INI `[webhook "name"]` or service-container
+  labels: see [Quick Start](#quick-start) and
+  [Docker Label Reference](#docker-label-reference).
+- **Security boundary** — why labels are service-container-only and what
+  the operator-tunable globals are: see
+  [INI vs Docker labels](#docker-label-reference) and
+  [`webhook-allowed-hosts`](#global-settings).
+- **The `json-post` fallback** —
+  [Custom Webhooks (URL-only, no custom preset)](#custom-webhooks-url-only-no-custom-preset)
+  and [Opting out of the default](#opting-out-of-the-default).
+- **`url` overriding `url_scheme`** — the column annotation in
+  [Webhook Settings](#webhook-settings).
+
 ## Quick Start
 
 ### Simplest case: just POST to a URL


### PR DESCRIPTION
## Summary

Adds a single mermaid flowchart to the top of `docs/webhooks.md` that traces the full webhook lifecycle — sources → registry → references → attach → dispatch — and links each stage to the section holding the full prose.

Surfaced during the operator-experience review on #676/#677: the file scatters the model across Quick Start → Configuration Reference → Docker Label Reference → Custom Webhooks → Configuration Precedence, and an operator landing on the page from a search has to assemble four sections before the lifecycle clicks. The diagram makes three otherwise-easy-to-miss asymmetries visible:

1. **DEFINITIONS** are operator-controlled (INI or service-container labels) while **REFERENCES** can come from any container.
2. INI definitions override label definitions on name collision (warn-logged).
3. The per-webhook `url` field short-circuits the preset's `url_scheme` at dispatch.

Plus the new `webhook-default-preset` selector from #676/#677 gets a visible branch (nil → bundled `json-post`, custom → operator's choice, empty → explicit opt-out with an actionable attach error).

## What the diagram covers

| Stage | Box / node | Notes |
|---|---|---|
| Define | `[webhook "name"]` INI section, `ofelia.webhook.NAME.*` labels on a service container | Service-container restriction shown inline |
| Conflict resolution | thick INI → registry edge | "INI wins on name collision" labeled inline |
| Registry | `WebhookConfigs.Webhooks` map keyed by name | |
| Reference | Per-job `webhooks: a,b` + `[global] webhook-webhooks = c` | Union deduped by name |
| Fallback | `webhook-default-preset` three-state semantics | nil / non-empty / empty branches all rendered |
| Attach | Composite middleware per job | (the #670/#671 path) |
| Dispatch | Trigger gate → BuildURL → ValidateWebhookURL → POST | `url` overriding `url_scheme` called out |

## What's NOT in the diagram (deliberately)

- Retry logic / backoff / dedup — these don't affect the operator's mental model of how a webhook gets wired up; they live further inside `Webhook.Run` and are documented in the dispatch table.
- Remote preset loading (`gh:` shorthand, `webhook-allow-remote-presets`) — separate concern, has its own section.
- Per-webhook field listing — already covered by the "Webhook Settings" table.

The diagram is a **navigation aid**, not a replacement for prose. Each stage links back to the relevant subsection.

## Render verification

Rendered through `minlag/mermaid-cli` Docker image (`mermaid-js/mermaid-cli`), 1312×2118 SVG, all nodes laid out cleanly. Style classes (yellow for sources, blue for references, green for registry, red for the opt-out error) survive the GitHub mermaid renderer.

## Test plan

- [x] Mermaid syntax validates (renders to SVG via `minlag/mermaid-cli`)
- [x] No code or behavior changes — pure docs PR
- [ ] Visual sanity check on GitHub's renderer once this PR is opened (reviewer eyeball)
- [ ] Internal anchor links (`#quick-start`, `#docker-label-reference`, `#global-settings`, `#custom-webhooks-url-only-no-custom-preset`, `#opting-out-of-the-default`, `#webhook-settings`) resolve to existing headings in `docs/webhooks.md`