### PR TITLE
fix(changelog): include #676 url-only webhook feature in v0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.1] - 2026-05-16
+
 ### Added
 
 - **Upgrade impact:** webhooks configured with `url = ...` but no `preset` were previously rejected at startup (the documented "Custom Webhooks" section promised they would work but the code returned `preset specification cannot be empty`). They now attach and fire using the new bundled `json-post` JSON-POST preset. Audit existing `[webhook "..."]` sections and `webhooks:` job references before upgrading — a stale URL-only config that previously sat inert will now actually send a JSON POST to whatever's in `url`. Pin `webhook-allowed-hosts` to a specific list if you want to restrict egress; set `webhook-default-preset =` (empty) to preserve pre-upgrade behavior and require every webhook to declare `preset` explicitly.
 
   New bundled `json-post` webhook preset and a `[global] webhook-default-preset` selector that ships with `json-post` as the default fallback. A webhook configured with just a `url = ...` (or Docker label `ofelia.webhook.<name>.url: ...`) now works out of the box — Ofelia POSTs a JSON payload describing the job and execution to that URL, no custom preset YAML required. The fallback preset is selected via `EffectiveDefaultPreset()` at attach time, so live INI / label changes to `webhook-default-preset` take effect on the next attach without restart. Three-state semantics are unambiguous: the field is `*string`, so nil = "operator did not set" (use bundled fallback), non-nil empty = "explicit opt-out", non-nil non-empty = "operator's chosen fallback name". When opt-out is in effect, the attachment-failed error message names `webhook-default-preset` explicitly so operators can grep their way from logs to the docs. Fixes [#676](https://github.com/netresearch/ofelia/issues/676).
-
-## [0.25.1] - 2026-05-16
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

Move the `### Added` entry for #676 (json-post bundled preset / url-only webhook) from `[Unreleased]` into `[0.25.1]`. The feature code shipped in commit [37b598d](https://github.com/netresearch/ofelia/commit/37b598d) (merged 2026-05-15 via [#677](https://github.com/netresearch/ofelia/pull/677)) and is in the published v0.25.1 binary; the CHANGELOG should match.

## Why this is correct for v0.25.1

The earlier restructure in #688 (commit e2be793) held the Added entry under `[Unreleased]` on the theory that "features go in minor releases per semver, not patch." That's not right for two reasons:

1. **0.x semver is flexible** — *"Major version zero (0.y.z) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable."* (semver.org §4)
2. **#676 is a bug-shape feature** — the documented "Custom Webhooks" section had been promising url-only configs would work since v0.16.0; the json-post preset closes the documented-but-broken behavior gap. Operationally indistinguishable from a Fixed entry.

Either way, **the CHANGELOG must describe what's in the release**, not impose retroactive scope choices. The v0.25.1 tag includes the json-post code; the entry needs to be in the v0.25.1 section.

## Release notes update

Will follow once this lands, adding the url-only webhook story to the v0.25.1 release notes.

## Test plan

- [x] CHANGELOG renders with #676 entry under [0.25.1]
- [ ] CI green
