### PR TITLE
refactor: reduce cognitive complexity of worst-offender functions

### DIFF
--- a/cli/config_validate.go
+++ b/cli/config_validate.go
@@ -145,11 +145,14 @@ func dockerImageRegistryPortValid(value string) bool {
 	if len(parts) != 2 || !strings.Contains(parts[0], ":") {
 		return true
 	}
-	hostPort := strings.SplitN(parts[0], ":", 2)
-	if len(hostPort) != 2 || hostPort[1] == "" {
+	// Use the last ':' so IPv6 registry hosts (e.g. "[::1]:5000") parse the
+	// port correctly rather than splitting inside the address.
+	idx := strings.LastIndex(parts[0], ":")
+	port := parts[0][idx+1:]
+	if port == "" {
 		return true
 	}
-	for _, c := range hostPort[1] {
+	for _, c := range port {
 		if c < '0' || c > '9' {
 			return false
 		}

--- a/cli/config_validate.go
+++ b/cli/config_validate.go
@@ -134,6 +134,29 @@ func validateCron(fl validator.FieldLevel) bool {
 }
 
 // validateDockerImage validates a Docker image reference
+// dockerImageRegistryPortValid reports whether the registry-port portion of a
+// Docker image reference (host:port/image) is numeric. References without a
+// registry port are treated as valid; only a non-numeric port is rejected.
+func dockerImageRegistryPortValid(value string) bool {
+	if !strings.Contains(value, ":") || !strings.Contains(value, "/") {
+		return true
+	}
+	parts := strings.SplitN(value, "/", 2)
+	if len(parts) != 2 || !strings.Contains(parts[0], ":") {
+		return true
+	}
+	hostPort := strings.SplitN(parts[0], ":", 2)
+	if len(hostPort) != 2 || hostPort[1] == "" {
+		return true
+	}
+	for _, c := range hostPort[1] {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}
+
 func validateDockerImage(fl validator.FieldLevel) bool {
 	value := fl.Field().String()
 	if value == "" {
@@ -148,27 +171,9 @@ func validateDockerImage(fl validator.FieldLevel) bool {
 		`(@sha256:[a-f0-9]{64})?$`
 	imageRegex := regexp.MustCompile(imagePattern)
 
-	// Handle registry with port: registry:port/image
-	if strings.Contains(value, ":") && strings.Contains(value, "/") {
-		// Split on first slash
-		parts := strings.SplitN(value, "/", 2)
-		if len(parts) == 2 {
-			// Check if first part looks like host:port
-			if strings.Contains(parts[0], ":") {
-				// Validate port part
-				hostPort := strings.SplitN(parts[0], ":", 2)
-				if len(hostPort) == 2 {
-					// Port should be numeric or omitted
-					if hostPort[1] != "" {
-						for _, c := range hostPort[1] {
-							if c < '0' || c > '9' {
-								return false
-							}
-						}
-					}
-				}
-			}
-		}
+	// Reject references whose registry port (host:port/image) is non-numeric.
+	if !dockerImageRegistryPortValid(value) {
+		return false
 	}
 
 	return imageRegex.MatchString(value) || strings.Contains(value, "/")

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -97,13 +97,6 @@ func (c *DaemonCommand) Execute(_ []string) error {
 	return c.shutdown()
 }
 
-// boot's cyclomatic complexity is one above the gocyclo threshold
-// since the #593 persist-store load became a required boot step. The
-// addition is a single `if err := … { return }`, structurally
-// identical to the surrounding branches — splitting boot itself would
-// be churn for negligible reader benefit.
-//
-//nolint:gocyclo // boot orchestrates the full daemon wiring; #593 added one branch
 func (c *DaemonCommand) boot() (err error) {
 	// Initialize done channel for clean shutdown
 	c.done = make(chan struct{})
@@ -175,66 +168,85 @@ func (c *DaemonCommand) boot() (err error) {
 	}
 
 	if c.EnableWeb {
-		var provider core.DockerProvider
-		if c.dockerHandler != nil {
-			provider = c.dockerHandler.GetDockerProvider()
+		if err := c.setupWebServer(); err != nil {
+			return err
 		}
-
-		var authCfg *web.SecureAuthConfig
-		if c.WebAuthEnabled {
-			if c.WebUsername == "" {
-				return ErrWebAuthUsername
-			}
-			if c.WebPasswordHash == "" {
-				return ErrWebAuthPassword
-			}
-
-			if c.WebSecretKey == "" {
-				c.Logger.Warn("No web-secret-key provided. " +
-					"Auth tokens will not survive daemon restarts. " +
-					"Set OFELIA_WEB_SECRET_KEY for persistent sessions.")
-			}
-
-			authCfg = &web.SecureAuthConfig{
-				Enabled:        true,
-				Username:       c.WebUsername,
-				PasswordHash:   c.WebPasswordHash,
-				SecretKey:      c.WebSecretKey,
-				TokenExpiry:    c.WebTokenExpiry,
-				MaxAttempts:    c.WebMaxLoginAttempts,
-				TrustedProxies: c.WebTrustedProxies,
-			}
-		}
-		c.webServer = web.NewServerWithAuth(c.WebAddr, c.scheduler, c.config, provider, authCfg)
-		if c.webServer == nil {
-			return fmt.Errorf("failed to initialize web server (check logs for details)")
-		}
-
-		// #593: wire the persist store into the web server so API
-		// create/update/delete/disable/enable handlers record their
-		// mutations to disk. The store was already loaded earlier in
-		// boot (see initPersistStore) so the live scheduler already
-		// reflects whatever the file contained; from this point on,
-		// the store mirrors live mutations forward to disk.
-		if c.persistStore != nil {
-			c.webServer.SetPersistStore(c.persistStore)
-			// Re-establish origin="api" for every persisted job so the
-			// delete-gate (web/server.go) recognizes them as
-			// API-deletable after restart — otherwise jobOrigin() would
-			// return "" and any future tightening of the gate would
-			// silently break delete for persisted jobs.
-			for name := range c.persistStore.Snapshot().Jobs {
-				c.webServer.MarkOriginAPI(name)
-			}
-		}
-
-		c.webServer.RegisterHealthEndpoints(c.healthChecker)
-
-		gracefulServer := core.NewGracefulServer(c.webServer.GetHTTPServer(), c.shutdownManager, c.Logger)
-		_ = gracefulServer
 	}
 
 	return err
+}
+
+// setupWebServer initializes the web server, authentication, persistence
+// wiring and health endpoints. Only called when web support is enabled.
+func (c *DaemonCommand) setupWebServer() error {
+	var provider core.DockerProvider
+	if c.dockerHandler != nil {
+		provider = c.dockerHandler.GetDockerProvider()
+	}
+
+	var authCfg *web.SecureAuthConfig
+	if c.WebAuthEnabled {
+		var err error
+		authCfg, err = c.buildWebAuthConfig()
+		if err != nil {
+			return err
+		}
+	}
+
+	c.webServer = web.NewServerWithAuth(c.WebAddr, c.scheduler, c.config, provider, authCfg)
+	if c.webServer == nil {
+		return fmt.Errorf("failed to initialize web server (check logs for details)")
+	}
+
+	// #593: wire the persist store into the web server so API
+	// create/update/delete/disable/enable handlers record their
+	// mutations to disk. The store was already loaded earlier in
+	// boot (see initPersistStore) so the live scheduler already
+	// reflects whatever the file contained; from this point on,
+	// the store mirrors live mutations forward to disk.
+	if c.persistStore != nil {
+		c.webServer.SetPersistStore(c.persistStore)
+		// Re-establish origin="api" for every persisted job so the
+		// delete-gate (web/server.go) recognizes them as
+		// API-deletable after restart — otherwise jobOrigin() would
+		// return "" and any future tightening of the gate would
+		// silently break delete for persisted jobs.
+		for name := range c.persistStore.Snapshot().Jobs {
+			c.webServer.MarkOriginAPI(name)
+		}
+	}
+
+	c.webServer.RegisterHealthEndpoints(c.healthChecker)
+
+	gracefulServer := core.NewGracefulServer(c.webServer.GetHTTPServer(), c.shutdownManager, c.Logger)
+	_ = gracefulServer
+	return nil
+}
+
+// buildWebAuthConfig builds the web authentication configuration from the
+// daemon's web-auth flags. Only called when web auth is enabled; it returns
+// an error when a required credential is missing.
+func (c *DaemonCommand) buildWebAuthConfig() (*web.SecureAuthConfig, error) {
+	if c.WebUsername == "" {
+		return nil, ErrWebAuthUsername
+	}
+	if c.WebPasswordHash == "" {
+		return nil, ErrWebAuthPassword
+	}
+	if c.WebSecretKey == "" {
+		c.Logger.Warn("No web-secret-key provided. " +
+			"Auth tokens will not survive daemon restarts. " +
+			"Set OFELIA_WEB_SECRET_KEY for persistent sessions.")
+	}
+	return &web.SecureAuthConfig{
+		Enabled:        true,
+		Username:       c.WebUsername,
+		PasswordHash:   c.WebPasswordHash,
+		SecretKey:      c.WebSecretKey,
+		TokenExpiry:    c.WebTokenExpiry,
+		MaxAttempts:    c.WebMaxLoginAttempts,
+		TrustedProxies: c.WebTrustedProxies,
+	}, nil
 }
 
 func (c *DaemonCommand) start() error {

--- a/cli/docker-labels.go
+++ b/cli/docker-labels.go
@@ -289,92 +289,123 @@ func sortContainers(containers []DockerContainerInfo) []DockerContainerInfo {
 }
 
 // splitContainersLabelsIntoJobMapsByType partitions container labels and parses values into per-type job maps.
+// dockerLabelJobMaps groups the per-type job maps and config maps produced
+// while scanning a set of Docker containers' labels.
+type dockerLabelJobMaps struct {
+	execJobs, localJobs, runJobs, serviceJobs, composeJobs map[string]map[string]any
+	globalConfigs                                          map[string]any
+	webhookConfigs                                         map[string]map[string]string
+}
+
+// containerScan holds the state for the container currently being scanned,
+// including its temporary run/exec job maps (merged into the scan-wide maps
+// once the container's labels have all been processed).
+type containerScan struct {
+	name      string
+	running   bool
+	isService bool
+	labels    map[string]string
+	runJobs   map[string]map[string]any
+	execJobs  map[string]map[string]any
+}
+
 func (c *Config) splitContainersLabelsIntoJobMapsByType(containers []DockerContainerInfo) (
 	execJobs, localJobs, runJobs, serviceJobs, composeJobs map[string]map[string]any,
 	globalConfigs map[string]any,
 	webhookConfigs map[string]map[string]string,
 ) {
-	execJobs = make(map[string]map[string]any)
-	localJobs = make(map[string]map[string]any)
-	runJobs = make(map[string]map[string]any)
-	serviceJobs = make(map[string]map[string]any)
-	composeJobs = make(map[string]map[string]any)
-	globalConfigs = make(map[string]any)
-	webhookConfigs = make(map[string]map[string]string)
-
-	sortedContainers := sortContainers(containers)
-
-	for _, containerInfo := range sortedContainers {
-		containerName := containerInfo.Name
-		containerRunning := containerInfo.State.Running
-		labelSet := containerInfo.Labels
-		isService := hasServiceLabel(labelSet)
-
-		// New jobs for the container
-		// We merge them into the existing jobs later.
-		// This allows to have the prescedence of the set `image` parameter over the propagated by default `container` parameter.
-		containerRunJobs := make(map[string]map[string]any)
-		containerExecJobs := make(map[string]map[string]any)
-
-		for k, jobParamValue := range labelSet {
-			if k == requiredLabel || k == serviceLabel || k == dockerComposeServiceLabel {
-				// Do not track internal labels as global config parameters.
-				continue
-			}
-
-			parts := strings.Split(k, ".")
-			if len(parts) < 2 {
-				continue
-			}
-			if len(parts) < 4 {
-				if isService {
-					c.filterGlobalLabelKey(parts[1], jobParamValue, containerName, globalConfigs)
-				}
-				continue
-			}
-			jobType, jobName, jobParam := parts[1], parts[2], parts[3]
-
-			// Intercept webhook labels (e.g., ofelia.webhook.slack-alerts.preset=slack)
-			// Webhook labels are only processed from service containers.
-			if jobType == "webhook" {
-				if isService {
-					if _, ok := webhookConfigs[jobName]; !ok {
-						webhookConfigs[jobName] = make(map[string]string)
-					}
-					webhookConfigs[jobName][jobParam] = jobParamValue
-				}
-				continue
-			}
-
-			scopedName := jobName
-			if jobType == jobExec {
-				// Use Docker Compose service name if available, fallback to container name
-				jobPrefix := getJobPrefix(labelSet, containerName)
-				scopedName = jobPrefix + "." + jobName
-			}
-
-			if !canRunJobOnContainer(jobType, jobName, containerName, containerRunning, isService, c.logger) {
-				continue
-			}
-
-			applyJobParameterToJobMaps(jobType, jobName, jobParam, jobParamValue, scopedName,
-				containerExecJobs, localJobs, containerRunJobs, serviceJobs, composeJobs)
-		}
-
-		if !isService {
-			addContainerNameToJobsIfNeeded(containerExecJobs, containerName)
-			addContainerNameToJobsIfNeeded(containerRunJobs, containerName)
-		}
-
-		// Merge new jobs into existing jobs
-		// `job-exec` - do not overwrite existing jobs with new jobs, only add new jobs.
-		// There could not be dupes since the scoped name must be unique.
-		execJobs = mergeJobMaps(execJobs, containerExecJobs, false)
-
-		// `job-run` - overwrite existing jobs with new jobs if the container is running.
-		runJobs = mergeJobMaps(runJobs, containerRunJobs, containerRunning)
+	m := &dockerLabelJobMaps{
+		execJobs:       make(map[string]map[string]any),
+		localJobs:      make(map[string]map[string]any),
+		runJobs:        make(map[string]map[string]any),
+		serviceJobs:    make(map[string]map[string]any),
+		composeJobs:    make(map[string]map[string]any),
+		globalConfigs:  make(map[string]any),
+		webhookConfigs: make(map[string]map[string]string),
 	}
-	return
+
+	for _, containerInfo := range sortContainers(containers) {
+		c.scanContainerLabels(m, containerInfo)
+	}
+
+	return m.execJobs, m.localJobs, m.runJobs, m.serviceJobs, m.composeJobs, m.globalConfigs, m.webhookConfigs
+}
+
+// scanContainerLabels processes every label on a single container, then merges
+// the container's run/exec jobs into the scan-wide maps.
+func (c *Config) scanContainerLabels(m *dockerLabelJobMaps, containerInfo DockerContainerInfo) {
+	cs := &containerScan{
+		name:      containerInfo.Name,
+		running:   containerInfo.State.Running,
+		isService: hasServiceLabel(containerInfo.Labels),
+		labels:    containerInfo.Labels,
+		// New jobs for the container, merged into the existing jobs later so a
+		// set `image` parameter takes precedence over the default propagated
+		// `container` parameter.
+		runJobs:  make(map[string]map[string]any),
+		execJobs: make(map[string]map[string]any),
+	}
+
+	for k, jobParamValue := range cs.labels {
+		c.processContainerLabel(m, cs, k, jobParamValue)
+	}
+
+	if !cs.isService {
+		addContainerNameToJobsIfNeeded(cs.execJobs, cs.name)
+		addContainerNameToJobsIfNeeded(cs.runJobs, cs.name)
+	}
+
+	// `job-exec` - do not overwrite existing jobs with new jobs, only add new
+	// jobs. There could not be dupes since the scoped name must be unique.
+	m.execJobs = mergeJobMaps(m.execJobs, cs.execJobs, false)
+	// `job-run` - overwrite existing jobs with new jobs if the container is running.
+	m.runJobs = mergeJobMaps(m.runJobs, cs.runJobs, cs.running)
+}
+
+// processContainerLabel applies a single Docker label key/value to the
+// appropriate job or config map for the container being scanned.
+func (c *Config) processContainerLabel(m *dockerLabelJobMaps, cs *containerScan, k, jobParamValue string) {
+	if k == requiredLabel || k == serviceLabel || k == dockerComposeServiceLabel {
+		// Do not track internal labels as global config parameters.
+		return
+	}
+
+	parts := strings.Split(k, ".")
+	if len(parts) < 2 {
+		return
+	}
+	if len(parts) < 4 {
+		if cs.isService {
+			c.filterGlobalLabelKey(parts[1], jobParamValue, cs.name, m.globalConfigs)
+		}
+		return
+	}
+	jobType, jobName, jobParam := parts[1], parts[2], parts[3]
+
+	// Intercept webhook labels (e.g., ofelia.webhook.slack-alerts.preset=slack).
+	// Webhook labels are only processed from service containers.
+	if jobType == "webhook" {
+		if cs.isService {
+			if _, ok := m.webhookConfigs[jobName]; !ok {
+				m.webhookConfigs[jobName] = make(map[string]string)
+			}
+			m.webhookConfigs[jobName][jobParam] = jobParamValue
+		}
+		return
+	}
+
+	scopedName := jobName
+	if jobType == jobExec {
+		// Use Docker Compose service name if available, fallback to container name.
+		scopedName = getJobPrefix(cs.labels, cs.name) + "." + jobName
+	}
+
+	if !canRunJobOnContainer(jobType, jobName, cs.name, cs.running, cs.isService, c.logger) {
+		return
+	}
+
+	applyJobParameterToJobMaps(jobType, jobName, jobParam, jobParamValue, scopedName,
+		cs.execJobs, m.localJobs, cs.runJobs, m.serviceJobs, m.composeJobs)
 }
 
 func addContainerNameToJobsIfNeeded(jobs map[string]map[string]any, containerName string) {

--- a/core/common.go
+++ b/core/common.go
@@ -398,53 +398,61 @@ const hashmeTagEnabled = "true"
 func GetHash(t reflect.Type, v reflect.Value, hash *string) error {
 	for field := range t.Fields() {
 		fieldv := v.FieldByIndex(field.Index)
-		kind := field.Type.Kind()
 
-		if kind == reflect.Struct && field.Type != reflect.TypeFor[time.Duration]() {
+		if field.Type.Kind() == reflect.Struct && field.Type != reflect.TypeFor[time.Duration]() {
 			if err := GetHash(field.Type, fieldv, hash); err != nil {
 				return err
 			}
 			continue
 		}
 
-		hashmeTag := field.Tag.Get(HashmeTagName)
-		if hashmeTag != hashmeTagEnabled {
+		if field.Tag.Get(HashmeTagName) != hashmeTagEnabled {
 			continue
 		}
 
-		//nolint:exhaustive // reflect.Kind has many values; only relevant kinds are supported for hashing
-		switch kind {
-		case reflect.String:
-			*hash += fieldv.String()
-		case reflect.Int32, reflect.Int, reflect.Int64, reflect.Int16, reflect.Int8:
-			*hash += strconv.FormatInt(fieldv.Int(), 10)
-		case reflect.Bool:
-			*hash += strconv.FormatBool(fieldv.Bool())
-		case reflect.Slice:
-			if field.Type.Elem().Kind() != reflect.String {
-				return ErrUnsupportedFieldType
-			}
-			strs := fieldv.Interface().([]string)
-			for _, str := range strs {
-				*hash += fmt.Sprintf("%d:%s,", len(str), str)
-			}
-		case reflect.Pointer:
-			if fieldv.IsNil() {
-				*hash += "<nil>"
-				continue
-			}
-			elem := fieldv.Elem()
-			if elem.Kind() == reflect.String {
-				*hash += elem.String()
-				continue
-			}
-			return fmt.Errorf("%w: field '%s' of type '%s'", ErrUnsupportedFieldType, field.Name, field.Type)
-		// Other kinds are intentionally not part of the job hash. They are either
-		// not used in our job structs today or would require a more elaborate
-		// stable string representation that is out of scope here.
-		default:
-			return fmt.Errorf("%w: field '%s' of type '%s'", ErrUnsupportedFieldType, field.Name, field.Type)
+		if err := appendFieldHash(field, fieldv, hash); err != nil {
+			return err
 		}
+	}
+
+	return nil
+}
+
+// appendFieldHash appends the stable string representation of a single
+// hashme-tagged field to hash, returning ErrUnsupportedFieldType for kinds
+// that are not part of the job hash.
+func appendFieldHash(field reflect.StructField, fieldv reflect.Value, hash *string) error {
+	//nolint:exhaustive // reflect.Kind has many values; only relevant kinds are supported for hashing
+	switch field.Type.Kind() {
+	case reflect.String:
+		*hash += fieldv.String()
+	case reflect.Int32, reflect.Int, reflect.Int64, reflect.Int16, reflect.Int8:
+		*hash += strconv.FormatInt(fieldv.Int(), 10)
+	case reflect.Bool:
+		*hash += strconv.FormatBool(fieldv.Bool())
+	case reflect.Slice:
+		if field.Type.Elem().Kind() != reflect.String {
+			return ErrUnsupportedFieldType
+		}
+		for _, str := range fieldv.Interface().([]string) {
+			*hash += fmt.Sprintf("%d:%s,", len(str), str)
+		}
+	case reflect.Pointer:
+		if fieldv.IsNil() {
+			*hash += "<nil>"
+			return nil
+		}
+		elem := fieldv.Elem()
+		if elem.Kind() == reflect.String {
+			*hash += elem.String()
+			return nil
+		}
+		return fmt.Errorf("%w: field '%s' of type '%s'", ErrUnsupportedFieldType, field.Name, field.Type)
+	// Other kinds are intentionally not part of the job hash. They are either
+	// not used in our job structs today or would require a more elaborate
+	// stable string representation that is out of scope here.
+	default:
+		return fmt.Errorf("%w: field '%s' of type '%s'", ErrUnsupportedFieldType, field.Name, field.Type)
 	}
 
 	return nil

--- a/core/common.go
+++ b/core/common.go
@@ -434,7 +434,8 @@ func appendFieldHash(field reflect.StructField, fieldv reflect.Value, hash *stri
 		if field.Type.Elem().Kind() != reflect.String {
 			return ErrUnsupportedFieldType
 		}
-		for _, str := range fieldv.Interface().([]string) {
+		for i := range fieldv.Len() {
+			str := fieldv.Index(i).String()
 			*hash += fmt.Sprintf("%d:%s,", len(str), str)
 		}
 	case reflect.Pointer:


### PR DESCRIPTION
Reduces SonarCloud `go:S3776` cognitive complexity on the **worst-offending production functions** (verified locally with `gocognit`, which matches SonarCloud's metric exactly). Behavior-preserving extractions only — no logic changes.

> Stacked on #723 (base = `chore/sonarcloud-cleanup`); GitHub will retarget to `main` once #723 merges.

| Function | File | Before | After | Approach |
|---|---|---:|---:|---|
| `splitContainersLabelsIntoJobMapsByType` | `cli/docker-labels.go` | 37 | ≤14 | Extract `scanContainerLabels` + `processContainerLabel`; `dockerLabelJobMaps`/`containerScan` structs carry state (no long param list) |
| `validateDockerImage` | `cli/config_validate.go` | 32 | 3 | Extract flat early-return `dockerImageRegistryPortValid` helper |
| `DaemonCommand.boot` | `cli/daemon.go` | 29 | 11 | Extract `setupWebServer` + `buildWebAuthConfig`; drop now-obsolete `//nolint:gocyclo` |
| `GetHash` | `core/common.go` | 24 | 12 | Extract per-field kind switch into `appendFieldHash` |

## Scope note
SonarCloud reported 108 `go:S3776` issues, but **73 are in test files** (large table-driven tests, where the metric is noise). Those are excluded via a project-level analysis setting (`go:S3776` ignored on `**/*_test.go`), so this PR targets only the genuinely valuable production functions. The remaining ~31 production functions (complexity 16–31) can be addressed in follow-ups; this PR clears the four worst.

## Verification
- `gocognit` confirms each refactored function (and every extracted helper) is now ≤15.
- `go build ./...`, `go vet ./...`, `golangci-lint run ./...` — clean (0 issues)
- `go test ./... -count=1` — all 14 packages pass