### PR TITLE
refactor(docker): drive disableHTTP2AutoConfig from schemeHandler.tlsCapable (#683)

### DIFF
--- a/core/adapters/docker/client.go
+++ b/core/adapters/docker/client.go
@@ -601,6 +601,10 @@ func applyTLSTransport(transport *http.Transport, cfg *ClientConfig, _ string) {
 // Operators who want TLS over a TCP daemon must use tcp+tls:// (#616) or
 // https:// directly. See #628 (this reconciliation) and #634 (the deeper
 // SDK URL-rewrite half of the docker-CLI parity story).
+//
+// HTTP/2 auto-config suppression is handled centrally by createHTTPClient
+// via the tlsCapable: false flag in schemeHandlers — do not re-add a
+// disableHTTP2AutoConfig call here.
 func applyTCPTransport(transport *http.Transport, _ *ClientConfig, _ string) {
 	transport.ForceAttemptHTTP2 = false
 }
@@ -624,6 +628,10 @@ func applyTCPTransport(transport *http.Transport, _ *ClientConfig, _ string) {
 // handles tcp://, so http:// and tcp:// dial to the same target for any
 // given operator-supplied DOCKER_HOST value. A plain strings.TrimPrefix
 // would have fed "host:port/v1.43" to net.Dial("tcp", …), failing.
+//
+// HTTP/2 auto-config suppression is handled centrally by createHTTPClient
+// via the tlsCapable: false flag in schemeHandlers — do not re-add a
+// disableHTTP2AutoConfig call here.
 func applyHTTPTransport(transport *http.Transport, cfg *ClientConfig, host string) {
 	addr := host
 	if parsed, err := url.Parse(host); err == nil && parsed.Host != "" {
@@ -643,6 +651,10 @@ func applyHTTPTransport(transport *http.Transport, cfg *ClientConfig, host strin
 // the connection will fail at dial time — see docs/TROUBLESHOOTING.md).
 // http:// has its own handler (applyHTTPTransport, #682) so it can
 // install a TCP DialContext that fixes hijack-path APIs.
+//
+// HTTP/2 auto-config suppression is handled centrally by createHTTPClient
+// via the tlsCapable: false flag in schemeHandlers — do not re-add a
+// disableHTTP2AutoConfig call here.
 func applyPlainTransport(transport *http.Transport, _ *ClientConfig, _ string) {
 	transport.ForceAttemptHTTP2 = false
 }

--- a/core/adapters/docker/client.go
+++ b/core/adapters/docker/client.go
@@ -84,9 +84,20 @@ var getenv = os.Getenv
 // createHTTPClient — which is invoked directly by some tests — while still
 // letting NewClientWithConfig reject anything not on the public allow-list
 // at the front door (the security / silent-downgrade contract from PR #612).
+//
+// `tlsCapable` marks schemes whose apply function wires real TLS material so
+// the transport can negotiate ALPN h2. createHTTPClient inverts this flag to
+// drive disableHTTP2AutoConfig — non-TLS schemes MUST suppress Go std lib's
+// lazy HTTP/2 auto-config or the SDK's hijack-path dialer misreads the
+// auto-allocated TLSClientConfig as operator-configured TLS and crashes on
+// plain Docker daemons (https://github.com/netresearch/ofelia/issues/668).
+// Driving suppression from the flag — instead of from a call inside each
+// apply function — means a future non-TLS scheme can't silently regress #668
+// by forgetting the call (see #683).
 type schemeHandler struct {
-	allowed bool
-	apply   func(transport *http.Transport, cfg *ClientConfig, host string)
+	allowed    bool
+	tlsCapable bool
+	apply      func(transport *http.Transport, cfg *ClientConfig, host string)
 }
 
 // schemeHandlers maps a lowercase URL scheme to its transport configuration.
@@ -119,12 +130,12 @@ type schemeHandler struct {
 //     is build-tagged. The handler is a no-op so non-Windows builds still
 //     compile and the scheme is on the public allow-list.
 var schemeHandlers = map[string]schemeHandler{
-	schemeUnix:   {allowed: true, apply: applyUnixTransport},
-	schemeTCP:    {allowed: true, apply: applyTCPTransport},
-	schemeHTTP:   {allowed: true, apply: applyHTTPTransport},
-	schemeHTTPS:  {allowed: true, apply: applyTLSTransport},
-	schemeNpipe:  {allowed: true, apply: applyPlainTransport},
-	schemeTCPTLS: {allowed: true, apply: applyTLSTransport},
+	schemeUnix:   {allowed: true, tlsCapable: false, apply: applyUnixTransport},
+	schemeTCP:    {allowed: true, tlsCapable: false, apply: applyTCPTransport},
+	schemeHTTP:   {allowed: true, tlsCapable: false, apply: applyHTTPTransport},
+	schemeHTTPS:  {allowed: true, tlsCapable: true, apply: applyTLSTransport},
+	schemeNpipe:  {allowed: true, tlsCapable: false, apply: applyPlainTransport},
+	schemeTCPTLS: {allowed: true, tlsCapable: true, apply: applyTLSTransport},
 }
 
 // supportedSchemesMsg is the cached, comma-separated list of allowed schemes
@@ -485,6 +496,13 @@ func createHTTPClient(config *ClientConfig) *http.Client {
 
 	if handler, ok := schemeHandlers[scheme]; ok {
 		handler.apply(transport, config, host)
+		// Non-TLS schemes MUST suppress Go std lib's lazy HTTP/2 auto-config
+		// (see schemeHandler.tlsCapable doc and #668). Driving this from the
+		// flag — instead of the apply function — guarantees by construction
+		// that a future non-TLS scheme can't regress the invariant (#683).
+		if !handler.tlsCapable {
+			disableHTTP2AutoConfig(transport)
+		}
 	} else {
 		// Unknown / unrecognized scheme: plain HTTP/1.1. This branch is
 		// unreachable when NewClientWithConfig validated the host, but
@@ -554,7 +572,8 @@ func disableHTTP2AutoConfig(transport *http.Transport) {
 
 // applyUnixTransport configures the transport to dial a Unix domain socket
 // at the path encoded in host. HTTP/2 is disabled (Docker over a Unix
-// socket is HTTP/1.1).
+// socket is HTTP/1.1). HTTP/2 auto-config suppression is handled centrally
+// by createHTTPClient via the tlsCapable: false flag in schemeHandlers.
 func applyUnixTransport(transport *http.Transport, cfg *ClientConfig, host string) {
 	socketPath := strings.TrimPrefix(host, schemeUnix+"://")
 	transport.DialContext = func(ctx context.Context, _, _ string) (net.Conn, error) {
@@ -562,7 +581,6 @@ func applyUnixTransport(transport *http.Transport, cfg *ClientConfig, host strin
 		return dialer.DialContext(ctx, schemeUnix, socketPath)
 	}
 	transport.ForceAttemptHTTP2 = false
-	disableHTTP2AutoConfig(transport)
 }
 
 // applyTLSTransport wires the transport for HTTPS / tcp+tls hosts: HTTP/2
@@ -585,7 +603,6 @@ func applyTLSTransport(transport *http.Transport, cfg *ClientConfig, _ string) {
 // SDK URL-rewrite half of the docker-CLI parity story).
 func applyTCPTransport(transport *http.Transport, _ *ClientConfig, _ string) {
 	transport.ForceAttemptHTTP2 = false
-	disableHTTP2AutoConfig(transport)
 }
 
 // applyHTTPTransport handles plain http:// Docker hosts. Identical to
@@ -619,7 +636,6 @@ func applyHTTPTransport(transport *http.Transport, cfg *ClientConfig, host strin
 		return dialer.DialContext(ctx, schemeTCP, addr)
 	}
 	transport.ForceAttemptHTTP2 = false
-	disableHTTP2AutoConfig(transport)
 }
 
 // applyPlainTransport is the no-frills HTTP/1.1 path used for npipe://
@@ -629,7 +645,6 @@ func applyHTTPTransport(transport *http.Transport, cfg *ClientConfig, host strin
 // install a TCP DialContext that fixes hijack-path APIs.
 func applyPlainTransport(transport *http.Transport, _ *ClientConfig, _ string) {
 	transport.ForceAttemptHTTP2 = false
-	disableHTTP2AutoConfig(transport)
 }
 
 // upgradeTCPToHTTPSIfTLSMaterial mirrors the docker CLI's silent scheme

--- a/core/adapters/docker/client_tcp_hijack_test.go
+++ b/core/adapters/docker/client_tcp_hijack_test.go
@@ -151,24 +151,37 @@ func TestApplyTLSTransport_DoesNotDisableHTTP2AutoConfig(t *testing.T) {
 // from the dispatch, not from a manually-duplicated call inside each apply
 // function. Replaces the per-apply-function check that lived here before
 // #683's data-driven refactor.
+//
+// Asserts a minimum count of covered schemes so a future map-deletion that
+// silently empties the loop body fails loudly; requires hostFor entries to
+// be present so a new scheme without a fixture cannot fall back to env-
+// derived defaults and silently test the wrong scheme.
 func TestSchemeHandler_NonTLSCapableSuppressesHTTP2(t *testing.T) {
-	// Static host samples for each scheme. Values don't matter beyond
-	// parsing — createHTTPClient never dials.
+	// Belt-and-braces: keep ambient DOCKER_HOST from contaminating
+	// resolveHostForDispatch's env fallback if hostFor were ever empty.
+	t.Setenv("DOCKER_HOST", "")
+	// Static host samples for each non-TLS scheme. Values don't matter
+	// beyond parsing — createHTTPClient never dials.
 	hostFor := map[string]string{
-		schemeUnix:   "unix:///var/run/docker.sock",
-		schemeTCP:    "tcp://127.0.0.1:2375",
-		schemeHTTP:   "http://127.0.0.1:2375",
-		schemeHTTPS:  "https://127.0.0.1:2376",
-		schemeNpipe:  "npipe://./pipe/docker_engine",
-		schemeTCPTLS: "tcp+tls://127.0.0.1:2376",
+		schemeUnix:  "unix:///var/run/docker.sock",
+		schemeTCP:   "tcp://127.0.0.1:2375",
+		schemeHTTP:  "http://127.0.0.1:2375",
+		schemeNpipe: "npipe://./pipe/docker_engine",
 	}
+	const minNonTLSSchemes = 4
+	covered := 0
 	for scheme, handler := range schemeHandlers {
 		if handler.tlsCapable {
 			continue
 		}
+		host, ok := hostFor[scheme]
+		if !ok {
+			t.Fatalf("hostFor missing entry for scheme %q — extend the fixture when adding a new non-TLS scheme", scheme)
+		}
+		covered++
 		t.Run(scheme, func(t *testing.T) {
 			cfg := DefaultConfig()
-			cfg.Host = hostFor[scheme]
+			cfg.Host = host
 			client := createHTTPClient(cfg)
 			transport, ok := client.Transport.(*http.Transport)
 			if !ok {
@@ -179,6 +192,9 @@ func TestSchemeHandler_NonTLSCapableSuppressesHTTP2(t *testing.T) {
 			}
 		})
 	}
+	if covered < minNonTLSSchemes {
+		t.Fatalf("only %d non-TLS schemes covered (want >=%d) — schemeHandlers shrank or all schemes flipped to tlsCapable=true", covered, minNonTLSSchemes)
+	}
 }
 
 // TestSchemeHandler_TLSCapableMeansHTTP2Allowed locks the inverse half of
@@ -186,18 +202,31 @@ func TestSchemeHandler_NonTLSCapableSuppressesHTTP2(t *testing.T) {
 // MUST keep TLSNextProto nil so ALPN h2 negotiation works. If a refactor
 // accidentally flips a TLS-capable scheme into the suppression path, HTTPS
 // Docker hosts silently lose HTTP/2.
+//
+// Asserts a minimum count of covered schemes so a future map-deletion that
+// silently empties the loop body fails loudly; requires hostFor entries to
+// be present so a new scheme without a fixture cannot fall back to env-
+// derived defaults and silently test the wrong scheme.
 func TestSchemeHandler_TLSCapableMeansHTTP2Allowed(t *testing.T) {
+	t.Setenv("DOCKER_HOST", "")
 	hostFor := map[string]string{
 		schemeHTTPS:  "https://127.0.0.1:2376",
 		schemeTCPTLS: "tcp+tls://127.0.0.1:2376",
 	}
+	const minTLSSchemes = 2
+	covered := 0
 	for scheme, handler := range schemeHandlers {
 		if !handler.tlsCapable {
 			continue
 		}
+		host, ok := hostFor[scheme]
+		if !ok {
+			t.Fatalf("hostFor missing entry for scheme %q — extend the fixture when adding a new TLS-capable scheme", scheme)
+		}
+		covered++
 		t.Run(scheme, func(t *testing.T) {
 			cfg := DefaultConfig()
-			cfg.Host = hostFor[scheme]
+			cfg.Host = host
 			client := createHTTPClient(cfg)
 			transport, ok := client.Transport.(*http.Transport)
 			if !ok {
@@ -210,6 +239,9 @@ func TestSchemeHandler_TLSCapableMeansHTTP2Allowed(t *testing.T) {
 				t.Fatalf("createHTTPClient(%s) did not set ForceAttemptHTTP2=true on a tlsCapable scheme", scheme)
 			}
 		})
+	}
+	if covered < minTLSSchemes {
+		t.Fatalf("only %d TLS-capable schemes covered (want >=%d) — schemeHandlers shrank or all schemes flipped to tlsCapable=false", covered, minTLSSchemes)
 	}
 }
 

--- a/core/adapters/docker/client_tcp_hijack_test.go
+++ b/core/adapters/docker/client_tcp_hijack_test.go
@@ -143,27 +143,71 @@ func TestApplyTLSTransport_DoesNotDisableHTTP2AutoConfig(t *testing.T) {
 	}
 }
 
-// TestApplyTransport_NonTLSDisableHTTP2AutoConfig asserts the inverse:
-// every non-TLS apply path MUST suppress HTTP/2 auto-config. Adding a new
-// non-TLS scheme handler without the call would silently re-introduce
-// #668; this table pins the invariant.
-func TestApplyTransport_NonTLSDisableHTTP2AutoConfig(t *testing.T) {
-	cases := []struct {
-		name  string
-		apply func(*http.Transport, *ClientConfig, string)
-		host  string
-	}{
-		{"unix", applyUnixTransport, "unix:///var/run/docker.sock"},
-		{"tcp", applyTCPTransport, "tcp://127.0.0.1:2375"},
-		{"http", applyHTTPTransport, "http://127.0.0.1:2375"},
-		{"plain", applyPlainTransport, "npipe://./pipe/docker_engine"},
+// TestSchemeHandler_NonTLSCapableSuppressesHTTP2 asserts the structural
+// invariant from #683: every scheme registered with tlsCapable=false in
+// schemeHandlers MUST end up with TLSNextProto suppressed after going
+// through createHTTPClient. Adding a new non-TLS scheme handler now only
+// requires registering it with tlsCapable=false — the suppression follows
+// from the dispatch, not from a manually-duplicated call inside each apply
+// function. Replaces the per-apply-function check that lived here before
+// #683's data-driven refactor.
+func TestSchemeHandler_NonTLSCapableSuppressesHTTP2(t *testing.T) {
+	// Static host samples for each scheme. Values don't matter beyond
+	// parsing — createHTTPClient never dials.
+	hostFor := map[string]string{
+		schemeUnix:   "unix:///var/run/docker.sock",
+		schemeTCP:    "tcp://127.0.0.1:2375",
+		schemeHTTP:   "http://127.0.0.1:2375",
+		schemeHTTPS:  "https://127.0.0.1:2376",
+		schemeNpipe:  "npipe://./pipe/docker_engine",
+		schemeTCPTLS: "tcp+tls://127.0.0.1:2376",
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			transport := &http.Transport{}
-			tc.apply(transport, DefaultConfig(), tc.host)
+	for scheme, handler := range schemeHandlers {
+		if handler.tlsCapable {
+			continue
+		}
+		t.Run(scheme, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Host = hostFor[scheme]
+			client := createHTTPClient(cfg)
+			transport, ok := client.Transport.(*http.Transport)
+			if !ok {
+				t.Fatalf("createHTTPClient returned non-*http.Transport: %T", client.Transport)
+			}
 			if transport.TLSNextProto == nil {
-				t.Fatalf("apply%s did not call disableHTTP2AutoConfig — silent regression risk for #668", tc.name)
+				t.Fatalf("createHTTPClient(%s) left TLSNextProto nil — non-TLS scheme must suppress HTTP/2 auto-config (#668, structural fix in #683)", scheme)
+			}
+		})
+	}
+}
+
+// TestSchemeHandler_TLSCapableMeansHTTP2Allowed locks the inverse half of
+// #683's structural invariant: every scheme registered with tlsCapable=true
+// MUST keep TLSNextProto nil so ALPN h2 negotiation works. If a refactor
+// accidentally flips a TLS-capable scheme into the suppression path, HTTPS
+// Docker hosts silently lose HTTP/2.
+func TestSchemeHandler_TLSCapableMeansHTTP2Allowed(t *testing.T) {
+	hostFor := map[string]string{
+		schemeHTTPS:  "https://127.0.0.1:2376",
+		schemeTCPTLS: "tcp+tls://127.0.0.1:2376",
+	}
+	for scheme, handler := range schemeHandlers {
+		if !handler.tlsCapable {
+			continue
+		}
+		t.Run(scheme, func(t *testing.T) {
+			cfg := DefaultConfig()
+			cfg.Host = hostFor[scheme]
+			client := createHTTPClient(cfg)
+			transport, ok := client.Transport.(*http.Transport)
+			if !ok {
+				t.Fatalf("createHTTPClient returned non-*http.Transport: %T", client.Transport)
+			}
+			if transport.TLSNextProto != nil {
+				t.Fatalf("createHTTPClient(%s) set TLSNextProto on a tlsCapable scheme — ALPN h2 negotiation now broken (#683)", scheme)
+			}
+			if !transport.ForceAttemptHTTP2 {
+				t.Fatalf("createHTTPClient(%s) did not set ForceAttemptHTTP2=true on a tlsCapable scheme", scheme)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Promote the "non-TLS schemes must suppress HTTP/2 auto-config" rule from a manually-duplicated call inside four `apply*` functions to a data-driven property on the `schemeHandler` struct.

\`createHTTPClient\` now drives \`disableHTTP2AutoConfig\` from the new \`schemeHandler.tlsCapable\` flag:

\`\`\`go
if handler, ok := schemeHandlers[scheme]; ok {
    handler.apply(transport, config, host)
    if !handler.tlsCapable {
        disableHTTP2AutoConfig(transport)
    }
}
\`\`\`

A future scheme added to \`schemeHandlers\` either declares \`tlsCapable: true\` (and accepts the implications — must wire TLS in its \`apply\`) or gets the [#668](https://github.com/netresearch/ofelia/issues/668) fix for free. The "silent regression risk" gap from [#683](https://github.com/netresearch/ofelia/issues/683) — a contributor adding a new non-TLS scheme and forgetting the \`disableHTTP2AutoConfig\` call — is now structurally impossible.

Closes [#683](https://github.com/netresearch/ofelia/issues/683).

## Behavior changes

**None for existing schemes.** \`TLSNextProto\` and \`ForceAttemptHTTP2\` end up at identical values after \`createHTTPClient\` returns. The unknown-scheme \`else\` branch is unchanged (no map entry to derive a flag from).

## Test changes

- \`TestApplyTransport_NonTLSDisableHTTP2AutoConfig\` → renamed to \`TestSchemeHandler_NonTLSCapableSuppressesHTTP2\` and rewritten to iterate \`schemeHandlers\` and assert via \`createHTTPClient\`. The new shape automatically covers any future \`tlsCapable: false\` scheme — previously every new non-TLS scheme had to be manually added to the cases table.
- New \`TestSchemeHandler_TLSCapableMeansHTTP2Allowed\` locks the inverse half of the invariant per the [#683 spec](https://github.com/netresearch/ofelia/issues/683#issue-description): every \`tlsCapable: true\` scheme keeps \`TLSNextProto\` nil through \`createHTTPClient\` (ALPN h2 negotiation works) AND sets \`ForceAttemptHTTP2 = true\`.
- \`TestApplyTLSTransport_DoesNotDisableHTTP2AutoConfig\` and \`TestDisableHTTP2AutoConfig_KeepsTLSClientConfigNil\` unchanged — they test the helper / the TLS-path negative control directly.

## References

- Introduced in: [#681](https://github.com/netresearch/ofelia/pull/681) (multi-axis review feedback)
- Original bug: [#668](https://github.com/netresearch/ofelia/issues/668)

## Test plan

- [x] \`go test ./...\` passes (full repo, 14 packages, 56s)
- [x] \`golangci-lint run\` clean
- [x] \`go vet ./...\` clean
- [ ] CI green