### PR TITLE
fix(core): RetryExecutor backoff honors ctx cancellation (#687)

### DIFF
--- a/core/retry.go
+++ b/core/retry.go
@@ -127,8 +127,9 @@ func (re *RetryExecutor) ExecuteWithRetry(job Job, ctx *Context, runFunc func(*C
 		// Wait before retry, honoring scheduler / job cancellation so
 		// SIGTERM drains promptly even mid-retry. Pre-fix this was a bare
 		// time.Sleep that blocked daemon shutdown for up to RetryDelay ×
-		// MaxRetries (compounded by exponential backoff). Sibling fix to
-		// https://github.com/netresearch/ofelia/issues/673 — see #687.
+		// MaxRetries. Fixes
+		// https://github.com/netresearch/ofelia/issues/687; sibling to the
+		// webhook backoff fix in #685 / #673.
 		runCtx := ctx.RunContext()
 		select {
 		case <-time.After(delay):

--- a/core/retry.go
+++ b/core/retry.go
@@ -124,8 +124,17 @@ func (re *RetryExecutor) ExecuteWithRetry(job Job, ctx *Context, runFunc func(*C
 			re.metrics.RecordJobRetry(job.GetName(), attempt+1, false)
 		}
 
-		// Wait before retry
-		time.Sleep(delay)
+		// Wait before retry, honoring scheduler / job cancellation so
+		// SIGTERM drains promptly even mid-retry. Pre-fix this was a bare
+		// time.Sleep that blocked daemon shutdown for up to RetryDelay ×
+		// MaxRetries (compounded by exponential backoff). Sibling fix to
+		// https://github.com/netresearch/ofelia/issues/673 — see #687.
+		runCtx := ctx.RunContext()
+		select {
+		case <-time.After(delay):
+		case <-runCtx.Done():
+			return fmt.Errorf("job %q retry interrupted: %w", job.GetName(), runCtx.Err())
+		}
 
 		attempt++
 	}

--- a/core/retry_test.go
+++ b/core/retry_test.go
@@ -4,6 +4,7 @@
 package core
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -198,5 +199,73 @@ func TestRetryConfig(t *testing.T) {
 
 	if config.RetryMaxDelayMs != 120000 {
 		t.Errorf("Expected RetryMaxDelayMs=120000, got %d", config.RetryMaxDelayMs)
+	}
+}
+
+// TestExecuteWithRetry_HonorsContextCancellation pins the fix for
+// https://github.com/netresearch/ofelia/issues/687.
+//
+// Before the fix the inter-attempt backoff used a bare time.Sleep that
+// did not observe ctx cancellation, so SIGTERM on a daemon mid-retry kept
+// the job goroutine pinned for up to RetryDelay × MaxRetries (compounded
+// by exponential backoff) waiting for the sleep to return — keeping the
+// scheduler from draining on shutdown. The fix replaces the sleep with a
+// select over (time.After, ctx.RunContext().Done()) so retries drain
+// promptly. Sibling to #673 / #685 (webhook retry backoff).
+//
+// We assert two things:
+//  1. After cancellation, ExecuteWithRetry returns within a small window
+//     (well under the RetryDelay budget) instead of blocking through it.
+//  2. The returned error wraps context.Canceled so callers can branch on it.
+func TestExecuteWithRetry_HonorsContextCancellation(t *testing.T) {
+	logger := newDiscardLogger()
+	executor := NewRetryExecutor(logger)
+
+	// Big retry budget so a naive time.Sleep impl would block the test
+	// well past its deadline.
+	const retryDelay = 30 * time.Second
+	job := &testRetryJob{
+		BareJob: BareJob{
+			Name:         "test-ctx-cancel",
+			MaxRetries:   5,
+			RetryDelayMs: int(retryDelay / time.Millisecond),
+		},
+	}
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	ctx := &Context{
+		Execution: &Execution{},
+		Ctx:       cancelCtx,
+	}
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	attempts := 0
+	start := time.Now()
+	err := executor.ExecuteWithRetry(job, ctx, func(c *Context) error {
+		attempts++
+		return errors.New("persistent failure")
+	})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("ExecuteWithRetry should return an error after cancellation")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("ExecuteWithRetry should return an error chain containing context.Canceled, got: %v", err)
+	}
+	// Tolerate CI slowness but stay well under RetryDelay. If the fix
+	// regresses to time.Sleep, elapsed will balloon to ~retryDelay.
+	if elapsed >= 5*time.Second {
+		t.Errorf("ExecuteWithRetry should drain promptly on ctx cancel (elapsed=%v, retryDelay=%v)",
+			elapsed, retryDelay)
+	}
+	// Cancellation hit during the first backoff, so runFunc should have
+	// been called exactly once (the initial attempt that failed).
+	if attempts != 1 {
+		t.Errorf("Expected 1 attempt before cancellation, got %d", attempts)
 	}
 }

--- a/core/retry_test.go
+++ b/core/retry_test.go
@@ -233,6 +233,7 @@ func TestExecuteWithRetry_HonorsContextCancellation(t *testing.T) {
 	}
 
 	cancelCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	ctx := &Context{
 		Execution: &Execution{},
 		Ctx:       cancelCtx,


### PR DESCRIPTION
## Summary

- `(*RetryExecutor).ExecuteWithRetry` used a bare `time.Sleep(delay)` between retries that ignored ctx cancellation. SIGTERM mid-retry blocked daemon shutdown for up to `RetryDelay × MaxRetries` (compounded by exponential backoff).
- Replaced with `select { case <-time.After(delay): case <-runCtx.Done(): … }` so retries drain promptly. Returns an error wrapping `context.Canceled` on cancellation.
- Added `TestExecuteWithRetry_HonorsContextCancellation` to pin the fix (30s delay × 5 retries, cancelled at 100ms, must return in <5s with `context.Canceled` in the error chain).

Sibling fix to the webhook backoff fix in [#685](https://github.com/netresearch/ofelia/pull/685) / [#673](https://github.com/netresearch/ofelia/issues/673) — different code path (job-level retry executor vs. webhook middleware).

Closes [#687](https://github.com/netresearch/ofelia/issues/687).

## Why this isn't covered by #685

#685 fixed the webhook middleware's retry backoff. This is the job-level retry executor (`core/retry.go`, different file, different timeout knobs).

## Known minor observation (out of scope)

The retry metric at `core/retry.go:124` (`RecordJobRetry(jobName, attempt+1, false)`) fires *before* the backoff, so after cancellation it records that attempt `N+1` happened when it actually never ran. The same ordering exists in the post-#685 webhook code, so I kept it consistent rather than touch it here. Worth a follow-up if either path needs metric accuracy.

## Test plan

- [x] `go test ./core/...` passes (including `TestExecuteWithRetry_HonorsContextCancellation`)
- [x] `golangci-lint run ./core/` clean
- [x] `go vet ./core/...` clean
- [ ] CI green