### PR TITLE
fix(config): honor global default-user = default as container-default sentinel

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -702,11 +702,17 @@ const UserContainerDefault = "default"
 
 // applyDefaultUser sets the job's User field to the global default if not explicitly configured.
 // This allows per-job override while respecting the global default-user setting.
-// Special value "default" explicitly uses the container's default user (empty string).
+// The sentinel "default" (UserContainerDefault) explicitly requests the
+// container's default user (empty string) and is honored whether it originates
+// from the per-job value or from the global default-user setting — the two
+// checks are deliberately separate (not else-if) so that
+// `[global] default-user = default` resolves to the container default, matching
+// the documented per-job behavior.
 func (c *Config) applyDefaultUser(user *string) {
 	if *user == "" {
 		*user = c.Global.DefaultUser
-	} else if *user == UserContainerDefault {
+	}
+	if *user == UserContainerDefault {
 		*user = "" // Use container's default user
 	}
 }

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -827,6 +827,16 @@ func TestApplyDefaultUser(t *testing.T) {
 	user = UserContainerDefault
 	cfg.applyDefaultUser(&user)
 	assert.Empty(t, user)
+
+	// Global default-user = "default" (the sentinel) must resolve to the
+	// container's default user for a job that does not set User explicitly,
+	// matching the documented per-job behavior. Regression: previously the
+	// else-if branch left the literal "default" username, which Docker
+	// rejects with "unable to find user default".
+	cfg.Global.DefaultUser = UserContainerDefault
+	user = ""
+	cfg.applyDefaultUser(&user)
+	assert.Empty(t, user)
 }
 
 func TestMergeMailDefaults(t *testing.T) {


### PR DESCRIPTION
Fixes #716

## What

`[global] default-user = default` now resolves to the container's default user, instead of being forwarded verbatim to `docker exec --user default` (which fails with `unable to find user default: no matching entries in passwd file`).

## Why

`UserContainerDefault` (`"default"`) is documented to select the container's default user, but `applyDefaultUser` only honored the sentinel in an `else if` — so it worked **per-job** but not when sourced from the global `default-user`:

```go
if *user == "" {
    *user = c.Global.DefaultUser        // job with no User -> "default"
} else if *user == UserContainerDefault { // skipped: the branch above already ran
    *user = ""
}
```

A label-defined job typically has no explicit `user`, so it took the first branch and ended up with the literal username `"default"`. See #716 for the full repro.

## How

Split the two checks (separate `if`s) so the sentinel is translated regardless of whether it comes from the per-job value or the global `default-user` setting:

```go
if *user == "" {
    *user = c.Global.DefaultUser
}
if *user == UserContainerDefault {
    *user = "" // container's default user
}
```

Behavior table (job `User`, global `default-user` → resolved):
- `""`, `nobody` → `nobody` (unchanged)
- `""`, `default` → `""` container default (**fixed**, was `"default"`)
- `""`, `""` → `""` (unchanged)
- `default`, `nobody` → `""` (unchanged)
- `alice`, * → `alice` (unchanged)

## Tests

Extended `TestApplyDefaultUser` with the global-sentinel case. `go build ./...`, `go vet`, and the `cli` suite pass locally (Go 1.26.4).