### PR TITLE
feat(webhooks): add optional device targeting for Pushover preset

### DIFF
--- a/cli/config_webhook.go
+++ b/cli/config_webhook.go
@@ -188,6 +188,10 @@ func parseWebhookConfig(section *ini.Section, config *middlewares.WebhookConfig)
 		config.LinkText = ExpandEnvVars(key.String())
 	}
 
+	if key, err := section.GetKey("device"); err == nil {
+		config.Device = ExpandEnvVars(key.String())
+	}
+
 	return nil
 }
 
@@ -280,7 +284,8 @@ func webhookConfigChanged(a, b *middlewares.WebhookConfig) bool {
 		a.ID != b.ID || a.Secret != b.Secret ||
 		a.Trigger != b.Trigger || a.Timeout != b.Timeout ||
 		a.RetryCount != b.RetryCount || a.RetryDelay != b.RetryDelay ||
-		a.Link != b.Link || a.LinkText != b.LinkText
+		a.Link != b.Link || a.LinkText != b.LinkText ||
+		a.Device != b.Device
 }
 
 // rebuildAllMiddlewares resets and rebuilds scheduler and job middlewares.
@@ -418,6 +423,8 @@ func applyWebhookLabelParams(config *middlewares.WebhookConfig, params map[strin
 			config.Link = val
 		case "link-text":
 			config.LinkText = val
+		case "device":
+			config.Device = val
 		}
 	}
 }

--- a/cli/config_webhook.go
+++ b/cli/config_webhook.go
@@ -394,7 +394,7 @@ func buildWebhookConfigsFromLabels(c *Config, webhookLabels map[string]map[strin
 // applyWebhookLabelParams applies flat label params to a WebhookConfig.
 // This mirrors parseWebhookConfig but works from a string map (Docker labels)
 // instead of an INI section.
-func applyWebhookLabelParams(config *middlewares.WebhookConfig, params map[string]string) {
+func applyWebhookLabelParams(config *middlewares.WebhookConfig, params map[string]string) { //nolint:gocyclo // flat label-dispatch table
 	for key, val := range params {
 		switch strings.ToLower(key) {
 		case "preset":

--- a/cli/config_webhook_integration_test.go
+++ b/cli/config_webhook_integration_test.go
@@ -469,6 +469,7 @@ preset = matrix
 url = https://matrix.example.com/hookshot/webhook/123
 link = https://logs.example.com/ofelia
 link-text = View Logs
+device = iphone,desktop
 trigger = error
 `
 	config, err := BuildFromString(iniContent, test.NewTestLogger())
@@ -487,5 +488,9 @@ trigger = error
 
 	if webhook.LinkText != "View Logs" {
 		t.Errorf("Expected link-text 'View Logs', got %q", webhook.LinkText)
+	}
+
+	if webhook.Device != "iphone,desktop" {
+		t.Errorf("Expected device 'iphone,desktop', got %q", webhook.Device)
 	}
 }

--- a/cli/config_webhook_test.go
+++ b/cli/config_webhook_test.go
@@ -174,6 +174,7 @@ func TestApplyWebhookLabelParams(t *testing.T) {
 		"retry-delay": "10s",
 		"link":        "https://logs.example.com",
 		"link-text":   "View Logs",
+		"device":      "iphone,desktop",
 	}
 
 	applyWebhookLabelParams(config, params)
@@ -207,6 +208,9 @@ func TestApplyWebhookLabelParams(t *testing.T) {
 	}
 	if config.LinkText != "View Logs" {
 		t.Errorf("Expected link-text 'View Logs', got %q", config.LinkText)
+	}
+	if config.Device != "iphone,desktop" {
+		t.Errorf("Expected device 'iphone,desktop', got %q", config.Device)
 	}
 }
 
@@ -510,6 +514,7 @@ func TestWebhookConfigChanged_AllFields(t *testing.T) {
 		{name: "RetryDelay changed", modify: func(c *middlewares.WebhookConfig) { c.RetryDelay = 15 * time.Second }, want: true},
 		{name: "Link changed", modify: func(c *middlewares.WebhookConfig) { c.Link = "https://dashboard.example.com" }, want: true},
 		{name: "LinkText changed", modify: func(c *middlewares.WebhookConfig) { c.LinkText = "Dashboard" }, want: true},
+		{name: "Device changed", modify: func(c *middlewares.WebhookConfig) { c.Device = "iphone" }, want: true},
 	}
 
 	for _, tt := range tests {

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -176,6 +176,7 @@ All webhook parameters can be set via Docker labels on the service container:
 | `ofelia.webhook.NAME.retry-delay` | Delay between retries (e.g., `5s`) |
 | `ofelia.webhook.NAME.link` | Optional URL to include in notification |
 | `ofelia.webhook.NAME.link-text` | Display text for link |
+| `ofelia.webhook.NAME.device` | Optional target device(s) for presets that support per-device delivery (Pushover); comma-separated |
 
 Two operator-tunable, non-SSRF-sensitive webhook globals are exposed via
 Docker labels. The SSRF-sensitive globals (`webhook-allowed-hosts`,
@@ -213,7 +214,7 @@ Ofelia includes presets for popular notification services:
 | `matrix` | Matrix (via hookshot bridge) | `url` |
 | `ntfy` | ntfy.sh (public topics) | `id` (topic) |
 | `ntfy-token` | ntfy.sh (with Bearer auth) | `id` (topic), `secret` (access token) |
-| `pushover` | Pushover | `id` (user key), `secret` (API token) |
+| `pushover` | Pushover | `id` (user key), `secret` (API token); optional `device` |
 | `pagerduty` | PagerDuty Events API v2 | `secret` (routing key) |
 | `gotify` | Gotify | `url`, `secret` (app token) |
 | `healthchecks` | Healthchecks.io | `id` (uuid or pingkey/slug) |
@@ -231,6 +232,7 @@ Ofelia includes presets for popular notification services:
 | `secret` | string | Service-specific secret/token |
 | `link` | string | Optional URL to include in notification (e.g., link to logs) |
 | `link-text` | string | Display text for link (default: "View Details") |
+| `device` | string | Optional target device(s) for presets that support per-device delivery (Pushover); comma-separated. Empty = preset default (all devices) |
 | `trigger` | string | When to send: `always`, `error`, `success`, `skipped` (default: `error`) |
 | `timeout` | duration | HTTP request timeout (default: `30s`) |
 | `retry-count` | int | Number of retries on failure (default: `3`) |
@@ -420,6 +422,9 @@ preset = pushover
 id = user-key-here
 secret = api-token-here
 trigger = error
+; Optional: target specific device(s) instead of all of the user's devices.
+; Comma-separate multiple device names. Omit to deliver to every device.
+device = iphone
 ```
 
 ### PagerDuty

--- a/middlewares/preset_test.go
+++ b/middlewares/preset_test.go
@@ -123,6 +123,14 @@ func TestPushoverPreset_Device(t *testing.T) {
 	withoutDevice, err := preset.RenderBodyWithPreset(baseData(""))
 	require.NoError(t, err)
 	assert.NotContains(t, withoutDevice, "device=")
+
+	// The body is application/x-www-form-urlencoded, so device values must be
+	// escaped. A comma-separated multi-device list (Pushover-native) keeps its
+	// separator as %2C, and spaces/specials cannot inject extra parameters.
+	encoded, err := preset.RenderBodyWithPreset(baseData("my phone,desk&top"))
+	require.NoError(t, err)
+	assert.Contains(t, encoded, "&device=my+phone%2Cdesk%26top")
+	assert.NotContains(t, encoded, "device=my phone")
 }
 
 func TestPresetLoader_LoadBundledPreset_PagerDuty(t *testing.T) {

--- a/middlewares/preset_test.go
+++ b/middlewares/preset_test.go
@@ -92,6 +92,37 @@ func TestPresetLoader_LoadBundledPreset_Pushover(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, preset)
 	assert.Equal(t, "pushover", preset.Name)
+	// device is an optional targeting variable
+	assert.False(t, preset.Variables["device"].Required)
+}
+
+// TestPushoverPreset_Device verifies the optional device parameter is only
+// emitted in the request body when configured, and omitted otherwise, so the
+// default behaviour (deliver to all of the user's devices) is preserved.
+func TestPushoverPreset_Device(t *testing.T) {
+	t.Parallel()
+
+	loader := NewPresetLoader(nil)
+	preset, err := loader.Load("pushover")
+	require.NoError(t, err)
+
+	baseData := func(device string) map[string]any {
+		return map[string]any{
+			"Job":       WebhookJobData{Name: "backup", Type: "exec"},
+			"Execution": WebhookExecutionData{Status: "successful"},
+			"Host":      WebhookHostData{Hostname: "h"},
+			"Ofelia":    WebhookOfeliaData{Version: "v"},
+			"Preset":    PresetDataForTemplate{ID: "user", Secret: "token", Device: device},
+		}
+	}
+
+	withDevice, err := preset.RenderBodyWithPreset(baseData("iphone"))
+	require.NoError(t, err)
+	assert.Contains(t, withDevice, "&device=iphone")
+
+	withoutDevice, err := preset.RenderBodyWithPreset(baseData(""))
+	require.NoError(t, err)
+	assert.NotContains(t, withoutDevice, "device=")
 }
 
 func TestPresetLoader_LoadBundledPreset_PagerDuty(t *testing.T) {

--- a/middlewares/preset_test.go
+++ b/middlewares/preset_test.go
@@ -98,7 +98,7 @@ func TestPresetLoader_LoadBundledPreset_Pushover(t *testing.T) {
 
 // TestPushoverPreset_Device verifies the optional device parameter is only
 // emitted in the request body when configured, and omitted otherwise, so the
-// default behaviour (deliver to all of the user's devices) is preserved.
+// default behavior (deliver to all of the user's devices) is preserved.
 func TestPushoverPreset_Device(t *testing.T) {
 	t.Parallel()
 

--- a/middlewares/presets/pushover.yaml
+++ b/middlewares/presets/pushover.yaml
@@ -25,4 +25,4 @@ variables:
     example: "iphone,desktop"
 
 body: |
-  token={{.Preset.Secret}}&user={{.Preset.ID}}{{if .Preset.Device}}&device={{.Preset.Device}}{{end}}&title=Ofelia: {{.Job.Name}}&message=Job {{.Job.Name}} {{if .Execution.Failed}}failed{{else if .Execution.Skipped}}was skipped{{else}}completed{{end}} in {{.Execution.Duration}}{{if .Execution.Failed}}%0A%0AError: {{json .Execution.Error}}{{end}}&priority={{if .Execution.Failed}}1{{else}}0{{end}}&sound={{if .Execution.Failed}}siren{{else}}pushover{{end}}
+  token={{.Preset.Secret}}&user={{.Preset.ID}}{{if .Preset.Device}}&device={{urlquery .Preset.Device}}{{end}}&title=Ofelia: {{.Job.Name}}&message=Job {{.Job.Name}} {{if .Execution.Failed}}failed{{else if .Execution.Skipped}}was skipped{{else}}completed{{end}} in {{.Execution.Duration}}{{if .Execution.Failed}}%0A%0AError: {{json .Execution.Error}}{{end}}&priority={{if .Execution.Failed}}1{{else}}0{{end}}&sound={{if .Execution.Failed}}siren{{else}}pushover{{end}}

--- a/middlewares/presets/pushover.yaml
+++ b/middlewares/presets/pushover.yaml
@@ -1,6 +1,6 @@
 name: pushover
 description: "Pushover push notifications"
-version: "1.0.0"
+version: "1.1.0"
 
 url_scheme: "https://api.pushover.net/1/messages.json"
 
@@ -19,6 +19,10 @@ variables:
     required: true
     sensitive: true
     example: "azGDORePK8gMaC0QOYAMyEEuzJnyUi"
+  device:
+    description: "Optional target device name(s), comma-separated. Empty delivers to all of the user's devices."
+    required: false
+    example: "iphone,desktop"
 
 body: |
-  token={{.Preset.Secret}}&user={{.Preset.ID}}&title=Ofelia: {{.Job.Name}}&message=Job {{.Job.Name}} {{if .Execution.Failed}}failed{{else if .Execution.Skipped}}was skipped{{else}}completed{{end}} in {{.Execution.Duration}}{{if .Execution.Failed}}%0A%0AError: {{json .Execution.Error}}{{end}}&priority={{if .Execution.Failed}}1{{else}}0{{end}}&sound={{if .Execution.Failed}}siren{{else}}pushover{{end}}
+  token={{.Preset.Secret}}&user={{.Preset.ID}}{{if .Preset.Device}}&device={{.Preset.Device}}{{end}}&title=Ofelia: {{.Job.Name}}&message=Job {{.Job.Name}} {{if .Execution.Failed}}failed{{else if .Execution.Skipped}}was skipped{{else}}completed{{end}} in {{.Execution.Duration}}{{if .Execution.Failed}}%0A%0AError: {{json .Execution.Error}}{{end}}&priority={{if .Execution.Failed}}1{{else}}0{{end}}&sound={{if .Execution.Failed}}siren{{else}}pushover{{end}}

--- a/middlewares/webhook.go
+++ b/middlewares/webhook.go
@@ -671,6 +671,7 @@ type PresetDataForTemplate struct {
 	URL      string
 	Link     string
 	LinkText string
+	Device   string
 }
 
 // buildWebhookDataWithPreset adds preset data to webhook data for templates that reference it
@@ -694,6 +695,7 @@ func (w *Webhook) buildWebhookDataWithPreset(ctx *core.Context) map[string]any {
 			URL:      w.Config.URL,
 			Link:     w.Config.Link,
 			LinkText: linkText,
+			Device:   w.Config.Device,
 		},
 	}
 }

--- a/middlewares/webhook_config.go
+++ b/middlewares/webhook_config.go
@@ -69,6 +69,11 @@ type WebhookConfig struct {
 	// LinkText is the display text for the link (defaults to "View Details" if link is set)
 	LinkText string `gcfg:"link-text" mapstructure:"link-text"`
 
+	// Device is an optional target device used by presets that support
+	// per-device delivery (currently the Pushover preset). Empty means the
+	// preset's default (e.g. all of the user's devices).
+	Device string `gcfg:"device" mapstructure:"device"`
+
 	// Trigger determines when to send notifications
 	Trigger TriggerType `gcfg:"trigger" mapstructure:"trigger"`
 


### PR DESCRIPTION
## What

Adds an optional `device` field to webhook configuration so the **Pushover** preset can deliver to specific device(s) instead of all of a user's devices.

When `device` is unset, behaviour is **unchanged** — the notification is delivered to all of the user's devices, exactly as before.

## Why

Pushover's API supports a `device` parameter to target one or more named devices. The bundled `pushover` preset only exposed `id` (user key) and `secret` (API token), with no way to pass `device` — the generic webhook field set (`id`/`secret`/`url`/`link`/`link-text`/…) has no slot for it, so there was no label- or INI-only path to target a device.

This follows the existing precedent of the generic optional fields `link` / `link-text`: a small, dedicated optional field rather than a preset-specific hack.

## How

- New optional `device` field on `WebhookConfig` — settable via INI `device = …` and Docker label `ofelia.webhook.NAME.device`, comma-separated for multiple devices.
- Exposed to body templates via `.Preset.Device`; the `pushover` preset emits `&device=` **only when set** (`{{if .Preset.Device}}…{{end}}`), so the wire format is identical to today when unused.
- Wired through the INI parser (`parseWebhookConfig`), the Docker label parser (`applyWebhookLabelParams`) and change detection (`webhookConfigChanged`), so `--docker-events` re-syncs when the device changes.
- Pushover preset version bumped `1.0.0 → 1.1.0`.

### Example

```ini
[webhook "pushover-alerts"]
preset = pushover
id = user-key-here
secret = api-token-here
device = iphone        ; optional; comma-separate for multiple; omit for all devices
trigger = error
```

Docker label equivalent on the service container:

```yaml
ofelia.webhook.pushover.device: "iphone,desktop"
```

## Tests

- `TestPushoverPreset_Device` — body contains `&device=iphone` when set, and no `device=` when empty.
- Extended `applyWebhookLabelParams` / INI parsing / `webhookConfigChanged` tests to cover `device`.
- `go build ./...`, `go vet`, and the `middlewares` + `cli` suites pass locally (Go 1.26.4). The only local failure, `TestNewPresetCache_DefaultDir_HardensExistingDir`, is a pre-existing macOS-only artifact of `os.UserCacheDir()` ignoring `XDG_CACHE_HOME` — it fails identically on `main` and is unrelated to this change.

## Notes

I considered routing arbitrary preset variables through the existing `CustomVars` map instead, but that mechanism isn't currently populated from INI/labels and isn't exposed to body templates, so a dedicated field mirroring `link`/`link-text` was the smaller, consistent change. Happy to switch to a generic approach if you'd prefer.