### PR TITLE
chore: prepare v0.25.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.25.1] - 2026-05-16
-
 ### Added
 
 - **Upgrade impact:** webhooks configured with `url = ...` but no `preset` were previously rejected at startup (the documented "Custom Webhooks" section promised they would work but the code returned `preset specification cannot be empty`). They now attach and fire using the new bundled `json-post` JSON-POST preset. Audit existing `[webhook "..."]` sections and `webhooks:` job references before upgrading — a stale URL-only config that previously sat inert will now actually send a JSON POST to whatever's in `url`. Pin `webhook-allowed-hosts` to a specific list if you want to restrict egress; set `webhook-default-preset =` (empty) to preserve pre-upgrade behavior and require every webhook to declare `preset` explicitly.
 
   New bundled `json-post` webhook preset and a `[global] webhook-default-preset` selector that ships with `json-post` as the default fallback. A webhook configured with just a `url = ...` (or Docker label `ofelia.webhook.<name>.url: ...`) now works out of the box — Ofelia POSTs a JSON payload describing the job and execution to that URL, no custom preset YAML required. The fallback preset is selected via `EffectiveDefaultPreset()` at attach time, so live INI / label changes to `webhook-default-preset` take effect on the next attach without restart. Three-state semantics are unambiguous: the field is `*string`, so nil = "operator did not set" (use bundled fallback), non-nil empty = "explicit opt-out", non-nil non-empty = "operator's chosen fallback name". When opt-out is in effect, the attachment-failed error message names `webhook-default-preset` explicitly so operators can grep their way from logs to the docs. Fixes [#676](https://github.com/netresearch/ofelia/issues/676).
+
+## [0.25.1] - 2026-05-16
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.1] - 2026-05-16
+
 ### Added
 
 - **Upgrade impact:** webhooks configured with `url = ...` but no `preset` were previously rejected at startup (the documented "Custom Webhooks" section promised they would work but the code returned `preset specification cannot be empty`). They now attach and fire using the new bundled `json-post` JSON-POST preset. Audit existing `[webhook "..."]` sections and `webhooks:` job references before upgrading — a stale URL-only config that previously sat inert will now actually send a JSON POST to whatever's in `url`. Pin `webhook-allowed-hosts` to a specific list if you want to restrict egress; set `webhook-default-preset =` (empty) to preserve pre-upgrade behavior and require every webhook to declare `preset` explicitly.


### PR DESCRIPTION
## Summary

Add `[0.25.1] - 2026-05-16` heading covering four bugfixes that landed since v0.25.0. The new json-post bundled preset (#676) stays in `[Unreleased]` for v0.26.0 per semver (new feature → minor release).

## Scope of v0.25.1

- `DOCKER_HOST=tcp://...` (plain HTTP) hijack now works — fixes a v0.25.0 regression where Go's lazy HTTP/2 auto-config mutated `*http.Transport.TLSClientConfig` in place, which the Docker SDK's hijack dialer misread as "TLS required" and dialed `tls.Dial` against a plaintext daemon. ([#681](https://github.com/netresearch/ofelia/pull/681), fixes [#668](https://github.com/netresearch/ofelia/issues/668))
- `DOCKER_HOST=http://...` hijack now works — sibling fix to #681 (same SDK dialer, different failure mode: `net.Dial("http", addr)` is rejected by Go's `net` package). Installs an explicit TCP `DialContext` on the `http://` transport with `url.Parse` support for path/IPv6 hosts. ([#686](https://github.com/netresearch/ofelia/pull/686), fixes [#682](https://github.com/netresearch/ofelia/issues/682))
- Webhook retry backoff AND in-flight HTTP request now honor ctx cancellation, so `SIGTERM` on a daemon mid-retry drains promptly instead of pinning a goroutine for up to `retry-delay × retry-count + timeout`. ([#685](https://github.com/netresearch/ofelia/pull/685), fixes [#673](https://github.com/netresearch/ofelia/issues/673))
- Multi-webhook job no longer silently drops the second `*Webhook` of the same type due to `middlewareContainer.Use()`'s reflect-type dedup. The fix attaches a single per-job composite carrying the union of global + per-job webhooks deduplicated by name. ([#670](https://github.com/netresearch/ofelia/issues/670))

## Held for v0.26.0 (stays in `[Unreleased]`)

- `### Added`: new bundled `json-post` webhook preset + `[global] webhook-default-preset` selector. New feature, per semver belongs in a minor bump. ([#676](https://github.com/netresearch/ofelia/issues/676))

## Version bump rationale

`0.x` semver patch — all four entries in v0.25.1 are bugfixes (no breaking changes, no features). The hijack-bug class produced operator-visible regressions on plain-`tcp://` and broke `run_exec` for a non-trivial subset of socket-proxy deployments; cutting as a patch rather than waiting for v0.26.0.

No file other than `CHANGELOG.md` is touched; the Release workflow injects the version via ldflags from the tag.

## Test plan

- [x] `go build ./... ` clean (no code changes)
- [ ] CI green on this PR
- [ ] CHANGELOG renders correctly on GitHub
- [ ] After merge: signed annotated tag `v0.25.1` pushed to origin
- [ ] Release workflow run succeeds (binaries, container, cosign bundle, SLSA attestations)
