### PR TITLE
chore: resolve SonarCloud findings (code smells, hotspots)

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -835,7 +835,7 @@ func syncJobMap[J jobConfig](c *Config, current map[string]J, parsed map[string]
 			delete(current, name)
 			continue
 		}
-		if updated := replaceIfChanged(c, name, j, newJob, prep, source); updated {
+		if replaceIfChanged(c, name, j, newJob, prep, source) {
 			current[name] = newJob
 			continue
 		}

--- a/cli/daemon_test.go
+++ b/cli/daemon_test.go
@@ -84,6 +84,7 @@ func TestWaitForServerWithErrChan_DelayedStart(t *testing.T) {
 func TestWaitForServerWithErrChan_CancelContext(t *testing.T) {
 	addr := getUnusedAddr(t)
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	go func() {
 		time.Sleep(100 * time.Millisecond)

--- a/cli/deprecations.go
+++ b/cli/deprecations.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+const deprecationRemovalVersion = "v1.0.0"
+
 // Names of currently deprecated options. Exported so callers (e.g. doctor
 // reports, label allowlists) can reference the canonical name without
 // duplicating string literals.
@@ -72,7 +74,7 @@ var Deprecations = []Deprecation{
 	{
 		Option:         DeprecatedSlackWebhook,
 		Replacement:    "[webhook \"name\"] sections with preset=slack",
-		RemovalVersion: "v1.0.0",
+		RemovalVersion: deprecationRemovalVersion,
 		Message: `Please migrate to the new webhook notification system:
   [webhook "slack"]
   preset = slack
@@ -119,7 +121,7 @@ See documentation: https://github.com/netresearch/ofelia#webhook-notifications`,
 	{
 		Option:         DeprecatedPollInterval,
 		Replacement:    "config-poll-interval and docker-poll-interval",
-		RemovalVersion: "v1.0.0",
+		RemovalVersion: deprecationRemovalVersion,
 		Message:        "Use 'config-poll-interval' for INI file watching and 'docker-poll-interval' for container polling fallback.",
 		KeyName:        deprecatedPollIntervalKey, // Normalized key for presence-based detection
 		CheckFunc: func(cfg *Config) bool {
@@ -146,7 +148,7 @@ See documentation: https://github.com/netresearch/ofelia#webhook-notifications`,
 	{
 		Option:         DeprecatedNoPoll,
 		Replacement:    "docker-poll-interval=0",
-		RemovalVersion: "v1.0.0",
+		RemovalVersion: deprecationRemovalVersion,
 		Message:        "Use 'docker-poll-interval=0' to disable container polling.",
 		KeyName:        deprecatedNoPollKey, // Normalized key for presence-based detection
 		CheckFunc: func(cfg *Config) bool {

--- a/cli/docker-labels.go
+++ b/cli/docker-labels.go
@@ -267,7 +267,7 @@ func sortContainers(containers []DockerContainerInfo) []DockerContainerInfo {
 	sortedContainers := make([]DockerContainerInfo, len(containers))
 	copy(sortedContainers, containers)
 
-	slices.SortStableFunc(sortedContainers, func(left DockerContainerInfo, right DockerContainerInfo) int {
+	slices.SortStableFunc(sortedContainers, func(left, right DockerContainerInfo) int {
 		if left.State.Running != right.State.Running {
 			if left.State.Running {
 				return -1

--- a/cli/docker_startup_retry_test.go
+++ b/cli/docker_startup_retry_test.go
@@ -107,6 +107,7 @@ func TestPingWithRetry_HonorsContextCancellation(t *testing.T) {
 
 	provider := &flakyPingProvider{pingErr: errors.New("never reachable"), failUntilNth: 999}
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go func() {
 		time.Sleep(50 * time.Millisecond)
 		cancel()
@@ -167,6 +168,7 @@ func TestPingWithRetry_CapsBackoffStep(t *testing.T) {
 
 	provider := &flakyPingProvider{pingErr: errors.New("down"), failUntilNth: 999}
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	go func() {
 		time.Sleep(200 * time.Millisecond)
 		cancel()

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -15,6 +15,12 @@ import (
 	"github.com/netresearch/go-cron"
 )
 
+const (
+	msgInvalidScheduleFmt = "Invalid schedule \"%s\": %v"
+	hintScheduleExamples  = "Examples: @daily, @every 1h, 0 2 * * *, */15 * * * *"
+	hintScheduleTest      = "Test schedule: https://crontab.guru"
+)
+
 // doctorDockerCallTimeout bounds each Docker SDK call performed by the doctor
 // command (Ping and per-image HasImageLocally). Without this, a wedged daemon
 // would hang the very diagnostic tool meant to surface this kind of failure.
@@ -435,10 +441,10 @@ func (c *DoctorCommand) checkSchedules(report *DoctorReport) {
 				Category: categoryJobSchedules,
 				Name:     fmt.Sprintf("job-run \"%s\"", name),
 				Status:   statusFail,
-				Message:  fmt.Sprintf("Invalid schedule \"%s\": %v", job.Schedule, err),
+				Message:  fmt.Sprintf(msgInvalidScheduleFmt, job.Schedule, err),
 				Hints: []string{
-					"Examples: @daily, @every 1h, 0 2 * * *, */15 * * * *",
-					"Test schedule: https://crontab.guru",
+					hintScheduleExamples,
+					hintScheduleTest,
 				},
 			})
 		}
@@ -453,10 +459,10 @@ func (c *DoctorCommand) checkSchedules(report *DoctorReport) {
 				Category: categoryJobSchedules,
 				Name:     fmt.Sprintf("job-local \"%s\"", name),
 				Status:   statusFail,
-				Message:  fmt.Sprintf("Invalid schedule \"%s\": %v", job.Schedule, err),
+				Message:  fmt.Sprintf(msgInvalidScheduleFmt, job.Schedule, err),
 				Hints: []string{
-					"Examples: @daily, @every 1h, 0 2 * * *, */15 * * * *",
-					"Test schedule: https://crontab.guru",
+					hintScheduleExamples,
+					hintScheduleTest,
 				},
 			})
 		}
@@ -471,10 +477,10 @@ func (c *DoctorCommand) checkSchedules(report *DoctorReport) {
 				Category: categoryJobSchedules,
 				Name:     fmt.Sprintf("job-exec \"%s\"", name),
 				Status:   statusFail,
-				Message:  fmt.Sprintf("Invalid schedule \"%s\": %v", job.Schedule, err),
+				Message:  fmt.Sprintf(msgInvalidScheduleFmt, job.Schedule, err),
 				Hints: []string{
-					"Examples: @daily, @every 1h, 0 2 * * *, */15 * * * *",
-					"Test schedule: https://crontab.guru",
+					hintScheduleExamples,
+					hintScheduleTest,
 				},
 			})
 		}
@@ -489,10 +495,10 @@ func (c *DoctorCommand) checkSchedules(report *DoctorReport) {
 				Category: categoryJobSchedules,
 				Name:     fmt.Sprintf("job-service-run \"%s\"", name),
 				Status:   statusFail,
-				Message:  fmt.Sprintf("Invalid schedule \"%s\": %v", job.Schedule, err),
+				Message:  fmt.Sprintf(msgInvalidScheduleFmt, job.Schedule, err),
 				Hints: []string{
-					"Examples: @daily, @every 1h, 0 2 * * *, */15 * * * *",
-					"Test schedule: https://crontab.guru",
+					hintScheduleExamples,
+					hintScheduleTest,
 				},
 			})
 		}
@@ -507,10 +513,10 @@ func (c *DoctorCommand) checkSchedules(report *DoctorReport) {
 				Category: categoryJobSchedules,
 				Name:     fmt.Sprintf("job-compose \"%s\"", name),
 				Status:   statusFail,
-				Message:  fmt.Sprintf("Invalid schedule \"%s\": %v", job.Schedule, err),
+				Message:  fmt.Sprintf(msgInvalidScheduleFmt, job.Schedule, err),
 				Hints: []string{
-					"Examples: @daily, @every 1h, 0 2 * * *, */15 * * * *",
-					"Test schedule: https://crontab.guru",
+					hintScheduleExamples,
+					hintScheduleTest,
 				},
 			})
 		}

--- a/config/sanitizer.go
+++ b/config/sanitizer.go
@@ -92,7 +92,7 @@ func (s *Sanitizer) ValidateCommand(command string) error {
 }
 
 // ValidatePath validates file paths to prevent traversal attacks
-func (s *Sanitizer) ValidatePath(path string, allowedBasePath string) error {
+func (s *Sanitizer) ValidatePath(path, allowedBasePath string) error {
 	// Check for path traversal attempts
 	if s.pathTraversalPattern.MatchString(path) {
 		return fmt.Errorf("path contains directory traversal attempt")

--- a/config/validator.go
+++ b/config/validator.go
@@ -70,7 +70,7 @@ func (v *Validator) Errors() ValidationErrors {
 }
 
 // ValidateRequired validates that a field is not empty
-func (v *Validator) ValidateRequired(field string, value string) {
+func (v *Validator) ValidateRequired(field, value string) {
 	if strings.TrimSpace(value) == "" {
 		v.AddError(field, value, "is required")
 	}
@@ -105,7 +105,7 @@ func (v *Validator) ValidatePositive(field string, value int) {
 }
 
 // ValidateURL validates that a string is a valid URL
-func (v *Validator) ValidateURL(field string, value string) {
+func (v *Validator) ValidateURL(field, value string) {
 	if value == "" {
 		return
 	}
@@ -117,7 +117,7 @@ func (v *Validator) ValidateURL(field string, value string) {
 }
 
 // ValidateEmail validates that a string is a valid email
-func (v *Validator) ValidateEmail(field string, value string) {
+func (v *Validator) ValidateEmail(field, value string) {
 	if value == "" {
 		return
 	}
@@ -131,7 +131,7 @@ func (v *Validator) ValidateEmail(field string, value string) {
 // ValidateCronExpression validates a cron expression using go-cron's parser.
 // This handles all formats: descriptors (@daily), @every intervals, standard
 // cron expressions with optional seconds, month/day names, and wraparound ranges.
-func (v *Validator) ValidateCronExpression(field string, value string) {
+func (v *Validator) ValidateCronExpression(field, value string) {
 	if value == "" {
 		return
 	}
@@ -162,7 +162,7 @@ func (v *Validator) ValidateEnum(field string, value string, allowed []string) {
 }
 
 // ValidatePath validates that a path exists or can be created
-func (v *Validator) ValidatePath(field string, value string) {
+func (v *Validator) ValidatePath(field, value string) {
 	if value == "" {
 		return
 	}

--- a/core/adapters/docker/convert_nil_test.go
+++ b/core/adapters/docker/convert_nil_test.go
@@ -10,7 +10,6 @@ import (
 
 	containertypes "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
-	mounttypes "github.com/docker/docker/api/types/mount"
 	networktypes "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
 	"github.com/stretchr/testify/assert"
@@ -386,8 +385,8 @@ func TestConvertToMount_ValidInput(t *testing.T) {
 	}
 
 	got := convertToMount(in)
-	if got.Type != mounttypes.TypeBind {
-		t.Errorf("Type = %q, want %q", got.Type, mounttypes.TypeBind)
+	if got.Type != mount.TypeBind {
+		t.Errorf("Type = %q, want %q", got.Type, mount.TypeBind)
 	}
 	if got.Source != "/host/path" {
 		t.Errorf("Source = %q, want %q", got.Source, "/host/path")

--- a/core/docker_sdk_provider_test.go
+++ b/core/docker_sdk_provider_test.go
@@ -684,8 +684,8 @@ func (m *testMetrics) RecordContainerWaitDuration(seconds float64)              
 func (m *testMetrics) RecordJobStart(jobName string)                            {}
 func (m *testMetrics) RecordJobComplete(jobName string, _ float64, _ bool)      {}
 func (m *testMetrics) RecordJobScheduled(jobName string)                        {}
-func (m *testMetrics) RecordWorkflowComplete(rootJobName string, _ string)      {}
-func (m *testMetrics) RecordWorkflowJobResult(jobName string, _ string)         {}
+func (m *testMetrics) RecordWorkflowComplete(rootJobName, _ string)             {}
+func (m *testMetrics) RecordWorkflowJobResult(jobName, _ string)                {}
 
 func TestSDKDockerProviderWithLogger(t *testing.T) {
 	mockClient := mock.NewDockerClient()

--- a/core/performance_metrics.go
+++ b/core/performance_metrics.go
@@ -21,7 +21,7 @@ type PerformanceRecorder interface {
 
 	// Job operations (extended beyond MetricsRecorder)
 	RecordJobExecution(jobName string, duration time.Duration, success bool)
-	RecordJobSkipped(jobName string, reason string)
+	RecordJobSkipped(jobName, reason string)
 
 	// System metrics
 	RecordConcurrentJobs(count int64)
@@ -273,12 +273,12 @@ func (pm *PerformanceMetrics) RecordJobScheduled(jobName string) {
 
 // RecordWorkflowComplete records a workflow completion event.
 // No-op: workflow metrics are tracked via the Prometheus Collector, not PerformanceMetrics.
-func (pm *PerformanceMetrics) RecordWorkflowComplete(rootJobName string, status string) {
+func (pm *PerformanceMetrics) RecordWorkflowComplete(rootJobName, status string) {
 }
 
 // RecordWorkflowJobResult records an individual job result within a workflow.
 // No-op: workflow metrics are tracked via the Prometheus Collector, not PerformanceMetrics.
-func (pm *PerformanceMetrics) RecordWorkflowJobResult(jobName string, result string) {
+func (pm *PerformanceMetrics) RecordWorkflowJobResult(jobName, result string) {
 }
 
 // RecordJobStart records a job start (from go-cron ObservabilityHooks)
@@ -299,7 +299,7 @@ func (pm *PerformanceMetrics) RecordJobComplete(jobName string, durationSeconds 
 }
 
 // RecordJobSkipped records when a job is skipped
-func (pm *PerformanceMetrics) RecordJobSkipped(jobName string, reason string) {
+func (pm *PerformanceMetrics) RecordJobSkipped(jobName, reason string) {
 	atomic.AddInt64(&pm.totalJobsSkipped, 1)
 
 	pm.customMutex.Lock()

--- a/core/performance_metrics.go
+++ b/core/performance_metrics.go
@@ -274,11 +274,13 @@ func (pm *PerformanceMetrics) RecordJobScheduled(jobName string) {
 // RecordWorkflowComplete records a workflow completion event.
 // No-op: workflow metrics are tracked via the Prometheus Collector, not PerformanceMetrics.
 func (pm *PerformanceMetrics) RecordWorkflowComplete(rootJobName, status string) {
+	// Intentional no-op; see method doc above.
 }
 
 // RecordWorkflowJobResult records an individual job result within a workflow.
 // No-op: workflow metrics are tracked via the Prometheus Collector, not PerformanceMetrics.
 func (pm *PerformanceMetrics) RecordWorkflowJobResult(jobName, result string) {
+	// Intentional no-op; see method doc above.
 }
 
 // RecordJobStart records a job start (from go-cron ObservabilityHooks)

--- a/core/resilience.go
+++ b/core/resilience.go
@@ -12,6 +12,8 @@ import (
 	"time"
 )
 
+const errFmtWrapName = "%w: %s"
+
 // RetryPolicy defines retry behavior
 type RetryPolicy struct {
 	MaxAttempts     int
@@ -174,18 +176,18 @@ func (cb *CircuitBreaker) beforeCall() error {
 			cb.transitionToHalfOpen()
 			return nil
 		}
-		return fmt.Errorf("%w: %s", ErrCircuitBreakerOpen, cb.name)
+		return fmt.Errorf(errFmtWrapName, ErrCircuitBreakerOpen, cb.name)
 
 	case StateHalfOpen:
 		// Allow limited calls in half-open state
 		if cb.halfOpenCalls >= cb.halfOpenMaxCalls {
-			return fmt.Errorf("%w: %s", ErrCircuitBreakerHalfOpen, cb.name)
+			return fmt.Errorf(errFmtWrapName, ErrCircuitBreakerHalfOpen, cb.name)
 		}
 		cb.halfOpenCalls++
 		return nil
 
 	default:
-		return fmt.Errorf("%w: %s", ErrCircuitBreakerUnknown, cb.name)
+		return fmt.Errorf(errFmtWrapName, ErrCircuitBreakerUnknown, cb.name)
 	}
 }
 

--- a/core/resilience_test.go
+++ b/core/resilience_test.go
@@ -126,6 +126,7 @@ func TestRetryNonRetryableError(t *testing.T) {
 func TestRetryContextCanceled(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	policy := DefaultRetryPolicy()
 	policy.InitialDelay = 100 * time.Millisecond
 
@@ -424,6 +425,7 @@ func TestRateLimiterWaitContextCanceled(t *testing.T) {
 	t.Parallel()
 	rl := NewRateLimiter(0.1, 1)
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Use the token
 	rl.Allow()

--- a/core/retry.go
+++ b/core/retry.go
@@ -48,8 +48,8 @@ type MetricsRecorder interface {
 	RecordJobComplete(jobName string, durationSeconds float64, panicked bool)
 	RecordJobScheduled(jobName string)
 	// Workflow completion metrics (from go-cron ObservabilityHooks)
-	RecordWorkflowComplete(rootJobName string, status string)
-	RecordWorkflowJobResult(jobName string, result string)
+	RecordWorkflowComplete(rootJobName, status string)
+	RecordWorkflowJobResult(jobName, result string)
 }
 
 // RetryExecutor wraps job execution with retry logic

--- a/core/retry_mutation_test.go
+++ b/core/retry_mutation_test.go
@@ -46,8 +46,8 @@ func (m *captureMetrics) RecordDockerError(operation string)                  {}
 func (m *captureMetrics) RecordJobStart(jobName string)                       {}
 func (m *captureMetrics) RecordJobComplete(jobName string, _ float64, _ bool) {}
 func (m *captureMetrics) RecordJobScheduled(jobName string)                   {}
-func (m *captureMetrics) RecordWorkflowComplete(_ string, _ string)           {}
-func (m *captureMetrics) RecordWorkflowJobResult(_ string, _ string)          {}
+func (m *captureMetrics) RecordWorkflowComplete(_, _ string)                  {}
+func (m *captureMetrics) RecordWorkflowJobResult(_, _ string)                 {}
 
 // retrySlogHandler captures slog records for assertion.
 type retrySlogHandler struct {

--- a/core/scheduler.go
+++ b/core/scheduler.go
@@ -14,6 +14,8 @@ import (
 	"github.com/netresearch/go-cron"
 )
 
+const errFmtWrapQuoted = "%w: %q"
+
 var (
 	ErrEmptyScheduler = errors.New("unable to start an empty scheduler")
 	ErrEmptySchedule  = errors.New("unable to add a job with an empty schedule")
@@ -624,7 +626,7 @@ func (s *Scheduler) UpdateJob(name string, newSchedule string, newJob Job) error
 	_, disabled := s.disabledNames[name]
 	if oldJob == nil || disabled {
 		s.mu.RUnlock()
-		return fmt.Errorf("%w: %q", ErrJobNotFound, name)
+		return fmt.Errorf(errFmtWrapQuoted, ErrJobNotFound, name)
 	}
 	s.mu.RUnlock()
 
@@ -664,7 +666,7 @@ func (s *Scheduler) DisableJob(name string) error {
 
 	j, _ := getJob(s.Jobs, name)
 	if j == nil {
-		return fmt.Errorf("%w: %q", ErrJobNotFound, name)
+		return fmt.Errorf(errFmtWrapQuoted, ErrJobNotFound, name)
 	}
 	if _, already := s.disabledNames[name]; already {
 		return nil // already disabled
@@ -693,12 +695,12 @@ func (s *Scheduler) EnableJob(name string) error {
 		if _, active := s.jobsByName[name]; active {
 			return nil
 		}
-		return fmt.Errorf("%w: %q", ErrJobNotFound, name)
+		return fmt.Errorf(errFmtWrapQuoted, ErrJobNotFound, name)
 	}
 
 	j, _ := getJob(s.Jobs, name)
 	if j == nil {
-		return fmt.Errorf("%w: %q", ErrJobNotFound, name)
+		return fmt.Errorf(errFmtWrapQuoted, ErrJobNotFound, name)
 	}
 
 	if err := s.cron.ResumeEntryByName(name); err != nil {

--- a/core/scheduler_mutation_test.go
+++ b/core/scheduler_mutation_test.go
@@ -657,9 +657,9 @@ func (m *mockMetricsRecorder) RecordJobStart(_ string)                { m.jobSta
 func (m *mockMetricsRecorder) RecordJobComplete(_ string, _ float64, _ bool) {
 	m.jobCompleted.Add(1)
 }
-func (m *mockMetricsRecorder) RecordJobScheduled(_ string)                { m.jobScheduled.Add(1) }
-func (m *mockMetricsRecorder) RecordWorkflowComplete(_ string, _ string)  {}
-func (m *mockMetricsRecorder) RecordWorkflowJobResult(_ string, _ string) {}
+func (m *mockMetricsRecorder) RecordJobScheduled(_ string)         { m.jobScheduled.Add(1) }
+func (m *mockMetricsRecorder) RecordWorkflowComplete(_, _ string)  {}
+func (m *mockMetricsRecorder) RecordWorkflowJobResult(_, _ string) {}
 
 // --- Test StopWithTimeout returns error on timeout ---
 func TestStopWithTimeout_Timeout(t *testing.T) {

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -217,13 +217,13 @@ func (mc *Collector) RecordJobScheduled(jobName string) {
 
 // RecordWorkflowComplete records a workflow completion (from go-cron ObservabilityHooks).
 // TODO: add label dimensions (root_job_name, status) once Collector supports labeled metrics.
-func (mc *Collector) RecordWorkflowComplete(rootJobName string, status string) {
+func (mc *Collector) RecordWorkflowComplete(rootJobName, status string) {
 	mc.IncrementCounter("ofelia_workflow_completions_total", 1)
 }
 
 // RecordWorkflowJobResult records an individual job result within a workflow (from go-cron ObservabilityHooks).
 // TODO: add label dimensions (job_name, result) once Collector supports labeled metrics.
-func (mc *Collector) RecordWorkflowJobResult(jobName string, result string) {
+func (mc *Collector) RecordWorkflowJobResult(jobName, result string) {
 	mc.IncrementCounter("ofelia_workflow_job_results_total", 1)
 }
 

--- a/middlewares/preset_cache.go
+++ b/middlewares/preset_cache.go
@@ -15,6 +15,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const metaFileSuffix = ".meta.yaml"
+
 const yamlExt = ".yaml"
 
 // PresetCache provides caching for remote presets
@@ -158,7 +160,7 @@ func (c *PresetCache) Put(url string, preset *Preset) error {
 
 // getFromDisk retrieves a preset from disk cache
 func (c *PresetCache) getFromDisk(key, url string) (*Preset, error) {
-	metaPath := filepath.Join(c.cacheDir, key+".meta.yaml")
+	metaPath := filepath.Join(c.cacheDir, key+metaFileSuffix)
 	presetPath := filepath.Join(c.cacheDir, key+".yaml")
 
 	// Read metadata
@@ -201,7 +203,7 @@ func (c *PresetCache) getFromDisk(key, url string) (*Preset, error) {
 
 // putToDisk stores a preset on disk
 func (c *PresetCache) putToDisk(key, url string, preset *Preset, expiresAt time.Time) error {
-	metaPath := filepath.Join(c.cacheDir, key+".meta.yaml")
+	metaPath := filepath.Join(c.cacheDir, key+metaFileSuffix)
 	presetPath := filepath.Join(c.cacheDir, key+".yaml")
 
 	// Write metadata
@@ -244,7 +246,7 @@ func (c *PresetCache) Invalidate(url string) {
 	c.mu.Unlock()
 
 	// Remove from disk
-	metaPath := filepath.Join(c.cacheDir, key+".meta.yaml")
+	metaPath := filepath.Join(c.cacheDir, key+metaFileSuffix)
 	presetPath := filepath.Join(c.cacheDir, key+".yaml")
 	_ = os.Remove(metaPath)
 	_ = os.Remove(presetPath)
@@ -320,7 +322,7 @@ func (c *PresetCache) Cleanup() error {
 		if now.After(meta.ExpiresAt) {
 			// Remove expired files
 			_ = os.Remove(metaPath)
-			presetPath := metaPath[:len(metaPath)-len(".meta.yaml")] + ".yaml"
+			presetPath := metaPath[:len(metaPath)-len(metaFileSuffix)] + ".yaml"
 			_ = os.Remove(presetPath)
 		}
 	}
@@ -330,7 +332,7 @@ func (c *PresetCache) Cleanup() error {
 
 // isMetaFile checks if a filename is a metadata file
 func isMetaFile(name string) bool {
-	return len(name) > 10 && name[len(name)-10:] == ".meta.yaml"
+	return len(name) > 10 && name[len(name)-10:] == metaFileSuffix
 }
 
 // Stats returns cache statistics

--- a/middlewares/preset_cache.go
+++ b/middlewares/preset_cache.go
@@ -332,7 +332,7 @@ func (c *PresetCache) Cleanup() error {
 
 // isMetaFile checks if a filename is a metadata file
 func isMetaFile(name string) bool {
-	return len(name) > 10 && name[len(name)-10:] == metaFileSuffix
+	return len(name) > len(metaFileSuffix) && name[len(name)-len(metaFileSuffix):] == metaFileSuffix
 }
 
 // Stats returns cache statistics

--- a/middlewares/webhook_mutation_test.go
+++ b/middlewares/webhook_mutation_test.go
@@ -700,6 +700,7 @@ func runCtxCancelScenario(t *testing.T, cfg *WebhookConfig) time.Duration {
 	require.NoError(t, err)
 
 	cancelCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	ctx := core.NewContextWithContext(cancelCtx, sh, job, e)
 	ctx.Start()
 	ctx.Stop(nil)

--- a/scripts/backfill-release-labels.sh
+++ b/scripts/backfill-release-labels.sh
@@ -9,6 +9,7 @@
 set -euo pipefail
 
 DRY_RUN="${1:-}"
+readonly DRY_RUN_FLAG="--dry-run"
 REPO="netresearch/ofelia"
 
 # Colors for output
@@ -18,10 +19,10 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_dry() { echo -e "${YELLOW}[DRY-RUN]${NC} $1"; }
+log_info() { local msg="$1"; echo -e "${BLUE}[INFO]${NC} ${msg}"; }
+log_success() { local msg="$1"; echo -e "${GREEN}[OK]${NC} ${msg}"; }
+log_warn() { local msg="$1"; echo -e "${YELLOW}[WARN]${NC} ${msg}"; }
+log_dry() { local msg="$1"; echo -e "${YELLOW}[DRY-RUN]${NC} ${msg}"; }
 
 # Comment templates
 pr_comment() {
@@ -92,7 +93,7 @@ process_pr() {
         return 0
     fi
 
-    if [[ "$DRY_RUN" == "--dry-run" ]]; then
+    if [[ "$DRY_RUN" == "$DRY_RUN_FLAG" ]]; then
         log_dry "Would label PR #${pr} with '${label}'"
         log_dry "Would comment on PR #${pr}"
     else
@@ -124,7 +125,7 @@ process_issue() {
         return 0
     fi
 
-    if [[ "$DRY_RUN" == "--dry-run" ]]; then
+    if [[ "$DRY_RUN" == "$DRY_RUN_FLAG" ]]; then
         log_dry "Would label Issue #${issue} with '${label}'"
         log_dry "Would comment on Issue #${issue}"
     else
@@ -172,7 +173,7 @@ process_release() {
     echo -e "${GREEN}═══════════════════════════════════════════════════════════════${NC}"
 
     # Ensure label exists
-    if [[ "$DRY_RUN" != "--dry-run" ]]; then
+    if [[ "$DRY_RUN" != "$DRY_RUN_FLAG" ]]; then
         gh label create "released:${tag}" --repo "$REPO" --color "0e8a16" \
             --description "Included in ${tag} release" 2>/dev/null || true
     fi
@@ -216,7 +217,7 @@ process_release() {
 
 # Main
 main() {
-    if [[ "$DRY_RUN" == "--dry-run" ]]; then
+    if [[ "$DRY_RUN" == "$DRY_RUN_FLAG" ]]; then
         echo -e "${YELLOW}╔═══════════════════════════════════════════════════════════════╗${NC}"
         echo -e "${YELLOW}║                      DRY RUN MODE                             ║${NC}"
         echo -e "${YELLOW}║           No changes will be made to GitHub                   ║${NC}"

--- a/scripts/update-release-notes.sh
+++ b/scripts/update-release-notes.sh
@@ -18,10 +18,10 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_dry() { echo -e "${YELLOW}[DRY-RUN]${NC} $1"; }
+log_info() { local msg="$1"; echo -e "${BLUE}[INFO]${NC} ${msg}"; }
+log_success() { local msg="$1"; echo -e "${GREEN}[OK]${NC} ${msg}"; }
+log_warn() { local msg="$1"; echo -e "${YELLOW}[WARN]${NC} ${msg}"; }
+log_dry() { local msg="$1"; echo -e "${YELLOW}[DRY-RUN]${NC} ${msg}"; }
 
 # Update release notes for a single release
 update_release_notes() {

--- a/static/ui/index.html
+++ b/static/ui/index.html
@@ -10,12 +10,13 @@
     /* Apply saved preferences before first paint to avoid flash */
     (function() {
       var t = localStorage.getItem('theme');
-      if (t && t !== 'auto') document.documentElement.setAttribute('data-theme', t);
+      if (t && t !== 'auto') document.documentElement.dataset.theme = t;
       var d = localStorage.getItem('density') || 'auto';
-      var coarse = window.matchMedia('(pointer: coarse)').matches;
-      var narrow = window.matchMedia('(max-width: 600px)').matches;
-      var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-      var eff = d === 'auto' ? ((coarse || narrow || reduce) ? 'comfortable' : 'compact') : d;
+      var coarse = globalThis.matchMedia('(pointer: coarse)').matches;
+      var narrow = globalThis.matchMedia('(max-width: 600px)').matches;
+      var reduce = globalThis.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      var eff = d;
+      if (d === 'auto') eff = (coarse || narrow || reduce) ? 'comfortable' : 'compact';
       if (eff === 'compact') document.body ? document.body.classList.add('compact') : document.documentElement.classList.add('compact-early');
     })();
   </script>
@@ -410,9 +411,9 @@
       if (dateStr === null || dateStr === undefined) return '';
       const str = String(dateStr);
       const dt = new Date(str);
-      if (isNaN(dt)) return '';
-      if (pref === 'utc') return dt.toISOString().replace('T',' ').replace('Z','');
-      if (pref === 'server') return str.replace('T',' ').replace('Z','');
+      if (Number.isNaN(dt.getTime())) return '';
+      if (pref === 'utc') return dt.toISOString().replaceAll('T',' ').replaceAll('Z','');
+      if (pref === 'server') return str.replaceAll('T',' ').replaceAll('Z','');
       return dt.toLocaleString();
     }
 
@@ -452,9 +453,9 @@
       currentTheme = t;
       localStorage.setItem('theme', t);
       if (t === 'auto') {
-        document.documentElement.removeAttribute('data-theme');
+        delete document.documentElement.dataset.theme;
       } else {
-        document.documentElement.setAttribute('data-theme', t);
+        document.documentElement.dataset.theme = t;
       }
       themeBtn.textContent = themeText[t];
       themeBtn.title = 'Theme: ' + themeText[t];
@@ -472,15 +473,16 @@
 
     /* Detect if device prefers comfortable: touch screen, narrow viewport, or prefers-reduced-motion */
     function systemWantsComfortable() {
-      return window.matchMedia('(pointer: coarse)').matches ||
-             window.matchMedia('(max-width: 600px)').matches ||
-             window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      return globalThis.matchMedia('(pointer: coarse)').matches ||
+             globalThis.matchMedia('(max-width: 600px)').matches ||
+             globalThis.matchMedia('(prefers-reduced-motion: reduce)').matches;
     }
 
     function applyDensity(d) {
       currentDensity = d;
       localStorage.setItem('density', d);
-      const effective = d === 'auto' ? (systemWantsComfortable() ? 'comfortable' : 'compact') : d;
+      let effective = d;
+      if (d === 'auto') effective = systemWantsComfortable() ? 'comfortable' : 'compact';
       document.body.classList.toggle('compact', effective === 'compact');
       document.documentElement.classList.remove('compact-early');
       densityBtn.textContent = densityText[d];
@@ -491,7 +493,7 @@
     });
     applyDensity(currentDensity);
     /* Re-evaluate auto density on resize */
-    window.matchMedia('(max-width: 600px)').addEventListener('change', () => {
+    globalThis.matchMedia('(max-width: 600px)').addEventListener('change', () => {
       if (currentDensity === 'auto') applyDensity('auto');
     });
 
@@ -589,9 +591,9 @@
         const stdout = escapeHtml(stripControlChars(e.stdout));
         const stderr = escapeHtml(stripControlChars(e.stderr));
         const hasOut = stdout || stderr;
+        const stderrBlock = stderr ? `<pre style="color:var(--pico-del-color)">${stderr}</pre>` : '';
         const output = hasOut ?
-          `<details><summary>view</summary><pre>${stdout}</pre>` +
-          (stderr ? `<pre style="color:var(--pico-del-color)">${stderr}</pre>` : '') + `</details>` : '';
+          `<details><summary>view</summary><pre>${stdout}</pre>` + stderrBlock + `</details>` : '';
         row.innerHTML = `<td>${dot}</td><td>${formatTime(e.date)}</td><td>${formatDuration(e.duration)}</td>` +
           `<td class="wrap">${err}</td><td>${output}</td>`;
         tbody.appendChild(row);

--- a/static/ui/index.html
+++ b/static/ui/index.html
@@ -591,9 +591,10 @@
         const stdout = escapeHtml(stripControlChars(e.stdout));
         const stderr = escapeHtml(stripControlChars(e.stderr));
         const hasOut = stdout || stderr;
+        const stdoutBlock = stdout ? `<pre>${stdout}</pre>` : '';
         const stderrBlock = stderr ? `<pre style="color:var(--pico-del-color)">${stderr}</pre>` : '';
         const output = hasOut ?
-          `<details><summary>view</summary><pre>${stdout}</pre>` + stderrBlock + `</details>` : '';
+          `<details><summary>view</summary>` + stdoutBlock + stderrBlock + `</details>` : '';
         row.innerHTML = `<td>${dot}</td><td>${formatTime(e.date)}</td><td>${formatDuration(e.duration)}</td>` +
           `<td class="wrap">${err}</td><td>${output}</td>`;
         tbody.appendChild(row);

--- a/web/server.go
+++ b/web/server.go
@@ -69,6 +69,21 @@ const (
 	originLabel = "label" // ofelia.job-run.<name>.* Docker labels
 )
 
+// HTTP route paths, header names, and error messages reused across handlers.
+const (
+	pathAPILogin      = "/api/login"
+	pathAPIAuthStatus = "/api/auth/status"
+	pathAPICSRFToken  = "/api/csrf-token"
+	pathAPIJobsPrefix = "/api/jobs/"
+
+	headerContentType = "Content-Type"
+	contentTypeJSON   = "application/json"
+
+	msgMethodNotAllowed   = "method not allowed"
+	msgInvalidRequestBody = "invalid request body"
+	msgJobNotFound        = "job not found"
+)
+
 // isConfigOwned reports whether `origin` denotes a job whose
 // authoritative source is the INI file or Docker labels. Such jobs
 // are NOT deletable via the API and NOT persisted in the state file
@@ -153,10 +168,10 @@ func NewServerWithAuth(addr string, s *core.Scheduler, cfg any, provider core.Do
 
 	if server.authConfig != nil && server.authConfig.Enabled {
 		loginHandler := NewSecureLoginHandler(server.authConfig, server.tokenManager, server.loginLimiter, server.trustedProxies...)
-		mux.Handle("/api/login", loginHandler)
+		mux.Handle(pathAPILogin, loginHandler)
 		mux.HandleFunc("/api/logout", server.logoutHandler)
-		mux.HandleFunc("/api/auth/status", server.authStatusHandler)
-		mux.HandleFunc("/api/csrf-token", server.csrfTokenHandler)
+		mux.HandleFunc(pathAPIAuthStatus, server.authStatusHandler)
+		mux.HandleFunc(pathAPICSRFToken, server.csrfTokenHandler)
 	}
 
 	mux.HandleFunc("/api/jobs/removed", server.removedJobsHandler)
@@ -167,7 +182,7 @@ func NewServerWithAuth(addr string, s *core.Scheduler, cfg any, provider core.Do
 	mux.HandleFunc("/api/jobs/create", server.createJobHandler)
 	mux.HandleFunc("/api/jobs/update", server.updateJobHandler)
 	mux.HandleFunc("/api/jobs/delete", server.deleteJobHandler)
-	mux.HandleFunc("/api/jobs/", server.historyHandler)
+	mux.HandleFunc(pathAPIJobsPrefix, server.historyHandler)
 	mux.HandleFunc("/api/jobs", server.jobsHandler)
 	mux.HandleFunc("/api/config", server.configHandler)
 
@@ -220,10 +235,10 @@ func (s *Server) RegisterHealthEndpoints(hc *HealthChecker) {
 
 	if s.authConfig != nil && s.authConfig.Enabled {
 		loginHandler := NewSecureLoginHandler(s.authConfig, s.tokenManager, s.loginLimiter, s.trustedProxies...)
-		mux.Handle("/api/login", loginHandler)
+		mux.Handle(pathAPILogin, loginHandler)
 		mux.HandleFunc("/api/logout", s.logoutHandler)
-		mux.HandleFunc("/api/auth/status", s.authStatusHandler)
-		mux.HandleFunc("/api/csrf-token", s.csrfTokenHandler)
+		mux.HandleFunc(pathAPIAuthStatus, s.authStatusHandler)
+		mux.HandleFunc(pathAPICSRFToken, s.csrfTokenHandler)
 	}
 
 	mux.HandleFunc("/api/jobs/removed", s.removedJobsHandler)
@@ -234,7 +249,7 @@ func (s *Server) RegisterHealthEndpoints(hc *HealthChecker) {
 	mux.HandleFunc("/api/jobs/create", s.createJobHandler)
 	mux.HandleFunc("/api/jobs/update", s.updateJobHandler)
 	mux.HandleFunc("/api/jobs/delete", s.deleteJobHandler)
-	mux.HandleFunc("/api/jobs/", s.historyHandler)
+	mux.HandleFunc(pathAPIJobsPrefix, s.historyHandler)
 	mux.HandleFunc("/api/jobs", s.jobsHandler)
 	mux.HandleFunc("/api/config", s.configHandler)
 
@@ -415,19 +430,19 @@ func (s *Server) buildAPIJobs(list []core.Job) []apiJob {
 
 func (s *Server) jobsHandler(w http.ResponseWriter, _ *http.Request) {
 	jobs := s.buildAPIJobs(s.scheduler.GetActiveJobs())
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(headerContentType, contentTypeJSON)
 	_ = json.NewEncoder(w).Encode(jobs)
 }
 
 func (s *Server) removedJobsHandler(w http.ResponseWriter, _ *http.Request) {
 	jobs := s.buildAPIJobs(s.scheduler.GetRemovedJobs())
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(headerContentType, contentTypeJSON)
 	_ = json.NewEncoder(w).Encode(jobs)
 }
 
 func (s *Server) disabledJobsHandler(w http.ResponseWriter, _ *http.Request) {
 	jobs := s.buildAPIJobs(s.scheduler.GetDisabledJobs())
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(headerContentType, contentTypeJSON)
 	_ = json.NewEncoder(w).Encode(jobs)
 }
 
@@ -462,12 +477,12 @@ func validateJobName(name string) error {
 
 func (s *Server) runJobHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		http.Error(w, msgMethodNotAllowed, http.StatusMethodNotAllowed)
 		return
 	}
 	var req jobRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request body", http.StatusBadRequest)
+		http.Error(w, msgInvalidRequestBody, http.StatusBadRequest)
 		return
 	}
 	if err := validateJobName(req.Name); err != nil {
@@ -476,7 +491,7 @@ func (s *Server) runJobHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := s.scheduler.RunJob(r.Context(), req.Name); err != nil {
 		if errors.Is(err, core.ErrJobNotFound) {
-			http.Error(w, "job not found", http.StatusNotFound)
+			http.Error(w, msgJobNotFound, http.StatusNotFound)
 		} else {
 			s.scheduler.Logger.Error("run job failed", "job", req.Name, "error", err)
 			http.Error(w, "failed to run job", http.StatusInternalServerError)
@@ -504,12 +519,12 @@ func (s *Server) toggleJobHandler(
 	afterPersist func(string) error,
 ) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		http.Error(w, msgMethodNotAllowed, http.StatusMethodNotAllowed)
 		return
 	}
 	var req jobRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request body", http.StatusBadRequest)
+		http.Error(w, msgInvalidRequestBody, http.StatusBadRequest)
 		return
 	}
 	if err := validateJobName(req.Name); err != nil {
@@ -518,7 +533,7 @@ func (s *Server) toggleJobHandler(
 	}
 	if err := toggle(req.Name); err != nil {
 		if errors.Is(err, core.ErrJobNotFound) {
-			http.Error(w, "job not found", http.StatusNotFound)
+			http.Error(w, msgJobNotFound, http.StatusNotFound)
 		} else {
 			s.scheduler.Logger.Error(action+" job failed", "job", req.Name, "error", err)
 			http.Error(w, "failed to "+action+" job", http.StatusInternalServerError)
@@ -595,12 +610,12 @@ func (s *Server) persistJob(name string, req *jobRequest) error {
 
 func (s *Server) createJobHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		http.Error(w, msgMethodNotAllowed, http.StatusMethodNotAllowed)
 		return
 	}
 	var req jobRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request body", http.StatusBadRequest)
+		http.Error(w, msgInvalidRequestBody, http.StatusBadRequest)
 		return
 	}
 	if err := validateJobName(req.Name); err != nil {
@@ -647,12 +662,12 @@ func (s *Server) createJobHandler(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) updateJobHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		http.Error(w, msgMethodNotAllowed, http.StatusMethodNotAllowed)
 		return
 	}
 	var req jobRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request body", http.StatusBadRequest)
+		http.Error(w, msgInvalidRequestBody, http.StatusBadRequest)
 		return
 	}
 	if err := validateJobName(req.Name); err != nil {
@@ -772,12 +787,12 @@ func (s *Server) jobFromRequest(req *jobRequest) (core.Job, error) {
 
 func (s *Server) deleteJobHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		http.Error(w, msgMethodNotAllowed, http.StatusMethodNotAllowed)
 		return
 	}
 	var req jobRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request body", http.StatusBadRequest)
+		http.Error(w, msgInvalidRequestBody, http.StatusBadRequest)
 		return
 	}
 	if err := validateJobName(req.Name); err != nil {
@@ -786,7 +801,7 @@ func (s *Server) deleteJobHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	j := s.scheduler.GetAnyJob(req.Name)
 	if j == nil {
-		http.Error(w, "job not found", http.StatusNotFound)
+		http.Error(w, msgJobNotFound, http.StatusNotFound)
 		return
 	}
 	// #593: only API-mutated jobs can be deleted. INI/Docker-label
@@ -815,7 +830,7 @@ func (s *Server) deleteJobHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) configHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(headerContentType, contentTypeJSON)
 	cfg := stripJobs(s.config)
 	_ = json.NewEncoder(w).Encode(cfg)
 }
@@ -854,7 +869,7 @@ func (s *Server) historyHandler(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	name := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/jobs/"), "/history")
+	name := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, pathAPIJobsPrefix), "/history")
 	target := s.scheduler.GetAnyJob(name)
 	if target == nil {
 		http.NotFound(w, r)
@@ -886,7 +901,7 @@ func (s *Server) historyHandler(w http.ResponseWriter, r *http.Request) {
 			Stderr:   stderr,
 		})
 	}
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(headerContentType, contentTypeJSON)
 	_ = json.NewEncoder(w).Encode(out)
 }
 
@@ -916,7 +931,7 @@ func (s *Server) logoutHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) authStatusHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(headerContentType, contentTypeJSON)
 
 	if s.authConfig == nil || !s.authConfig.Enabled {
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -948,7 +963,7 @@ func (s *Server) authStatusHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) csrfTokenHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set(headerContentType, contentTypeJSON)
 
 	if s.tokenManager == nil {
 		http.Error(w, "Auth not enabled", http.StatusNotFound)
@@ -968,7 +983,7 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
 
-		if path == "/api/login" || path == "/api/csrf-token" || path == "/api/auth/status" ||
+		if path == pathAPILogin || path == pathAPICSRFToken || path == pathAPIAuthStatus ||
 			path == "/health" || path == "/healthz" || path == "/ready" || path == "/live" {
 			next.ServeHTTP(w, r)
 			return

--- a/web/server.go
+++ b/web/server.go
@@ -73,7 +73,7 @@ const (
 const (
 	pathAPILogin      = "/api/login"
 	pathAPIAuthStatus = "/api/auth/status"
-	pathAPICSRFToken  = "/api/csrf-token"
+	pathAPICSRFToken  = "/api/csrf-token" // #nosec G101 -- public API route path, not a credential
 	pathAPIJobsPrefix = "/api/jobs/"
 
 	headerContentType = "Content-Type"


### PR DESCRIPTION
Resolves [SonarCloud](https://sonarcloud.io/project/overview?id=netresearch_ofelia) code smells and security hotspots. Triaged into **code fixes** (this PR) and **dispositions** (marked directly in SonarCloud with rationale comments).

## Code fixes in this PR

| Commit | Rule(s) | Count | Change |
|---|---|---|---|
| group consecutive same-type parameters | `godre:S8209` | 21 | `(a string, b string)` → `(a, b string)` |
| defer context cancel to prevent leaks | `godre:S8188` | 6 | `defer cancel()` after `context.WithCancel` |
| minor lint cleanups | `godre:S8213/S8193`, `go:S1186` | 4 | dup import / inline var / no-op comments |
| extract duplicated string literals | `go:S1192` | 16 | routes, headers, messages → constants |
| modernize inline JavaScript | `javascript:S7764/S7781/S7761/S3358/S7773` | 19 | globalThis, replaceAll, dataset, ternary, Number.isNaN |
| tidy release helper scripts | `shelldre:S7679/S1192` | 9 | local vars, `--dry-run` constant |
| annotate CSRF route constant | gosec G101 | 1 | `#nosec` for a route path falsely flagged as a credential |

Notable correctness care:
- `isNaN(dt)` (where `dt` is a `Date`) became `Number.isNaN(dt.getTime())` — a naive `Number.isNaN(dt)` would always be `false`.
- string-arg `.replace()` → `.replaceAll()` only where the target occurs once (ISO/date strings), preserving behavior.

## Dispositions (marked in SonarCloud, no code change)

- **Hotspots (13/14 reviewed=SAFE):** 12× first-party `netresearch/.github` reusable workflows pinned to `@main` (intentional centralization, not third-party actions); `net/http/pprof` already carries `#nosec G108`. The Dockerfile-root hotspot is left open and tracked in #721.
- **False positive:** 7× `go:S1135` matching the literal word in stdlib `context.TODO()`; 1× `Web:S6807` `aria-checked` on a native `<input type=checkbox>` (native checked state is exposed to AT).
- **Accepted (by-design):** `docker:S8431` tag+digest (Renovate-managed); 3 genuine TODOs (gated future work, prometheus ones tracked in #722); `go:S108` idiomatic channel-drain loops; `godre:S8242` contained-context (already `//nolint:containedctx`); `godre:S8196` descriptive unexported interface names.

## Cognitive complexity (`go:S3776`, 108 total)
- **73 in test files** → excluded from `go:S3776` via a project-level analysis setting (`**/*_test.go`); the metric is noise on large table-driven tests.
- **4 worst production offenders refactored** in #724 (stacked on this PR).
- Remaining ~31 production functions (complexity 16–27) — follow-up.

## Follow-ups filed
- #721 — harden Docker runtime image to run as non-root (needs Docker-socket group handling)
- #722 — add label dimensions to workflow metrics once Collector supports labeled metrics

## Still open (need direction)
- `go:S107` (2) — 8- and 10-parameter functions; genuine smells but invasive param-struct refactors.

## Verification
- `go build ./...`, `go vet ./...`, `golangci-lint run` — clean
- `go test ./... -short` — all 14 packages pass
- `gosec`, `shellcheck` (warning level) clean; inline JS passes `node --check`