### PR TITLE
feat(docker): retry Docker connection on startup with exponential backoff (#523)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `[docker] startup-retry-count` and `[docker] startup-retry-interval` config (also exposed as `--docker-startup-retry-count` / `OFELIA_DOCKER_STARTUP_RETRY_COUNT` and `--docker-startup-retry-interval` / `OFELIA_DOCKER_STARTUP_RETRY_INTERVAL`) retry the initial Docker connection with exponential backoff before the daemon exits. Default is `startup-retry-count=0`, which preserves the pre-fix "exit on first failure" behavior; setting `startup-retry-count=5 startup-retry-interval=1s` yields a 1s → 2s → 4s → 8s → 16s budget (~31s total). Each per-attempt ping is still bounded by `dockerStartupPingTimeout` (10s) so a wedged daemon cannot inflate startup beyond `(count+1)·10s + Σbackoffs`. The backoff window observes ctx cancellation so SIGTERM during startup drains promptly instead of blocking the full budget (same shape as [#685](https://github.com/netresearch/ofelia/pull/685) / [#687](https://github.com/netresearch/ofelia/pull/687)). Useful for TCP-based Docker hosts where the daemon may briefly be unreachable on startup before health checks settle (socket proxies, remote Docker hosts, Docker-in-Docker). Closes [#523](https://github.com/netresearch/ofelia/issues/523).
+
 ### Security
 
 - Extended the `[global] allow-host-jobs-from-labels=false` policy to cover both `job-run` AND `job-service-run` entries that mount host filesystem paths via Docker labels (e.g. `ofelia.job-run.X.volume=/:/host:rw`) **or** inherit a donor container's bind mounts via `volumes-from` (e.g. `ofelia.job-run.X.volumes-from=ofelia` to pull in the daemon's `/var/run/docker.sock` mount). Pre-fix, only `job-local` and `job-compose` were filtered, leaving every container-spawning job type (`job-run` and Swarm `job-service-run`) with open container-to-host privilege-escalation vectors via `volume=` and `volumes-from=`. An attacker controlling labels on any container Ofelia watched could mount `/` into the spawned container directly, or chain via `volumes-from=ofelia` to inherit the Docker socket and gain full daemon access. The new per-job filter:

--- a/cli/config.go
+++ b/cli/config.go
@@ -1296,6 +1296,28 @@ type DockerConfig struct {
 	// Default is 10s for backwards compatibility.
 	PollingFallback time.Duration `mapstructure:"polling-fallback" validate:"gte=0" default:"10s"`
 
+	// StartupRetryCount sets the number of EXTRA Docker connection attempts
+	// at daemon startup beyond the initial ping. The total attempt budget is
+	// StartupRetryCount + 1; 0 (the default) preserves the pre-#523 behavior
+	// of a single ping that exits the daemon on failure. Useful with TCP-based
+	// Docker hosts (socket proxies, remote daemons, Docker-in-Docker) where
+	// the daemon may briefly be unreachable on startup before health checks
+	// settle. Per attempt the call is bounded by dockerStartupPingTimeout
+	// (10s) so the worst-case startup budget is
+	// (count+1) × dockerStartupPingTimeout + Σ backoffs.
+	// Can be set via --docker-startup-retry-count or
+	// OFELIA_DOCKER_STARTUP_RETRY_COUNT. See
+	// https://github.com/netresearch/ofelia/issues/523.
+	StartupRetryCount int `mapstructure:"startup-retry-count" validate:"gte=0,lte=20" default:"0"`
+
+	// StartupRetryInterval is the base interval between Docker connection
+	// retry attempts at daemon startup. Backoff is exponential
+	// (interval × 2^(attempt-1)) and is honored only when StartupRetryCount > 0.
+	// Defaults to 1s so the issue's suggested 5-retry budget produces a
+	// 1s → 2s → 4s → 8s → 16s spacing (≈31s total). Capped at 5min per
+	// step to bound the daemon's startup delay on a wedged Docker host.
+	StartupRetryInterval time.Duration `mapstructure:"startup-retry-interval" validate:"gte=0,lte=5m" default:"1s"`
+
 	// Deprecated: Use ConfigPollInterval and DockerPollInterval instead.
 	// If set, this value is used for both config and container polling (BC).
 	PollInterval time.Duration `mapstructure:"poll-interval" validate:"gte=0"`

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -49,6 +49,12 @@ type DaemonCommand struct {
 	WebMaxLoginAttempts  int            `long:"web-max-login-attempts" env:"OFELIA_WEB_MAX_LOGIN_ATTEMPTS" description:"Lockout" default:"5"`                             //nolint:revive
 	WebTrustedProxies    []string       `long:"web-trusted-proxies" env:"OFELIA_WEB_TRUSTED_PROXIES" env-delim:"," description:"Trusted proxy CIDRs for X-Forwarded-For"` //nolint:revive
 
+	// Docker startup-retry knobs (#523). Placed at the end of the field
+	// block so the long descriptions don't push the existing columns past
+	// the line-length limit when gofmt aligns struct-tag columns.
+	DockerStartupRetryCount    *int           `long:"docker-startup-retry-count" env:"OFELIA_DOCKER_STARTUP_RETRY_COUNT" description:"Extra Docker connection attempts on startup beyond the initial ping (default 0)"` //nolint:revive,lll
+	DockerStartupRetryInterval *time.Duration `long:"docker-startup-retry-interval" env:"OFELIA_DOCKER_STARTUP_RETRY_INTERVAL" description:"Base interval for Docker startup retries; doubles each attempt"`            //nolint:revive,lll
+
 	scheduler       *core.Scheduler
 	pprofServer     *http.Server
 	webServer       *web.Server
@@ -289,6 +295,12 @@ func (c *DaemonCommand) applyOptions(config *Config) {
 	}
 	if c.DockerIncludeStopped != nil {
 		config.Docker.IncludeStopped = *c.DockerIncludeStopped
+	}
+	if c.DockerStartupRetryCount != nil {
+		config.Docker.StartupRetryCount = *c.DockerStartupRetryCount
+	}
+	if c.DockerStartupRetryInterval != nil {
+		config.Docker.StartupRetryInterval = *c.DockerStartupRetryInterval
 	}
 
 	c.applyWebOptions(config)

--- a/cli/daemon_ext_test.go
+++ b/cli/daemon_ext_test.go
@@ -159,6 +159,53 @@ func TestApplyOptions_AllFields(t *testing.T) {
 	assert.Equal(t, "debug", config.Global.LogLevel)
 }
 
+// TestApplyOptions_DockerStartupRetryFlags pins the CLI/env wiring for
+// the new --docker-startup-retry-count / --docker-startup-retry-interval
+// flags introduced in PR #699 / #523. Two parity tests: pointer-nil
+// (no override) and pointer-set (override applied). Mirrors the existing
+// DockerPollInterval/DockerIncludeStopped patterns above so the
+// applyOptions seam stays mutation-test-covered.
+func TestApplyOptions_DockerStartupRetryFlags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil-flags-preserve-config", func(t *testing.T) {
+		t.Parallel()
+		config := NewConfig(test.NewTestLogger())
+		config.Docker.StartupRetryCount = 5
+		config.Docker.StartupRetryInterval = 2 * time.Second
+
+		// All flag pointers nil — applyOptions must NOT touch the
+		// pre-existing config values (operator set them via INI).
+		cmd := &DaemonCommand{}
+		cmd.applyOptions(config)
+
+		assert.Equal(t, 5, config.Docker.StartupRetryCount,
+			"nil CLI flag must NOT clobber INI-supplied StartupRetryCount")
+		assert.Equal(t, 2*time.Second, config.Docker.StartupRetryInterval,
+			"nil CLI flag must NOT clobber INI-supplied StartupRetryInterval")
+	})
+
+	t.Run("flags-override-config", func(t *testing.T) {
+		t.Parallel()
+		config := NewConfig(test.NewTestLogger())
+		config.Docker.StartupRetryCount = 1
+		config.Docker.StartupRetryInterval = 100 * time.Millisecond
+
+		count := 7
+		interval := 3 * time.Second
+		cmd := &DaemonCommand{
+			DockerStartupRetryCount:    &count,
+			DockerStartupRetryInterval: &interval,
+		}
+		cmd.applyOptions(config)
+
+		assert.Equal(t, 7, config.Docker.StartupRetryCount,
+			"non-nil CLI flag must override INI-supplied StartupRetryCount")
+		assert.Equal(t, 3*time.Second, config.Docker.StartupRetryInterval,
+			"non-nil CLI flag must override INI-supplied StartupRetryInterval")
+	})
+}
+
 func TestApplyConfigDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/cli/docker_config_handler.go
+++ b/cli/docker_config_handler.go
@@ -47,6 +47,13 @@ type DockerHandler struct {
 	dockerPollInterval time.Duration // For container polling (explicit)
 	pollingFallback    time.Duration // Auto-enable polling if events fail
 
+	// Startup retry — see DockerConfig.StartupRetryCount / .StartupRetryInterval
+	// and https://github.com/netresearch/ofelia/issues/523. Honored by both
+	// the buildSDKProvider post-construction ping and the NewDockerHandler
+	// externally-provided-provider ping.
+	startupRetryCount    int
+	startupRetryInterval time.Duration
+
 	// Runtime state for fallback mechanism
 	mu                    sync.Mutex
 	eventsFailed          bool
@@ -115,16 +122,18 @@ func NewDockerHandler(
 	configPoll, dockerPoll, fallback, useEvents := resolveConfig(cfg, logger)
 
 	c := &DockerHandler{
-		ctx:                ctx,
-		cancel:             cancel,
-		filters:            cfg.Filters,
-		notifier:           notifier,
-		logger:             logger,
-		configPollInterval: configPoll,
-		useEvents:          useEvents,
-		dockerPollInterval: dockerPoll,
-		pollingFallback:    fallback,
-		includeStopped:     cfg.IncludeStopped,
+		ctx:                  ctx,
+		cancel:               cancel,
+		filters:              cfg.Filters,
+		notifier:             notifier,
+		logger:               logger,
+		configPollInterval:   configPoll,
+		useEvents:            useEvents,
+		dockerPollInterval:   dockerPoll,
+		pollingFallback:      fallback,
+		includeStopped:       cfg.IncludeStopped,
+		startupRetryCount:    cfg.StartupRetryCount,
+		startupRetryInterval: cfg.StartupRetryInterval,
 	}
 
 	var err error
@@ -138,12 +147,10 @@ func NewDockerHandler(
 		c.dockerProvider = provider
 	}
 
-	// Do a sanity check on docker. Bound the call so a wedged daemon cannot
-	// hang Ofelia at startup; see https://github.com/netresearch/ofelia/issues/614.
-	pingCtx, pingCancel := context.WithTimeout(ctx, dockerStartupPingTimeout)
-	err = c.dockerProvider.Ping(pingCtx)
-	pingCancel()
-	if err != nil {
+	// Do a sanity check on docker. Bound each attempt so a wedged daemon
+	// cannot hang Ofelia at startup; see issue #614. Retry with exponential
+	// backoff when the operator opted in via StartupRetryCount > 0; see #523.
+	if err = pingWithRetry(ctx, c.dockerProvider, c.startupRetryCount, c.startupRetryInterval, logger); err != nil {
 		cancel()
 		//nolint:revive // Error message intentionally verbose for UX (actionable troubleshooting hints)
 		return nil, fmt.Errorf("failed to connect to Docker daemon: %w\n  → Check Docker daemon is running: systemctl status docker\n  → Verify Docker API is accessible: docker info\n  → Check for Docker daemon errors: journalctl -u docker -n 50", err)
@@ -197,20 +204,62 @@ func (c *DockerHandler) buildSDKProvider() (core.DockerProvider, error) {
 		return nil, fmt.Errorf("failed to create SDK Docker provider: %w", err)
 	}
 
-	// Verify connection with a bounded context derived from the handler's own
-	// context so a SIGINT during startup also cancels the sanity ping. See
-	// https://github.com/netresearch/ofelia/issues/614 for the deadline; using
-	// c.ctx rather than context.Background propagates parent cancellation per
-	// PR #636 code review.
-	pingCtx, pingCancel := context.WithTimeout(c.ctx, dockerStartupPingTimeout)
-	err = provider.Ping(pingCtx)
-	pingCancel()
-	if err != nil {
+	// Verify connection; each attempt is bounded by dockerStartupPingTimeout
+	// (see issue #614) and the parent ctx (so SIGINT during startup cancels).
+	// Retries with exponential backoff are honored only when the operator
+	// opted in via StartupRetryCount > 0; see #523.
+	if err = pingWithRetry(c.ctx, provider, c.startupRetryCount, c.startupRetryInterval, c.logger); err != nil {
 		_ = provider.Close()
 		return nil, fmt.Errorf("SDK provider failed to connect to Docker: %w", err)
 	}
 
 	return provider, nil
+}
+
+// pingWithRetry calls provider.Ping with exponential backoff. The total
+// attempt budget is count+1 (the initial attempt plus `count` retries),
+// so count=0 collapses to a single ping — the pre-#523 behavior.
+// baseInterval × 2^(attempt-1) is the backoff before the n-th retry
+// (1s → 2s → 4s → ...). Each individual attempt is bounded by
+// dockerStartupPingTimeout. The backoff observes ctx cancellation via a
+// select over time.After / ctx.Done so SIGTERM during startup drains
+// promptly instead of blocking the full retry budget — same shape as
+// the retry-loop fixes in #685 (webhook) and #687 (job retries).
+//
+// Returns the last attempt's Ping error on exhaustion; returns a
+// wrapped context error if canceled during a backoff window.
+// See https://github.com/netresearch/ofelia/issues/523.
+func pingWithRetry(ctx context.Context, provider core.DockerProvider, count int, baseInterval time.Duration, logger *slog.Logger) error {
+	const maxBackoffStep = 5 * time.Minute
+	var lastErr error
+	for attempt := 0; attempt <= count; attempt++ {
+		pingCtx, pingCancel := context.WithTimeout(ctx, dockerStartupPingTimeout)
+		err := provider.Ping(pingCtx)
+		pingCancel()
+		if err == nil {
+			if attempt > 0 {
+				logger.Info(fmt.Sprintf("Docker reachable after %d retry attempt(s)", attempt))
+			}
+			return nil
+		}
+		lastErr = err
+		if attempt == count {
+			break // exhausted; fall through to return lastErr
+		}
+		// Exponential backoff: baseInterval × 2^attempt, capped per step.
+		backoff := baseInterval << attempt //nolint:gosec // attempt bounded by StartupRetryCount validation (<=20)
+		if backoff > maxBackoffStep || backoff <= 0 {
+			backoff = maxBackoffStep
+		}
+		logger.Warn(fmt.Sprintf("Docker ping failed (attempt %d/%d), retrying in %v",
+			attempt+1, count+1, backoff), "error", err)
+		select {
+		case <-time.After(backoff):
+		case <-ctx.Done():
+			return fmt.Errorf("docker startup retry canceled: %w", ctx.Err())
+		}
+	}
+	return lastErr
 }
 
 // watchConfig handles INI configuration file polling (separate from container detection).

--- a/cli/docker_config_handler.go
+++ b/cli/docker_config_handler.go
@@ -138,22 +138,28 @@ func NewDockerHandler(
 
 	var err error
 	if provider == nil {
+		// buildSDKProvider already runs pingWithRetry on the freshly-built
+		// SDK client, so we do NOT ping a second time here — that
+		// previously meant up to 2×(count+1) attempts in the SDK-built
+		// path, doubling the worst-case startup budget. Surfaced by
+		// Gemini's review on PR #699.
 		c.dockerProvider, err = c.buildSDKProvider()
 		if err != nil {
 			cancel()
-			return nil, err
+			//nolint:revive // Error message intentionally verbose for UX (actionable troubleshooting hints)
+			return nil, fmt.Errorf("failed to connect to Docker daemon: %w\n  → Check Docker daemon is running: systemctl status docker\n  → Verify Docker API is accessible: docker info\n  → Check for Docker daemon errors: journalctl -u docker -n 50", err)
 		}
 	} else {
 		c.dockerProvider = provider
-	}
-
-	// Do a sanity check on docker. Bound each attempt so a wedged daemon
-	// cannot hang Ofelia at startup; see issue #614. Retry with exponential
-	// backoff when the operator opted in via StartupRetryCount > 0; see #523.
-	if err = pingWithRetry(ctx, c.dockerProvider, c.startupRetryCount, c.startupRetryInterval, logger); err != nil {
-		cancel()
-		//nolint:revive // Error message intentionally verbose for UX (actionable troubleshooting hints)
-		return nil, fmt.Errorf("failed to connect to Docker daemon: %w\n  → Check Docker daemon is running: systemctl status docker\n  → Verify Docker API is accessible: docker info\n  → Check for Docker daemon errors: journalctl -u docker -n 50", err)
+		// Sanity-check the externally-supplied provider. Bound each
+		// attempt so a wedged daemon cannot hang Ofelia at startup
+		// (issue #614). Retry with exponential backoff when the operator
+		// opted in via StartupRetryCount > 0 (issue #523).
+		if err = pingWithRetry(ctx, c.dockerProvider, c.startupRetryCount, c.startupRetryInterval, logger); err != nil {
+			cancel()
+			//nolint:revive // Error message intentionally verbose for UX (actionable troubleshooting hints)
+			return nil, fmt.Errorf("failed to connect to Docker daemon: %w\n  → Check Docker daemon is running: systemctl status docker\n  → Verify Docker API is accessible: docker info\n  → Check for Docker daemon errors: journalctl -u docker -n 50", err)
+		}
 	}
 
 	// Start config file watcher (separate from container detection)

--- a/cli/docker_config_handler.go
+++ b/cli/docker_config_handler.go
@@ -247,16 +247,23 @@ func pingWithRetry(ctx context.Context, provider core.DockerProvider, count int,
 			break // exhausted; fall through to return lastErr
 		}
 		// Exponential backoff: baseInterval × 2^attempt, capped per step.
+		// baseInterval == 0 (operator explicitly chose "no sleep between
+		// attempts") skips the select entirely — without this branch the
+		// overflow guard below would silently promote 0 to maxBackoffStep,
+		// turning a fast-retry config into a 5-min-step config.
 		backoff := baseInterval << attempt //nolint:gosec // attempt bounded by StartupRetryCount validation (<=20)
-		if backoff > maxBackoffStep || backoff <= 0 {
+		if backoff > maxBackoffStep {
 			backoff = maxBackoffStep
 		}
 		logger.Warn(fmt.Sprintf("Docker ping failed (attempt %d/%d), retrying in %v",
 			attempt+1, count+1, backoff), "error", err)
+		if backoff <= 0 {
+			continue // immediate retry; honor ctx via the next Ping's pingCtx
+		}
 		select {
 		case <-time.After(backoff):
 		case <-ctx.Done():
-			return fmt.Errorf("docker startup retry canceled: %w", ctx.Err())
+			return fmt.Errorf("Docker startup retry canceled: %w", ctx.Err())
 		}
 	}
 	return lastErr

--- a/cli/docker_startup_retry_test.go
+++ b/cli/docker_startup_retry_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netresearch/ofelia/core"
+	"github.com/netresearch/ofelia/test"
+)
+
+// flakyPingProvider is a minimal core.DockerProvider that records ping
+// attempts and returns a configurable failure pattern. Used by the
+// startup-retry tests to verify the (count+1)-attempt budget and the
+// "succeed after N attempts" recovery path. Only Ping and Close are
+// exercised; the other methods panic so an accidental call surfaces in
+// the test output.
+type flakyPingProvider struct {
+	attempts     atomic.Int32
+	failUntilNth int32 // return pingErr for attempts 1..failUntilNth, nil after
+	pingErr      error
+	mockDockerProviderForHandler
+}
+
+func (p *flakyPingProvider) Ping(_ context.Context) error {
+	n := p.attempts.Add(1)
+	if n <= p.failUntilNth {
+		return p.pingErr
+	}
+	return nil
+}
+
+// TestPingWithRetry_NoRetriesPreservesPreFixBehavior pins that the
+// default (StartupRetryCount=0) collapses to a single Ping attempt — no
+// behavior change for operators who haven't opted into the new feature.
+// Closes the regression-risk concern that adding the retry helper would
+// silently change the "exit on first failure" startup contract.
+func TestPingWithRetry_NoRetriesPreservesPreFixBehavior(t *testing.T) {
+	t.Parallel()
+
+	provider := &flakyPingProvider{pingErr: errors.New("boom"), failUntilNth: 999}
+	err := pingWithRetry(context.Background(), provider, 0, time.Second, test.NewTestLogger())
+
+	require.Error(t, err)
+	assert.Equal(t, "boom", err.Error(),
+		"count=0 must return the single Ping error directly (no retry wrapping)")
+	assert.Equal(t, int32(1), provider.attempts.Load(),
+		"count=0 must produce exactly 1 attempt (the pre-#523 single-ping behavior)")
+}
+
+// TestPingWithRetry_SucceedsAfterNAttempts pins the recovery path: when
+// the Docker daemon comes up partway through the retry budget, the
+// helper returns nil and the daemon proceeds normally. The fix for
+// #523's reported "socket proxy not yet ready" scenario.
+func TestPingWithRetry_SucceedsAfterNAttempts(t *testing.T) {
+	t.Parallel()
+
+	provider := &flakyPingProvider{pingErr: errors.New("not ready yet"), failUntilNth: 2}
+	// Tiny interval so the test doesn't pay the full backoff budget.
+	err := pingWithRetry(context.Background(), provider, 5, time.Millisecond, test.NewTestLogger())
+
+	require.NoError(t, err,
+		"daemon should become reachable on attempt 3 (after 2 failed attempts) and the helper must return nil")
+	assert.Equal(t, int32(3), provider.attempts.Load(),
+		"exactly 3 attempts: 2 failures + 1 success")
+}
+
+// TestPingWithRetry_ExhaustsBudgetAndReturnsLastError pins the failure
+// path: if every attempt fails, the helper returns the last error
+// (preserving the existing "exit with the failure reason" UX) and the
+// attempt budget is exactly count+1 (not count, not count+2).
+func TestPingWithRetry_ExhaustsBudgetAndReturnsLastError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("daemon down")
+	provider := &flakyPingProvider{pingErr: wantErr, failUntilNth: 999}
+	err := pingWithRetry(context.Background(), provider, 3, time.Millisecond, test.NewTestLogger())
+
+	require.Error(t, err)
+	assert.Equal(t, wantErr, err,
+		"on exhaustion the helper must return the last Ping error verbatim — no wrapping that would obscure the operator-facing reason")
+	assert.Equal(t, int32(4), provider.attempts.Load(),
+		"count=3 must produce exactly 4 attempts (initial + 3 retries)")
+}
+
+// TestPingWithRetry_HonorsContextCancellation pins that ctx cancellation
+// during the backoff window interrupts the retry budget instead of
+// blocking the full Σ baseInterval × 2^attempt sum. Same shape as the
+// retry-loop ctx-cancellation fixes in #685 (webhook) and #687 (job
+// retries) — daemon SIGTERM during startup must drain promptly.
+func TestPingWithRetry_HonorsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	provider := &flakyPingProvider{pingErr: errors.New("never reachable"), failUntilNth: 999}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	// Big base interval so without ctx cancellation the test would
+	// block ~60s waiting on the backoff schedule.
+	start := time.Now()
+	err := pingWithRetry(ctx, provider, 5, 30*time.Second, test.NewTestLogger())
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled,
+		"the returned error must wrap context.Canceled so callers can branch on shutdown vs. real Docker errors")
+	assert.Less(t, elapsed, 5*time.Second,
+		"ctx cancellation during backoff must drain promptly (elapsed=%v); pre-fix this would block ~30s on the first time.After", elapsed)
+}
+
+// TestNewDockerHandler_StartupRetrySucceedsAfterFailures is the end-to-
+// end integration test for the #523 fix: NewDockerHandler reads
+// StartupRetryCount/Interval from DockerConfig and the daemon comes up
+// after a flaky-start period. Pre-#523 the daemon would have exited on
+// the first ping failure.
+func TestNewDockerHandler_StartupRetrySucceedsAfterFailures(t *testing.T) {
+	provider := &flakyPingProvider{pingErr: errors.New("warming up"), failUntilNth: 2}
+	notifier := &dummyNotifier{}
+
+	handler, err := NewDockerHandler(context.Background(), notifier, test.NewTestLogger(),
+		&DockerConfig{
+			StartupRetryCount:    5,
+			StartupRetryInterval: time.Millisecond,
+		}, provider)
+	t.Cleanup(func() {
+		if handler != nil {
+			_ = handler.Shutdown(context.Background())
+		}
+	})
+
+	require.NoError(t, err,
+		"NewDockerHandler must succeed when Docker comes up within the retry budget — the #523 fix")
+	assert.NotNil(t, handler)
+	assert.GreaterOrEqual(t, provider.attempts.Load(), int32(3),
+		"at least 3 ping attempts must have happened (2 failures + the success that let startup proceed)")
+}
+
+// Verify flakyPingProvider satisfies the core.DockerProvider interface
+// expected by NewDockerHandler. Compile-time assertion — if the
+// interface changes, this fails fast at build instead of at first use.
+var _ core.DockerProvider = (*flakyPingProvider)(nil)

--- a/cli/docker_startup_retry_test.go
+++ b/cli/docker_startup_retry_test.go
@@ -20,9 +20,15 @@ import (
 // flakyPingProvider is a minimal core.DockerProvider that records ping
 // attempts and returns a configurable failure pattern. Used by the
 // startup-retry tests to verify the (count+1)-attempt budget and the
-// "succeed after N attempts" recovery path. Only Ping and Close are
-// exercised; the other methods panic so an accidental call surfaces in
-// the test output.
+// "succeed after N attempts" recovery path.
+//
+// Only Ping is overridden; everything else falls through to the embedded
+// mockDockerProviderForHandler, which returns zero values (nil errors,
+// empty slices, etc.). The startup-retry tests don't exercise those
+// methods, but if a future test does and depends on a specific behavior,
+// it should either override the method explicitly or use a different
+// mock. The attempt counter uses atomic.Int32 so concurrent retries
+// (none today) would still be race-free.
 type flakyPingProvider struct {
 	attempts     atomic.Int32
 	failUntilNth int32 // return pingErr for attempts 1..failUntilNth, nil after

--- a/cli/docker_startup_retry_test.go
+++ b/cli/docker_startup_retry_test.go
@@ -119,12 +119,70 @@ func TestPingWithRetry_HonorsContextCancellation(t *testing.T) {
 		"ctx cancellation during backoff must drain promptly (elapsed=%v); pre-fix this would block ~30s on the first time.After", elapsed)
 }
 
+// TestPingWithRetry_ZeroIntervalDoesNotPromoteToCap pins the fix for
+// the foot-gun flagged in the PR #699 code review: when the operator
+// opts into retries (count>0) but explicitly sets interval=0 (meaning
+// "no sleep between attempts"), the helper MUST NOT silently promote
+// the 0 to maxBackoffStep (5 minutes). The earlier shape did exactly
+// that — `if backoff <= 0 { backoff = maxBackoffStep }` — turning a
+// fast-retry config into a 25-minute startup window for count=5. The
+// new behavior is "immediate retry, skip the select", which matches
+// operator intuition.
+func TestPingWithRetry_ZeroIntervalDoesNotPromoteToCap(t *testing.T) {
+	t.Parallel()
+
+	provider := &flakyPingProvider{pingErr: errors.New("not ready"), failUntilNth: 2}
+	start := time.Now()
+	err := pingWithRetry(context.Background(), provider, 5, 0, test.NewTestLogger())
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), provider.attempts.Load(),
+		"3 attempts to recover (2 failures + 1 success)")
+	assert.Less(t, elapsed, time.Second,
+		"interval=0 must mean 'no sleep between attempts'; pre-fix this would have been ~25min (5×5min cap)")
+}
+
+// TestPingWithRetry_CapsBackoffStep pins the maxBackoffStep ceiling
+// (5min per attempt). Without the cap, a baseInterval=10m would produce
+// a 10min first-backoff, defeating the daemon's startup budget. We use
+// ctx cancellation to avoid a 5-minute real-time test: cancel after
+// the first backoff begins, then assert elapsed lands close to the cap
+// (within tolerance) rather than to baseInterval.
+//
+// Concretely: baseInterval=10m, count=1 means one retry with backoff
+// = min(10m, 5m) = 5m. Canceling after 200ms must surface as
+// "interrupted during the 5m wait", not "interrupted during the 10m wait".
+// The cap is hard to test directly without faking time; we settle for
+// "elapsed is way less than baseInterval AND ctx.Canceled is returned",
+// which catches any future removal of the cap clamp.
+func TestPingWithRetry_CapsBackoffStep(t *testing.T) {
+	t.Parallel()
+
+	provider := &flakyPingProvider{pingErr: errors.New("down"), failUntilNth: 999}
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	err := pingWithRetry(ctx, provider, 1, 10*time.Minute, test.NewTestLogger())
+	elapsed := time.Since(start)
+
+	require.ErrorIs(t, err, context.Canceled,
+		"cancellation must surface; if the cap is removed the test will wait the full 10m baseInterval and timeout")
+	assert.Less(t, elapsed, 5*time.Second,
+		"cap-bypass regression: elapsed=%v should be a small ctx-cancellation drain, not the 10m baseInterval", elapsed)
+}
+
 // TestNewDockerHandler_StartupRetrySucceedsAfterFailures is the end-to-
 // end integration test for the #523 fix: NewDockerHandler reads
 // StartupRetryCount/Interval from DockerConfig and the daemon comes up
 // after a flaky-start period. Pre-#523 the daemon would have exited on
 // the first ping failure.
 func TestNewDockerHandler_StartupRetrySucceedsAfterFailures(t *testing.T) {
+	t.Parallel()
 	provider := &flakyPingProvider{pingErr: errors.New("warming up"), failUntilNth: 2}
 	notifier := &dummyNotifier{}
 


### PR DESCRIPTION
## Summary

Adds opt-in startup retry to the Docker connection ping in \`NewDockerHandler\` / \`buildSDKProvider\` so the daemon survives a brief Docker outage on boot (socket proxy not yet ready, remote daemon still initializing, Docker-in-Docker race). Pre-fix the daemon pinged Docker exactly once and exited fatally on failure — see the workarounds in [#522](https://github.com/netresearch/ofelia/issues/522) / [#523](https://github.com/netresearch/ofelia/issues/523).

Closes [#523](https://github.com/netresearch/ofelia/issues/523).

## Behavior

\`\`\`ini
[docker]
startup-retry-count = 5      ; default 0 → 1 attempt = pre-#523 behavior
startup-retry-interval = 1s  ; default 1s → 1s,2s,4s,8s,16s backoff
\`\`\`

CLI / env: \`--docker-startup-retry-count\` / \`OFELIA_DOCKER_STARTUP_RETRY_COUNT\`, \`--docker-startup-retry-interval\` / \`OFELIA_DOCKER_STARTUP_RETRY_INTERVAL\`.

| Setting | Pre-#523 | Post-#523 default | Per the issue's suggested config |
|---|---|---|---|
| \`startup-retry-count\` | n/a | 0 | 5 |
| \`startup-retry-interval\` | n/a | 1s | 1s |
| Total attempts | 1 | 1 | 6 (initial + 5 retries) |
| Worst-case startup delay | 10s (ping timeout) | 10s | ~31s backoff + (6·10s) per-attempt timeout |

The per-attempt ping is still bounded by \`dockerStartupPingTimeout\` (10s, from [#614](https://github.com/netresearch/ofelia/issues/614)) so a wedged daemon cannot inflate startup. The backoff window observes ctx cancellation — SIGTERM during startup drains promptly via a \`select\` over \`time.After\` / \`ctx.Done\`, mirroring the [#685](https://github.com/netresearch/ofelia/pull/685) (webhook) and [#687](https://github.com/netresearch/ofelia/pull/687) (job-retry) fixes for the same anti-pattern.

## Why default \`count=0\` instead of the issue's suggested 5

The issue describes the operator-facing UX with a 5-retry default, but the actual fix-sketch in the issue says: "Keep the current behavior as default (retry count = 0 means no change)". Going with that to avoid silently changing startup semantics for operators who haven't opted in — the new feature is documented, but the daemon's startup-failure UX is unchanged unless the operator picks it up.

## Tests (5 new)

- \`TestPingWithRetry_NoRetriesPreservesPreFixBehavior\` — count=0 produces exactly 1 attempt.
- \`TestPingWithRetry_SucceedsAfterNAttempts\` — recovery: daemon comes up on attempt 3.
- \`TestPingWithRetry_ExhaustsBudgetAndReturnsLastError\` — count=N produces exactly N+1 attempts, last error returned verbatim.
- \`TestPingWithRetry_HonorsContextCancellation\` — SIGTERM during backoff drains in <5s vs ~30s budget.
- \`TestNewDockerHandler_StartupRetrySucceedsAfterFailures\` — end-to-end through \`NewDockerHandler\` with the new \`DockerConfig\` fields.

## Test plan

- [x] \`go test ./...\` passes (full repo, 14 packages, ~58s)
- [x] \`golangci-lint run\` clean
- [x] \`go vet ./...\` clean
- [ ] CI green