### PR TITLE
refactor: reduce cognitive complexity of remaining production functions (S3776/S107)

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -164,6 +164,44 @@ func resolveConfigFiles(pattern string) ([]string, error) {
 	return files, nil
 }
 
+// loadConfigFile reads one INI config file, parses it into c, merges used keys
+// into allUsedKeys, logs unknown-key warnings, and updates latest with the file
+// mod-time. Returns an error only when the file cannot be read or parsed.
+func loadConfigFile(f string, c *Config, logger *slog.Logger, allUsedKeys map[string]bool, latest *time.Time) error {
+	data, err := os.ReadFile(f) // #nosec G304 -- file path from user config flag, not external input
+	if err != nil {
+		//nolint:revive // Error message intentionally verbose for UX (actionable troubleshooting hints)
+		return fmt.Errorf("failed to load config file %q: %w\n  → Check file exists and is readable: ls -l %q\n  → Verify file path is correct\n  → Check file permissions (should be readable)", f, err, f)
+	}
+	cfg, err := ini.LoadSources(ini.LoadOptions{AllowShadows: true, InsensitiveKeys: true}, data)
+	if err != nil {
+		//nolint:revive // Error message intentionally verbose for UX (actionable troubleshooting hints)
+		return fmt.Errorf("failed to parse config file %q: %w\n  → Check INI syntax is valid\n  → Verify environment variable substitutions resolve correctly", f, err)
+	}
+	parseRes, parseErr := parseIni(cfg, c)
+	if parseErr != nil {
+		//nolint:revive // Error message intentionally verbose for UX (actionable troubleshooting hints)
+		return fmt.Errorf("failed to parse config file %q: %w\n  → Check INI syntax is valid (sections in [brackets], key=value pairs)\n  → Look for syntax errors near line mentioned in error\n  → Use 'ofelia validate --config=%q' to validate syntax", f, parseErr, f)
+	}
+
+	// Merge used keys from this file
+	if parseRes != nil {
+		for k, v := range parseRes.usedKeys {
+			if v {
+				allUsedKeys[k] = true
+			}
+		}
+		// Log warnings for unknown keys
+		logUnknownKeyWarnings(logger, f, parseRes)
+	}
+
+	if info, statErr := os.Stat(f); statErr == nil && info.ModTime().After(*latest) {
+		*latest = info.ModTime()
+	}
+	logger.Debug("loaded config file", "file", f)
+	return nil
+}
+
 // BuildFromFile builds a scheduler using the config from one or multiple files.
 // The filename may include glob patterns. When multiple files are matched,
 // they are parsed in lexical order and merged.
@@ -178,40 +216,9 @@ func BuildFromFile(filename string, logger *slog.Logger) (*Config, error) {
 	allUsedKeys := make(map[string]bool)
 
 	for _, f := range files {
-		data, err := os.ReadFile(f) // #nosec G304 -- file path from user config flag, not external input
-		if err != nil {
-			//nolint:revive // Error message intentionally verbose for UX (actionable troubleshooting hints)
-			return nil, fmt.Errorf("failed to load config file %q: %w\n  → Check file exists and is readable: ls -l %q\n  → Verify file path is correct\n  → Check file permissions (should be readable)", f, err, f)
+		if err := loadConfigFile(f, c, logger, allUsedKeys, &latest); err != nil {
+			return nil, err
 		}
-		cfg, err := ini.LoadSources(ini.LoadOptions{AllowShadows: true, InsensitiveKeys: true}, data)
-		if err != nil {
-			//nolint:revive // Error message intentionally verbose for UX (actionable troubleshooting hints)
-			return nil, fmt.Errorf("failed to parse config file %q: %w\n  → Check INI syntax is valid\n  → Verify environment variable substitutions resolve correctly", f, err)
-		}
-		parseRes, parseErr := parseIni(cfg, c)
-		if parseErr != nil {
-			//nolint:revive // Error message intentionally verbose for UX (actionable troubleshooting hints)
-			return nil, fmt.Errorf("failed to parse config file %q: %w\n  → Check INI syntax is valid (sections in [brackets], key=value pairs)\n  → Look for syntax errors near line mentioned in error\n  → Use 'ofelia validate --config=%q' to validate syntax", f, parseErr, f)
-		}
-
-		// Merge used keys from this file
-		if parseRes != nil {
-			for k, v := range parseRes.usedKeys {
-				if v {
-					allUsedKeys[k] = true
-				}
-			}
-
-			// Log warnings for unknown keys
-			logUnknownKeyWarnings(logger, f, parseRes)
-		}
-
-		if info, statErr := os.Stat(f); statErr == nil {
-			if info.ModTime().After(latest) {
-				latest = info.ModTime()
-			}
-		}
-		logger.Debug("loaded config file", "file", f)
 	}
 	c.configPath = filename
 	c.configFiles = files
@@ -296,6 +303,26 @@ func dockerKnownKeys() []string {
 	return extractMapstructureKeys(DockerConfig{})
 }
 
+// jobUnknownKeyMessage builds the warning text for a single unknown key in a job
+// section. The shape is identical to logSectionUnknownKeyWarnings but includes
+// the job name in the section label.
+func jobUnknownKeyMessage(key, jobType, jobName, filename, suggestion string) string {
+	switch {
+	case suggestion != "" && filename != "":
+		return fmt.Sprintf("Unknown configuration key '%s' in [%s \"%s\"] of %s (did you mean '%s'?)",
+			key, jobType, jobName, filename, suggestion)
+	case suggestion != "":
+		return fmt.Sprintf("Unknown configuration key '%s' in [%s \"%s\"] (did you mean '%s'?)",
+			key, jobType, jobName, suggestion)
+	case filename != "":
+		return fmt.Sprintf("Unknown configuration key '%s' in [%s \"%s\"] of %s (typo?)",
+			key, jobType, jobName, filename)
+	default:
+		return fmt.Sprintf("Unknown configuration key '%s' in [%s \"%s\"] (typo?)",
+			key, jobType, jobName)
+	}
+}
+
 // logJobUnknownKeyWarnings logs warnings for unknown keys in job sections with
 // "did you mean?" suggestions. If filename is non-empty, it is included in the message.
 func logJobUnknownKeyWarnings(logger *slog.Logger, unknownJobs []jobUnknownKeys, filename string) {
@@ -303,23 +330,7 @@ func logJobUnknownKeyWarnings(logger *slog.Logger, unknownJobs []jobUnknownKeys,
 		knownKeys := getKnownKeysForJobType(job.JobType)
 		for _, key := range job.UnknownKeys {
 			suggestion := findClosestMatch(key, knownKeys)
-			if filename != "" {
-				if suggestion != "" {
-					logger.Warn(fmt.Sprintf("Unknown configuration key '%s' in [%s \"%s\"] of %s (did you mean '%s'?)",
-						key, job.JobType, job.JobName, filename, suggestion))
-				} else {
-					logger.Warn(fmt.Sprintf("Unknown configuration key '%s' in [%s \"%s\"] of %s (typo?)",
-						key, job.JobType, job.JobName, filename))
-				}
-			} else {
-				if suggestion != "" {
-					logger.Warn(fmt.Sprintf("Unknown configuration key '%s' in [%s \"%s\"] (did you mean '%s'?)",
-						key, job.JobType, job.JobName, suggestion))
-				} else {
-					logger.Warn(fmt.Sprintf("Unknown configuration key '%s' in [%s \"%s\"] (typo?)",
-						key, job.JobType, job.JobName))
-				}
-			}
+			logger.Warn(jobUnknownKeyMessage(key, job.JobType, job.JobName, filename, suggestion))
 		}
 	}
 }
@@ -821,6 +832,29 @@ type jobConfig interface {
 	ResetMiddlewares(...core.Middleware)
 }
 
+// reconcileParsedJob decides whether a parsed job should be added to current.
+// Returns true when the caller should proceed to addNewJob (the existing entry,
+// if any, has already been removed from the scheduler). Returns false when the
+// job should be skipped (e.g. INI takes precedence over a label-defined entry).
+func reconcileParsedJob[J jobConfig](c *Config, name string, cur J, curOK bool, source JobSource, jobKind string) bool {
+	if !curOK {
+		return true // no existing entry — always add
+	}
+	switch {
+	case cur.GetJobSource() == source:
+		return false // same source, already updated in the first loop
+	case source == JobSourceINI && cur.GetJobSource() == JobSourceLabel:
+		c.logger.Warn(fmt.Sprintf("overriding label-defined %s job %q with INI job", jobKind, name))
+		_ = c.sh.RemoveJob(cur)
+		return true
+	case source == JobSourceLabel && cur.GetJobSource() == JobSourceINI:
+		c.logger.Warn(fmt.Sprintf("ignoring label-defined %s job %q because an INI job with the same name exists", jobKind, name))
+		return false
+	default:
+		return false
+	}
+}
+
 // syncJobMap updates the scheduler and the provided job map based on the parsed
 // configuration. The prep function is called on each job before comparison or
 // registration to set fields such as Name or Client and apply defaults.
@@ -837,26 +871,14 @@ func syncJobMap[J jobConfig](c *Config, current map[string]J, parsed map[string]
 		}
 		if replaceIfChanged(c, name, j, newJob, prep, source) {
 			current[name] = newJob
-			continue
 		}
 	}
 
 	for name, j := range parsed {
-		if cur, ok := current[name]; ok {
-			switch {
-			case cur.GetJobSource() == source:
-				continue
-			case source == JobSourceINI && cur.GetJobSource() == JobSourceLabel:
-				c.logger.Warn(fmt.Sprintf("overriding label-defined %s job %q with INI job", jobKind, name))
-				_ = c.sh.RemoveJob(cur)
-			case source == JobSourceLabel && cur.GetJobSource() == JobSourceINI:
-				c.logger.Warn(fmt.Sprintf("ignoring label-defined %s job %q because an INI job with the same name exists", jobKind, name))
-				continue
-			default:
-				continue
-			}
+		cur, curOK := current[name]
+		if reconcileParsedJob(c, name, cur, curOK, source, jobKind) {
+			addNewJob(c, name, j, prep, source, current)
 		}
-		addNewJob(c, name, j, prep, source, current)
 	}
 }
 
@@ -1021,72 +1043,31 @@ func (c *Config) dockerContainersUpdate(containers []DockerContainerInfo) {
 	CheckDeprecations(parsedLabelConfig)
 }
 
-func (c *Config) iniConfigUpdate() error {
-	if c.configPath == "" {
-		return nil
-	}
-
-	files, err := resolveConfigFiles(c.configPath)
-	if err != nil {
-		return err
-	}
-
-	latest, changed, err := latestChanged(files, c.configModTime)
-	if err != nil {
-		return err
-	}
-	for _, f := range files {
-		c.logger.Debug(fmt.Sprintf("checking config file %s", f))
-	}
-	if !changed {
-		c.logger.Debug("config not changed")
-		return nil
-	}
-	c.logger.Debug(fmt.Sprintf("reloading config files from %s", strings.Join(files, ", ")))
-
-	parsed, err := BuildFromFile(c.configPath, c.logger)
-	if err != nil {
-		return err
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	globalChanged := !reflect.DeepEqual(parsed.Global, c.Global)
-	c.configFiles = files
-	c.configModTime = latest
-	c.logger.Debug(fmt.Sprintf("applied config files from %s", strings.Join(files, ", ")))
-	if globalChanged {
-		c.Global = parsed.Global
-		c.refreshWebhookManagerOnGlobalChange()
-		c.sh.ResetMiddlewares()
-		c.buildSchedulerMiddlewares(c.sh)
-		wm := c.getWebhookManager()
-		// All jobs (including disabled/paused) need middleware updates.
-		// Use safe accessors that hold the scheduler's own lock to get a copy.
-		allJobs := append(c.sh.GetActiveJobs(), c.sh.GetDisabledJobs()...)
-		for _, j := range allJobs {
-			if jc, ok := j.(jobConfig); ok {
-				jc.ResetMiddlewares()
-				jc.buildMiddlewares(c.logger, wm)
-				j.Use(c.sh.Middlewares()...)
-			}
-		}
-		if err := ApplyLogLevel(c.Global.LogLevel, c.levelVar); err != nil {
-			c.logger.Warn(fmt.Sprintf("Failed to apply global log level (using default): %v", err))
+// rebuildAfterGlobalChange re-wires scheduler middlewares and per-job
+// middleware chains when the [global] section changed on live-reload.
+func (c *Config) rebuildAfterGlobalChange() {
+	c.refreshWebhookManagerOnGlobalChange()
+	c.sh.ResetMiddlewares()
+	c.buildSchedulerMiddlewares(c.sh)
+	wm := c.getWebhookManager()
+	// All jobs (including disabled/paused) need middleware updates.
+	// Use safe accessors that hold the scheduler's own lock to get a copy.
+	allJobs := append(c.sh.GetActiveJobs(), c.sh.GetDisabledJobs()...)
+	for _, j := range allJobs {
+		if jc, ok := j.(jobConfig); ok {
+			jc.ResetMiddlewares()
+			jc.buildMiddlewares(c.logger, wm)
+			j.Use(c.sh.Middlewares()...)
 		}
 	}
-
-	// Surface newly added [webhook "name"] sections from the reloaded INI into
-	// the live config. Without this step a brand-new webhook block has no
-	// effect until restart — only the embedded global fields benefit from the
-	// dual-store collapse from #620. INI source wins on collisions; existing
-	// entries are left untouched (label-defined entries keep their state, and
-	// a webhook re-named in the INI is treated as a removal-then-add at the
-	// next reconcile rather than a silent overwrite). See #640.
-	if c.mergeReloadedWebhookSections(parsed) {
-		c.refreshWebhookManagerOnGlobalChange()
+	if err := ApplyLogLevel(c.Global.LogLevel, c.levelVar); err != nil {
+		c.logger.Warn(fmt.Sprintf("Failed to apply global log level (using default): %v", err))
 	}
+}
 
+// syncAllJobMapsFromINI propagates parsed INI job maps into the live job maps
+// via syncJobMap for all five job types.
+func (c *Config) syncAllJobMapsFromINI(parsed *Config) {
 	execPrep := func(name string, j *ExecJobConfig) {
 		_ = defaults.Set(j)
 		c.applyDefaultUser(&j.User)
@@ -1141,7 +1122,59 @@ func (c *Config) iniConfigUpdate() error {
 		c.injectDedup(&j.SlackConfig, &j.MailConfig)
 	}
 	syncJobMap(c, c.ComposeJobs, parsed.ComposeJobs, composePrep, JobSourceINI, "compose")
+}
 
+func (c *Config) iniConfigUpdate() error {
+	if c.configPath == "" {
+		return nil
+	}
+
+	files, err := resolveConfigFiles(c.configPath)
+	if err != nil {
+		return err
+	}
+
+	latest, changed, err := latestChanged(files, c.configModTime)
+	if err != nil {
+		return err
+	}
+	for _, f := range files {
+		c.logger.Debug(fmt.Sprintf("checking config file %s", f))
+	}
+	if !changed {
+		c.logger.Debug("config not changed")
+		return nil
+	}
+	c.logger.Debug(fmt.Sprintf("reloading config files from %s", strings.Join(files, ", ")))
+
+	parsed, err := BuildFromFile(c.configPath, c.logger)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	globalChanged := !reflect.DeepEqual(parsed.Global, c.Global)
+	c.configFiles = files
+	c.configModTime = latest
+	c.logger.Debug(fmt.Sprintf("applied config files from %s", strings.Join(files, ", ")))
+	if globalChanged {
+		c.Global = parsed.Global
+		c.rebuildAfterGlobalChange()
+	}
+
+	// Surface newly added [webhook "name"] sections from the reloaded INI into
+	// the live config. Without this step a brand-new webhook block has no
+	// effect until restart — only the embedded global fields benefit from the
+	// dual-store collapse from #620. INI source wins on collisions; existing
+	// entries are left untouched (label-defined entries keep their state, and
+	// a webhook re-named in the INI is treated as a removal-then-add at the
+	// next reconcile rather than a silent overwrite). See #640.
+	if c.mergeReloadedWebhookSections(parsed) {
+		c.refreshWebhookManagerOnGlobalChange()
+	}
+
+	c.syncAllJobMapsFromINI(parsed)
 	return nil
 }
 
@@ -1156,6 +1189,15 @@ type ExecJobConfig struct {
 	JobSource                 JobSource `json:"-" mapstructure:"-"`
 }
 
+// jobNotificationConfigs bundles the four per-job middleware config pointers
+// so buildJobMiddlewares satisfies the S107 ≤7-parameter rule.
+type jobNotificationConfigs struct {
+	Overlap *middlewares.OverlapConfig
+	Slack   *middlewares.SlackConfig
+	Save    *middlewares.SaveConfig
+	Mail    *middlewares.MailConfig
+}
+
 // buildJobMiddlewares attaches the standard per-job middleware stack
 // (Overlap, Slack, Save, Mail) to job j, then the webhook composite resolved
 // from per-job names unioned with the global selector. Extracted from five
@@ -1165,23 +1207,20 @@ type ExecJobConfig struct {
 func buildJobMiddlewares(
 	logger *slog.Logger,
 	j core.Job,
-	overlap *middlewares.OverlapConfig,
-	slack *middlewares.SlackConfig,
-	save *middlewares.SaveConfig,
-	mail *middlewares.MailConfig,
+	cfg jobNotificationConfigs,
 	wm *middlewares.WebhookManager,
 	webhookNames []string,
 ) {
-	j.Use(middlewares.NewOverlap(overlap))
-	j.Use(middlewares.NewSlack(slack)) //nolint:staticcheck // deprecated but kept for backwards compatibility
-	j.Use(middlewares.NewSave(save))
-	j.Use(middlewares.NewMail(mail))
+	j.Use(middlewares.NewOverlap(cfg.Overlap))
+	j.Use(middlewares.NewSlack(cfg.Slack)) //nolint:staticcheck // deprecated but kept for backwards compatibility
+	j.Use(middlewares.NewSave(cfg.Save))
+	j.Use(middlewares.NewMail(cfg.Mail))
 	attachJobWebhookMiddlewares(logger, j.GetName(), wm, webhookNames, j.Use)
 }
 
 func (c *ExecJobConfig) buildMiddlewares(logger *slog.Logger, wm *middlewares.WebhookManager) {
 	buildJobMiddlewares(logger, &c.ExecJob,
-		&c.OverlapConfig, &c.SlackConfig, &c.SaveConfig, &c.MailConfig,
+		jobNotificationConfigs{&c.OverlapConfig, &c.SlackConfig, &c.SaveConfig, &c.MailConfig},
 		wm, c.GetWebhookNames())
 }
 
@@ -1214,7 +1253,7 @@ type RunJobConfig struct {
 
 func (c *RunJobConfig) buildMiddlewares(logger *slog.Logger, wm *middlewares.WebhookManager) {
 	buildJobMiddlewares(logger, &c.RunJob,
-		&c.OverlapConfig, &c.SlackConfig, &c.SaveConfig, &c.MailConfig,
+		jobNotificationConfigs{&c.OverlapConfig, &c.SlackConfig, &c.SaveConfig, &c.MailConfig},
 		wm, c.GetWebhookNames())
 }
 
@@ -1259,19 +1298,19 @@ func (c *ComposeJobConfig) SetJobSource(s JobSource) { c.JobSource = s }
 
 func (c *LocalJobConfig) buildMiddlewares(logger *slog.Logger, wm *middlewares.WebhookManager) {
 	buildJobMiddlewares(logger, &c.LocalJob,
-		&c.OverlapConfig, &c.SlackConfig, &c.SaveConfig, &c.MailConfig,
+		jobNotificationConfigs{&c.OverlapConfig, &c.SlackConfig, &c.SaveConfig, &c.MailConfig},
 		wm, c.GetWebhookNames())
 }
 
 func (c *ComposeJobConfig) buildMiddlewares(logger *slog.Logger, wm *middlewares.WebhookManager) {
 	buildJobMiddlewares(logger, &c.ComposeJob,
-		&c.OverlapConfig, &c.SlackConfig, &c.SaveConfig, &c.MailConfig,
+		jobNotificationConfigs{&c.OverlapConfig, &c.SlackConfig, &c.SaveConfig, &c.MailConfig},
 		wm, c.GetWebhookNames())
 }
 
 func (c *RunServiceConfig) buildMiddlewares(logger *slog.Logger, wm *middlewares.WebhookManager) {
 	buildJobMiddlewares(logger, &c.RunServiceJob,
-		&c.OverlapConfig, &c.SlackConfig, &c.SaveConfig, &c.MailConfig,
+		jobNotificationConfigs{&c.OverlapConfig, &c.SlackConfig, &c.SaveConfig, &c.MailConfig},
 		wm, c.GetWebhookNames())
 }
 
@@ -1333,6 +1372,31 @@ type DockerConfig struct {
 	DisablePolling bool `mapstructure:"no-poll" default:"false"`
 }
 
+// decodeJobSection dispatches a single INI section to the appropriate decodeJob
+// call based on the section name prefix. Returns an error only when decoding
+// fails; sections that don't match a known job type are silently ignored.
+func decodeJobSection(section *ini.Section, name string, c *Config, unknownJobs *[]jobUnknownKeys) error {
+	switch {
+	case strings.HasPrefix(name, jobExec):
+		return decodeJob(section, &ExecJobConfig{JobSource: JobSourceINI},
+			func(n string, j *ExecJobConfig) { c.ExecJobs[n] = j }, jobExec, unknownJobs)
+	case strings.HasPrefix(name, jobServiceRun):
+		return decodeJob(section, &RunServiceConfig{JobSource: JobSourceINI},
+			func(n string, j *RunServiceConfig) { c.ServiceJobs[n] = j }, jobServiceRun, unknownJobs)
+	case strings.HasPrefix(name, jobRun):
+		return decodeJob(section, &RunJobConfig{JobSource: JobSourceINI},
+			func(n string, j *RunJobConfig) { c.RunJobs[n] = j }, jobRun, unknownJobs)
+	case strings.HasPrefix(name, jobLocal):
+		return decodeJob(section, &LocalJobConfig{JobSource: JobSourceINI},
+			func(n string, j *LocalJobConfig) { c.LocalJobs[n] = j }, jobLocal, unknownJobs)
+	case strings.HasPrefix(name, jobCompose):
+		return decodeJob(section, &ComposeJobConfig{JobSource: JobSourceINI},
+			func(n string, j *ComposeJobConfig) { c.ComposeJobs[n] = j }, jobCompose, unknownJobs)
+	default:
+		return nil
+	}
+}
+
 func parseIni(cfg *ini.File, c *Config) (*parseResult, error) {
 	parseRes, err := parseGlobalAndDocker(cfg, c)
 	if err != nil {
@@ -1348,57 +1412,8 @@ func parseIni(cfg *ini.File, c *Config) (*parseResult, error) {
 
 	for _, section := range cfg.Sections() {
 		name := strings.TrimSpace(section.Name())
-		switch {
-		case strings.HasPrefix(name, jobExec):
-			if err := decodeJob(
-				section,
-				&ExecJobConfig{JobSource: JobSourceINI},
-				func(n string, j *ExecJobConfig) { c.ExecJobs[n] = j },
-				jobExec,
-				&unknownJobs,
-			); err != nil {
-				return nil, err
-			}
-		case strings.HasPrefix(name, jobRun):
-			if err := decodeJob(
-				section,
-				&RunJobConfig{JobSource: JobSourceINI},
-				func(n string, j *RunJobConfig) { c.RunJobs[n] = j },
-				jobRun,
-				&unknownJobs,
-			); err != nil {
-				return nil, err
-			}
-		case strings.HasPrefix(name, jobServiceRun):
-			if err := decodeJob(
-				section,
-				&RunServiceConfig{JobSource: JobSourceINI},
-				func(n string, j *RunServiceConfig) { c.ServiceJobs[n] = j },
-				jobServiceRun,
-				&unknownJobs,
-			); err != nil {
-				return nil, err
-			}
-		case strings.HasPrefix(name, jobLocal):
-			if err := decodeJob(
-				section,
-				&LocalJobConfig{JobSource: JobSourceINI},
-				func(n string, j *LocalJobConfig) { c.LocalJobs[n] = j },
-				jobLocal,
-				&unknownJobs,
-			); err != nil {
-				return nil, err
-			}
-		case strings.HasPrefix(name, jobCompose):
-			if err := decodeJob(
-				section,
-				&ComposeJobConfig{JobSource: JobSourceINI},
-				func(n string, j *ComposeJobConfig) { c.ComposeJobs[n] = j },
-				jobCompose,
-				&unknownJobs,
-			); err != nil {
-				return nil, err
-			}
+		if err := decodeJobSection(section, name, c, &unknownJobs); err != nil {
+			return nil, err
 		}
 	}
 
@@ -1435,45 +1450,46 @@ type jobUnknownKeys struct {
 	UnknownKeys []string // Keys that didn't match any struct field
 }
 
+// decodeIniSection decodes a named INI section into dst. It merges the
+// decoded keys into usedKeys and returns the slice of unrecognized keys.
+// Returns a nil slice and no error when the section is absent.
+func decodeIniSection(cfg *ini.File, name string, dst any, usedKeys map[string]bool) ([]string, error) {
+	// ini.HasSection avoids the error-on-absent pattern that triggers nilerr.
+	if !cfg.HasSection(name) {
+		return nil, nil
+	}
+	sec, _ := cfg.GetSection(name) // HasSection guard above makes this safe
+	input := sectionToMap(sec)
+	decResult, decErr := decodeWithMetadata(input, dst)
+	if decErr != nil {
+		return nil, fmt.Errorf("decode [%s]: %w", name, decErr)
+	}
+	for k, v := range decResult.UsedKeys {
+		if v {
+			usedKeys[k] = true
+		}
+	}
+	return decResult.UnusedKeys, nil
+}
+
 func parseGlobalAndDocker(cfg *ini.File, c *Config) (*parseResult, error) {
 	result := &parseResult{
 		usedKeys: make(map[string]bool),
 	}
 
-	if sec, err := cfg.GetSection("global"); err == nil {
-		input := sectionToMap(sec)
-		decResult, decErr := decodeWithMetadata(input, &c.Global)
-		if decErr != nil {
-			return nil, fmt.Errorf("decode [global]: %w", decErr)
-		}
-		// Track used keys for deprecation detection
-		for k, v := range decResult.UsedKeys {
-			if v {
-				result.usedKeys[k] = true
-			}
-		}
-		result.unknownGlobal = decResult.UnusedKeys
-		// c.WebhookConfigs.Global aliases &c.Global.WebhookGlobalConfig (set in
-		// NewConfig), so mapstructure-decoded webhook-* keys are visible to the
-		// webhook subsystem without an explicit copy. The embedded struct was
-		// pre-seeded with defaults in NewConfig(), so unset keys retain them.
+	var err error
+	// c.WebhookConfigs.Global aliases &c.Global.WebhookGlobalConfig (set in
+	// NewConfig), so mapstructure-decoded webhook-* keys are visible to the
+	// webhook subsystem without an explicit copy. The embedded struct was
+	// pre-seeded with defaults in NewConfig(), so unset keys retain them.
+	result.unknownGlobal, err = decodeIniSection(cfg, "global", &c.Global, result.usedKeys)
+	if err != nil {
+		return nil, err
 	}
-
-	if sec, err := cfg.GetSection("docker"); err == nil {
-		input := sectionToMap(sec)
-		decResult, decErr := decodeWithMetadata(input, &c.Docker)
-		if decErr != nil {
-			return nil, fmt.Errorf("decode [docker]: %w", decErr)
-		}
-		// Track used keys for deprecation detection
-		for k, v := range decResult.UsedKeys {
-			if v {
-				result.usedKeys[k] = true
-			}
-		}
-		result.unknownDocker = decResult.UnusedKeys
+	result.unknownDocker, err = decodeIniSection(cfg, "docker", &c.Docker, result.usedKeys)
+	if err != nil {
+		return nil, err
 	}
-
 	return result, nil
 }
 

--- a/cli/config_decode.go
+++ b/cli/config_decode.go
@@ -142,42 +142,38 @@ func extractMapstructureKeysFromType(t reflect.Type) []string {
 
 	keys := make([]string, 0)
 	for field := range t.Fields() {
-		// Skip unexported fields
 		if !field.IsExported() {
 			continue
 		}
-
-		// Handle embedded structs (squash)
-		if field.Anonymous || hasSquashTag(field) {
-			embedded := extractMapstructureKeysFromType(field.Type)
-			keys = append(keys, embedded...)
-			continue
+		if k := mapstructureKeyForField(field); k != "" {
+			keys = append(keys, k)
+		} else if field.Anonymous || hasSquashTag(field) {
+			keys = append(keys, extractMapstructureKeysFromType(field.Type)...)
 		}
-
-		// Get mapstructure tag
-		tag := field.Tag.Get("mapstructure")
-
-		// Skip fields explicitly marked to ignore
-		if tag == "-" {
-			continue
-		}
-
-		// Parse tag (handle "name,omitempty" format)
-		if tag != "" {
-			parts := strings.Split(tag, ",")
-			name := parts[0]
-			if name != "" && name != "-" {
-				keys = append(keys, name)
-				continue
-			}
-		}
-
-		// No mapstructure tag or empty name - use lowercase field name
-		// mapstructure matches by lowercase field name when no tag is specified
-		keys = append(keys, strings.ToLower(field.Name))
 	}
-
 	return keys
+}
+
+// mapstructureKeyForField returns the configuration key name for a struct field,
+// or "" when the field should be skipped or expanded (embedded/squashed structs).
+// Priority: explicit mapstructure tag → lowercase field name. Returns "" for
+// ignored ("-") fields and for anonymous/squashed fields (handled by caller).
+func mapstructureKeyForField(field reflect.StructField) string {
+	// Embedded/squashed structs are expanded by the caller.
+	if field.Anonymous || hasSquashTag(field) {
+		return ""
+	}
+	tag := field.Tag.Get("mapstructure")
+	if tag == "-" {
+		return ""
+	}
+	if tag != "" {
+		if name := strings.SplitN(tag, ",", 2)[0]; name != "" && name != "-" {
+			return name
+		}
+	}
+	// No mapstructure tag or empty name - use lowercase field name.
+	return strings.ToLower(field.Name)
 }
 
 // hasSquashTag checks if a struct field has the mapstructure ",squash" tag option.

--- a/cli/config_webhook.go
+++ b/cli/config_webhook.go
@@ -142,57 +142,61 @@ func parseWebhookName(sectionName string) string {
 //
 //nolint:unparam // error return kept for future validation additions
 func parseWebhookConfig(section *ini.Section, config *middlewares.WebhookConfig) error {
+	applyWebhookINIStrings(section, config)
+	applyWebhookINIDurations(section, config)
+	applyWebhookINIInts(section, config)
+	return nil
+}
+
+// applyWebhookINIStrings reads the string-typed webhook INI keys into config.
+func applyWebhookINIStrings(section *ini.Section, config *middlewares.WebhookConfig) {
 	if key, err := section.GetKey("preset"); err == nil {
 		config.Preset = ExpandEnvVars(key.String())
 	}
-
 	if key, err := section.GetKey("id"); err == nil {
 		config.ID = ExpandEnvVars(key.String())
 	}
-
 	if key, err := section.GetKey("secret"); err == nil {
 		config.Secret = ExpandEnvVars(key.String())
 	}
-
 	if key, err := section.GetKey("url"); err == nil {
 		config.URL = ExpandEnvVars(key.String())
 	}
-
 	if key, err := section.GetKey("trigger"); err == nil {
 		config.Trigger = middlewares.TriggerType(ExpandEnvVars(key.String()))
 	}
+	if key, err := section.GetKey("link"); err == nil {
+		config.Link = ExpandEnvVars(key.String())
+	}
+	if key, err := section.GetKey("link-text"); err == nil {
+		config.LinkText = ExpandEnvVars(key.String())
+	}
+	if key, err := section.GetKey("device"); err == nil {
+		config.Device = ExpandEnvVars(key.String())
+	}
+}
 
+// applyWebhookINIDurations reads duration-typed webhook INI keys into config.
+func applyWebhookINIDurations(section *ini.Section, config *middlewares.WebhookConfig) {
 	if key, err := section.GetKey("timeout"); err == nil {
 		if d, err := key.Duration(); err == nil {
 			config.Timeout = d
 		}
 	}
-
-	if key, err := section.GetKey("retry-count"); err == nil {
-		if n, err := key.Int(); err == nil {
-			config.RetryCount = n
-		}
-	}
-
 	if key, err := section.GetKey("retry-delay"); err == nil {
 		if d, err := key.Duration(); err == nil {
 			config.RetryDelay = d
 		}
 	}
+}
 
-	if key, err := section.GetKey("link"); err == nil {
-		config.Link = ExpandEnvVars(key.String())
+// applyWebhookINIInts reads integer-typed webhook INI keys into config.
+func applyWebhookINIInts(section *ini.Section, config *middlewares.WebhookConfig) {
+	if key, err := section.GetKey("retry-count"); err == nil {
+		if n, err := key.Int(); err == nil {
+			config.RetryCount = n
+		}
 	}
-
-	if key, err := section.GetKey("link-text"); err == nil {
-		config.LinkText = ExpandEnvVars(key.String())
-	}
-
-	if key, err := section.GetKey("device"); err == nil {
-		config.Device = ExpandEnvVars(key.String())
-	}
-
-	return nil
 }
 
 // JobWebhookConfig holds per-job webhook configuration

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -277,54 +277,67 @@ func (c *DaemonCommand) start() error {
 	}
 	c.Logger.Info("Scheduler started", "jobCount", jobCount)
 
-	if c.EnablePprof {
-		c.Logger.Info(fmt.Sprintf("Starting pprof server on %s...", c.PprofAddr))
-		pprofErrChan := make(chan error, 1)
-		go func() {
-			if err := c.pprofServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-				c.Logger.Error(fmt.Sprintf("Error starting HTTP server: %v", err))
-				pprofErrChan <- err
-				c.closeDone()
-			}
-		}()
-
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		if err := waitForServerWithErrChan(ctx, c.PprofAddr, pprofErrChan); err != nil {
-			c.Logger.Error(fmt.Sprintf("pprof server failed to start: %v", err))
-			return fmt.Errorf("pprof server startup failed: %w", err)
-		}
-		c.Logger.Info(fmt.Sprintf("pprof server ready on %s", c.PprofAddr))
-	} else {
-		c.Logger.Info("pprof server disabled")
+	if err := c.startPprofServer(); err != nil {
+		return err
 	}
-
-	if c.EnableWeb {
-		c.Logger.Info(fmt.Sprintf("Starting web server on %s...", c.WebAddr))
-		webErrChan := make(chan error, 1)
-		go func() {
-			if err := c.webServer.Start(); err != nil {
-				c.Logger.Error(fmt.Sprintf("Error starting web server: %v", err))
-				webErrChan <- err
-				c.closeDone()
-			}
-		}()
-
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		if err := waitForServerWithErrChan(ctx, c.WebAddr, webErrChan); err != nil {
-			c.Logger.Error(fmt.Sprintf("web server failed to start: %v", err))
-			return fmt.Errorf("web server startup failed: %w", err)
-		}
-		c.Logger.Info(fmt.Sprintf("Web UI ready at http://%s", c.WebAddr))
-	} else {
-		c.Logger.Info("web server disabled")
+	if err := c.startWebServer(); err != nil {
+		return err
 	}
 
 	c.Logger.Info("Ofelia is now running. Press Ctrl+C to stop.")
 
+	return nil
+}
+
+// startPprofServer starts the pprof HTTP server when enabled, or logs that it
+// is disabled. Returns an error when the server fails to become ready within 5 s.
+func (c *DaemonCommand) startPprofServer() error {
+	if !c.EnablePprof {
+		c.Logger.Info("pprof server disabled")
+		return nil
+	}
+	c.Logger.Info(fmt.Sprintf("Starting pprof server on %s...", c.PprofAddr))
+	pprofErrChan := make(chan error, 1)
+	go func() {
+		if err := c.pprofServer.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+			c.Logger.Error(fmt.Sprintf("Error starting HTTP server: %v", err))
+			pprofErrChan <- err
+			c.closeDone()
+		}
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := waitForServerWithErrChan(ctx, c.PprofAddr, pprofErrChan); err != nil {
+		c.Logger.Error(fmt.Sprintf("pprof server failed to start: %v", err))
+		return fmt.Errorf("pprof server startup failed: %w", err)
+	}
+	c.Logger.Info(fmt.Sprintf("pprof server ready on %s", c.PprofAddr))
+	return nil
+}
+
+// startWebServer starts the web UI server when enabled, or logs that it is
+// disabled. Returns an error when the server fails to become ready within 5 s.
+func (c *DaemonCommand) startWebServer() error {
+	if !c.EnableWeb {
+		c.Logger.Info("web server disabled")
+		return nil
+	}
+	c.Logger.Info(fmt.Sprintf("Starting web server on %s...", c.WebAddr))
+	webErrChan := make(chan error, 1)
+	go func() {
+		if err := c.webServer.Start(); err != nil {
+			c.Logger.Error(fmt.Sprintf("Error starting web server: %v", err))
+			webErrChan <- err
+			c.closeDone()
+		}
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := waitForServerWithErrChan(ctx, c.WebAddr, webErrChan); err != nil {
+		c.Logger.Error(fmt.Sprintf("web server failed to start: %v", err))
+		return fmt.Errorf("web server startup failed: %w", err)
+	}
+	c.Logger.Info(fmt.Sprintf("Web UI ready at http://%s", c.WebAddr))
 	return nil
 }
 
@@ -578,62 +591,82 @@ func (c *DaemonCommand) persistedJobToScheduler(name string, j *persist.Job) (co
 	validator := cfgvalidator.NewCommandValidator()
 	switch j.Type {
 	case persist.JobTypeRun:
-		if provider == nil {
-			return nil, fmt.Errorf("docker provider unavailable for run job")
-		}
-		rj := core.NewRunJob(provider)
-		rj.Name = name
-		rj.Schedule = j.Schedule
-		rj.Command = j.Command
-		rj.Image = j.Image
-		rj.Container = j.Container
-		return rj, nil
+		return c.buildPersistedRunJob(name, j, provider)
 	case persist.JobTypeExec:
-		if provider == nil {
-			return nil, fmt.Errorf("docker provider unavailable for exec job")
-		}
-		ej := core.NewExecJob(provider)
-		ej.Name = name
-		ej.Schedule = j.Schedule
-		ej.Command = j.Command
-		ej.Container = j.Container
-		return ej, nil
+		return c.buildPersistedExecJob(name, j, provider)
 	case persist.JobTypeCompose:
-		if j.File != "" {
-			if err := validator.ValidateFilePath(j.File); err != nil {
-				return nil, fmt.Errorf("invalid compose file path: %w", err)
-			}
-		}
-		if err := validator.ValidateServiceName(j.Service); err != nil {
-			return nil, fmt.Errorf("invalid service name: %w", err)
-		}
-		if j.Command != "" {
-			if err := validator.ValidateCommandArgs(args.GetArgs(j.Command)); err != nil {
-				return nil, fmt.Errorf("invalid command arguments: %w", err)
-			}
-		}
-		cj := &core.ComposeJob{}
-		cj.Name = name
-		cj.Schedule = j.Schedule
-		cj.Command = j.Command
-		cj.File = j.File
-		cj.Service = j.Service
-		cj.Exec = j.Exec
-		return cj, nil
+		return buildPersistedComposeJob(name, j, validator)
 	case persist.JobTypeLocal, "":
-		if j.Command != "" {
-			if err := validator.ValidateCommandArgs(args.GetArgs(j.Command)); err != nil {
-				return nil, fmt.Errorf("invalid command arguments: %w", err)
-			}
-		}
-		lj := &core.LocalJob{}
-		lj.Name = name
-		lj.Schedule = j.Schedule
-		lj.Command = j.Command
-		return lj, nil
+		return buildPersistedLocalJob(name, j, validator)
 	default:
 		return nil, fmt.Errorf("unknown job type %q", j.Type)
 	}
+}
+
+// buildPersistedRunJob materializes a persist.JobTypeRun into a core.RunJob.
+func (c *DaemonCommand) buildPersistedRunJob(name string, j *persist.Job, provider core.DockerProvider) (core.Job, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("docker provider unavailable for run job")
+	}
+	rj := core.NewRunJob(provider)
+	rj.Name = name
+	rj.Schedule = j.Schedule
+	rj.Command = j.Command
+	rj.Image = j.Image
+	rj.Container = j.Container
+	return rj, nil
+}
+
+// buildPersistedExecJob materializes a persist.JobTypeExec into a core.ExecJob.
+func (c *DaemonCommand) buildPersistedExecJob(name string, j *persist.Job, provider core.DockerProvider) (core.Job, error) {
+	if provider == nil {
+		return nil, fmt.Errorf("docker provider unavailable for exec job")
+	}
+	ej := core.NewExecJob(provider)
+	ej.Name = name
+	ej.Schedule = j.Schedule
+	ej.Command = j.Command
+	ej.Container = j.Container
+	return ej, nil
+}
+
+// buildPersistedComposeJob materializes a persist.JobTypeCompose into a core.ComposeJob.
+func buildPersistedComposeJob(name string, j *persist.Job, validator *cfgvalidator.CommandValidator) (core.Job, error) {
+	if j.File != "" {
+		if err := validator.ValidateFilePath(j.File); err != nil {
+			return nil, fmt.Errorf("invalid compose file path: %w", err)
+		}
+	}
+	if err := validator.ValidateServiceName(j.Service); err != nil {
+		return nil, fmt.Errorf("invalid service name: %w", err)
+	}
+	if j.Command != "" {
+		if err := validator.ValidateCommandArgs(args.GetArgs(j.Command)); err != nil {
+			return nil, fmt.Errorf("invalid command arguments: %w", err)
+		}
+	}
+	cj := &core.ComposeJob{}
+	cj.Name = name
+	cj.Schedule = j.Schedule
+	cj.Command = j.Command
+	cj.File = j.File
+	cj.Service = j.Service
+	cj.Exec = j.Exec
+	return cj, nil
+}
+
+// buildPersistedLocalJob materializes a persist.JobTypeLocal into a core.LocalJob.
+func buildPersistedLocalJob(name string, j *persist.Job, validator *cfgvalidator.CommandValidator) (core.Job, error) {
+	if j.Command != "" {
+		if err := validator.ValidateCommandArgs(args.GetArgs(j.Command)); err != nil {
+			return nil, fmt.Errorf("invalid command arguments: %w", err)
+		}
+	}
+	lj := &core.LocalJob{}
+	lj.Name = name
+	lj.Schedule = j.Schedule
+	lj.Command = j.Command
+	return lj, nil
 }
 
 // validatePersistedJobName mirrors web.validateJobName but lives in

--- a/cli/docker-labels.go
+++ b/cli/docker-labels.go
@@ -234,27 +234,37 @@ func canRunJobOnContainer(jobType string, jobName string, containerName string, 
 
 // applyJobParameterToJobMaps updates the appropriate job map for the given parameter.
 // It is extracted to keep splitContainersLabelsIntoJobMapsByType cyclomatic complexity under the linter limit.
+// containerJobMaps groups the per-type job maps applied while processing a
+// single container's labels, keeping applyJobParameterToJobMaps's signature small.
+type containerJobMaps struct {
+	exec    map[string]map[string]any
+	local   map[string]map[string]any
+	run     map[string]map[string]any
+	service map[string]map[string]any
+	compose map[string]map[string]any
+}
+
 func applyJobParameterToJobMaps(
 	jobType, jobName, jobParam, paramValue string,
 	scopedJobName string,
-	execJobs, localJobs, containerRunJobs, serviceJobs, composeJobs map[string]map[string]any,
+	jm *containerJobMaps,
 ) {
 	switch jobType {
 	case jobExec:
-		ensureJob(execJobs, scopedJobName)
-		setJobParam(execJobs[scopedJobName], jobParam, paramValue)
+		ensureJob(jm.exec, scopedJobName)
+		setJobParam(jm.exec[scopedJobName], jobParam, paramValue)
 	case jobLocal:
-		ensureJob(localJobs, jobName)
-		setJobParam(localJobs[jobName], jobParam, paramValue)
+		ensureJob(jm.local, jobName)
+		setJobParam(jm.local[jobName], jobParam, paramValue)
 	case jobServiceRun:
-		ensureJob(serviceJobs, jobName)
-		setJobParam(serviceJobs[jobName], jobParam, paramValue)
+		ensureJob(jm.service, jobName)
+		setJobParam(jm.service[jobName], jobParam, paramValue)
 	case jobRun:
-		ensureJob(containerRunJobs, jobName)
-		setJobParam(containerRunJobs[jobName], jobParam, paramValue)
+		ensureJob(jm.run, jobName)
+		setJobParam(jm.run[jobName], jobParam, paramValue)
 	case jobCompose:
-		ensureJob(composeJobs, jobName)
-		setJobParam(composeJobs[jobName], jobParam, paramValue)
+		ensureJob(jm.compose, jobName)
+		setJobParam(jm.compose[jobName], jobParam, paramValue)
 	}
 }
 
@@ -405,7 +415,13 @@ func (c *Config) processContainerLabel(m *dockerLabelJobMaps, cs *containerScan,
 	}
 
 	applyJobParameterToJobMaps(jobType, jobName, jobParam, jobParamValue, scopedName,
-		cs.execJobs, m.localJobs, cs.runJobs, m.serviceJobs, m.composeJobs)
+		&containerJobMaps{
+			exec:    cs.execJobs,
+			local:   m.localJobs,
+			run:     cs.runJobs,
+			service: m.serviceJobs,
+			compose: m.composeJobs,
+		})
 }
 
 func addContainerNameToJobsIfNeeded(jobs map[string]map[string]any, containerName string) {

--- a/cli/docker_config_handler.go
+++ b/cli/docker_config_handler.go
@@ -568,10 +568,10 @@ func (c *DockerHandler) processEventStream(
 				// Channel closed, reconnect
 				return true, backoff
 			}
-			// Success - reset backoff and clear failed state
+			// Success - reset backoff and keep processing on the same subscription.
+			backoff = watchEventsInitialBackoff
 			c.clearEventStreamError()
 			c.refreshContainerLabels()
-			return true, watchEventsInitialBackoff
 		}
 	}
 }

--- a/cli/docker_config_handler.go
+++ b/cli/docker_config_handler.go
@@ -289,14 +289,21 @@ func (c *DockerHandler) watchConfig() {
 		case <-c.ctx.Done():
 			return
 		case <-ticker.C:
-			if cfg, ok := c.notifier.(*Config); ok {
-				cfg.logger.Debug(fmt.Sprintf("checking config file %s", cfg.configPath))
-				if err := cfg.iniConfigUpdate(); err != nil {
-					if !errors.Is(err, os.ErrNotExist) {
-						c.logger.Warn(fmt.Sprintf("%v", err))
-					}
-				}
-			}
+			c.pollConfigFile()
+		}
+	}
+}
+
+// pollConfigFile triggers a config file reload when the notifier is a *Config.
+func (c *DockerHandler) pollConfigFile() {
+	cfg, ok := c.notifier.(*Config)
+	if !ok {
+		return
+	}
+	cfg.logger.Debug(fmt.Sprintf("checking config file %s", cfg.configPath))
+	if err := cfg.iniConfigUpdate(); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			c.logger.Warn(fmt.Sprintf("%v", err))
 		}
 	}
 }
@@ -364,22 +371,9 @@ func (c *DockerHandler) refreshContainerLabels() {
 }
 
 func (c *DockerHandler) GetDockerContainers() ([]DockerContainerInfo, error) {
-	filters := map[string][]string{
-		"label": {requiredLabelFilter},
-	}
-	for _, f := range c.filters {
-		parts := strings.SplitN(f, "=", 2)
-		if len(parts) != 2 {
-			//nolint:revive // Error message intentionally verbose for UX (actionable troubleshooting hints)
-			return nil, fmt.Errorf("invalid docker filter %q\n  → Filters must use key=value format (e.g., 'label=app=web')\n  → Valid filter keys: label, name, id, status, network\n  → Example: --docker-filter='label=environment=production'\n  → Check your OFELIA_DOCKER_FILTER environment variable or config file", f)
-		}
-		key, value := parts[0], parts[1]
-		values, ok := filters[key]
-		if ok {
-			filters[key] = append(values, value)
-		} else {
-			filters[key] = []string{value}
-		}
+	filters, err := c.buildContainerFilters()
+	if err != nil {
+		return nil, err
 	}
 
 	conts, err := c.dockerProvider.ListContainers(c.ctx, domain.ListOptions{
@@ -395,32 +389,62 @@ func (c *DockerHandler) GetDockerContainers() ([]DockerContainerInfo, error) {
 		return nil, ErrNoContainerWithOfeliaEnabled
 	}
 
-	containers := make([]DockerContainerInfo, 0, len(conts))
+	return c.filterContainerInfos(conts), nil
+}
 
+// buildContainerFilters constructs the Docker API filter map from the handler's
+// configured filters. Returns an error if any filter is malformed.
+func (c *DockerHandler) buildContainerFilters() (map[string][]string, error) {
+	filters := map[string][]string{
+		"label": {requiredLabelFilter},
+	}
+	for _, f := range c.filters {
+		parts := strings.SplitN(f, "=", 2)
+		if len(parts) != 2 {
+			//nolint:revive // Error message intentionally verbose for UX (actionable troubleshooting hints)
+			return nil, fmt.Errorf("invalid docker filter %q\n  → Filters must use key=value format (e.g., 'label=app=web')\n  → Valid filter keys: label, name, id, status, network\n  → Example: --docker-filter='label=environment=production'\n  → Check your OFELIA_DOCKER_FILTER environment variable or config file", f)
+		}
+		key, value := parts[0], parts[1]
+		if existing, ok := filters[key]; ok {
+			filters[key] = append(existing, value)
+		} else {
+			filters[key] = []string{value}
+		}
+	}
+	return filters, nil
+}
+
+// filterContainerInfos converts raw container list entries to DockerContainerInfo,
+// keeping only containers that have a name and at least one Ofelia label.
+func (c *DockerHandler) filterContainerInfos(conts []domain.Container) []DockerContainerInfo {
+	containers := make([]DockerContainerInfo, 0, len(conts))
 	for _, cont := range conts {
 		if cont.Name == "" || len(cont.Labels) == 0 {
 			continue
 		}
-		ofeliaLabels := make(map[string]string)
-		for k, v := range cont.Labels {
-			if strings.HasPrefix(k, labelPrefix) || k == dockerComposeServiceLabel {
-				ofeliaLabels[k] = v
-			}
-		}
+		ofeliaLabels := extractOfeliaLabels(cont.Labels)
 		if len(ofeliaLabels) == 0 {
 			continue
 		}
-		name := cont.Name
-		containerInfo := DockerContainerInfo{
-			Name:    name,
+		containers = append(containers, DockerContainerInfo{
+			Name:    cont.Name,
 			Created: cont.Created,
 			State:   cont.State,
 			Labels:  ofeliaLabels,
-		}
-		containers = append(containers, containerInfo)
+		})
 	}
+	return containers
+}
 
-	return containers, nil
+// extractOfeliaLabels filters a raw label map to only the keys relevant to Ofelia.
+func extractOfeliaLabels(labels map[string]string) map[string]string {
+	result := make(map[string]string)
+	for k, v := range labels {
+		if strings.HasPrefix(k, labelPrefix) || k == dockerComposeServiceLabel {
+			result[k] = v
+		}
+	}
+	return result
 }
 
 // handleEventStreamError marks the event stream as failed and starts fallback polling if configured.
@@ -461,12 +485,11 @@ func (c *DockerHandler) clearEventStreamError() {
 
 func (c *DockerHandler) watchEvents() {
 	const (
-		initialBackoff = 1 * time.Second
-		maxBackoff     = 5 * time.Minute
-		backoffFactor  = 2
+		maxBackoff    = 5 * time.Minute
+		backoffFactor = 2
 	)
 
-	backoff := initialBackoff
+	backoff := watchEventsInitialBackoff
 
 	for {
 		// Check if context is canceled before attempting subscription
@@ -476,65 +499,85 @@ func (c *DockerHandler) watchEvents() {
 		default:
 		}
 
-		eventCh, errCh := c.dockerProvider.SubscribeEvents(c.ctx, domain.EventFilter{
-			Filters: map[string][]string{
-				"type":  {dockerEventTypeContainer},
-				"label": {"ofelia.enabled=true"},
-				"event": {
-					// Lifecycle events
-					domain.EventActionCreate,
-					domain.EventActionStart,
-					domain.EventActionRestart,
-					domain.EventActionStop,
-					domain.EventActionKill,
-					domain.EventActionDie,
-					domain.EventActionDestroy,
-					// Management events
-					domain.EventActionPause,
-					domain.EventActionUnpause,
-					domain.EventActionRename,
-					domain.EventActionUpdate,
-				},
-			},
-		})
-
-		// Inner loop: process events until error or shutdown
-	innerLoop:
-		for {
-			select {
-			case <-c.ctx.Done():
-				return
-			case err, ok := <-errCh:
-				if !ok {
-					// Channel closed, exit inner loop to reconnect
-					break innerLoop
-				}
-				if err != nil {
-					c.logger.Warn(fmt.Sprintf("Docker event stream error, reconnecting in %v: %v", backoff, err))
-					c.handleEventStreamError()
-				}
-				// Wait with backoff before reconnecting
-				select {
-				case <-c.ctx.Done():
-					return
-				case <-time.After(backoff):
-				}
-				// Increase backoff for next failure (capped at maxBackoff)
-				backoff = min(time.Duration(float64(backoff)*backoffFactor), maxBackoff)
-				break innerLoop // Exit inner loop to reconnect
-			case _, ok := <-eventCh:
-				if !ok {
-					// Channel closed, exit inner loop to reconnect
-					break innerLoop
-				}
-				// Success - reset backoff and clear failed state
-				backoff = initialBackoff
-				c.clearEventStreamError()
-				c.refreshContainerLabels()
-			}
+		eventCh, errCh := c.dockerProvider.SubscribeEvents(c.ctx, c.buildEventFilter())
+		reconnect, newBackoff := c.processEventStream(eventCh, errCh, backoff, maxBackoff, backoffFactor)
+		backoff = newBackoff
+		if !reconnect {
+			return
 		}
 	}
 }
+
+// buildEventFilter constructs the Docker event subscription filter for container events.
+func (c *DockerHandler) buildEventFilter() domain.EventFilter {
+	return domain.EventFilter{
+		Filters: map[string][]string{
+			"type":  {dockerEventTypeContainer},
+			"label": {"ofelia.enabled=true"},
+			"event": {
+				// Lifecycle events
+				domain.EventActionCreate,
+				domain.EventActionStart,
+				domain.EventActionRestart,
+				domain.EventActionStop,
+				domain.EventActionKill,
+				domain.EventActionDie,
+				domain.EventActionDestroy,
+				// Management events
+				domain.EventActionPause,
+				domain.EventActionUnpause,
+				domain.EventActionRename,
+				domain.EventActionUpdate,
+			},
+		},
+	}
+}
+
+// processEventStream runs the inner receive loop for one event-stream subscription.
+// Returns (reconnect=true, updatedBackoff) when the caller should reconnect, or
+// (reconnect=false, _) when the context is done and the outer loop should exit.
+func (c *DockerHandler) processEventStream(
+	eventCh <-chan domain.Event,
+	errCh <-chan error,
+	backoff, maxBackoff time.Duration,
+	backoffFactor float64,
+) (reconnect bool, newBackoff time.Duration) {
+	for {
+		select {
+		case <-c.ctx.Done():
+			return false, backoff
+		case err, ok := <-errCh:
+			if !ok {
+				// Channel closed, reconnect
+				return true, backoff
+			}
+			if err != nil {
+				c.logger.Warn(fmt.Sprintf("Docker event stream error, reconnecting in %v: %v", backoff, err))
+				c.handleEventStreamError()
+			}
+			// Wait with backoff before reconnecting
+			select {
+			case <-c.ctx.Done():
+				return false, backoff
+			case <-time.After(backoff):
+			}
+			// Increase backoff for next failure (capped at maxBackoff)
+			return true, min(time.Duration(float64(backoff)*backoffFactor), maxBackoff)
+		case _, ok := <-eventCh:
+			if !ok {
+				// Channel closed, reconnect
+				return true, backoff
+			}
+			// Success - reset backoff and clear failed state
+			c.clearEventStreamError()
+			c.refreshContainerLabels()
+			return true, watchEventsInitialBackoff
+		}
+	}
+}
+
+// watchEventsInitialBackoff is the reset value for the watchEvents reconnect backoff.
+const watchEventsInitialBackoff = 1 * time.Second
 
 func (c *DockerHandler) Shutdown(ctx context.Context) error {
 	if c.cancel != nil {

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -430,90 +430,35 @@ func (c *DoctorCommand) checkSchedules(report *DoctorReport) {
 		return
 	}
 
-	allValid := true
-
-	// Check run jobs
+	// scheduleMap maps job-type label prefix to (jobName→schedule) pairs.
+	type jobSchedule struct{ kind, name, schedule string }
+	var jobs []jobSchedule
 	for name, job := range conf.RunJobs {
-		if err := validateCronSchedule(job.Schedule); err != nil {
-			allValid = false
-			report.Healthy = false
-			report.Checks = append(report.Checks, CheckResult{
-				Category: categoryJobSchedules,
-				Name:     fmt.Sprintf("job-run \"%s\"", name),
-				Status:   statusFail,
-				Message:  fmt.Sprintf(msgInvalidScheduleFmt, job.Schedule, err),
-				Hints: []string{
-					hintScheduleExamples,
-					hintScheduleTest,
-				},
-			})
-		}
+		jobs = append(jobs, jobSchedule{jobRun, name, job.Schedule})
 	}
-
-	// Check local jobs
 	for name, job := range conf.LocalJobs {
-		if err := validateCronSchedule(job.Schedule); err != nil {
-			allValid = false
-			report.Healthy = false
-			report.Checks = append(report.Checks, CheckResult{
-				Category: categoryJobSchedules,
-				Name:     fmt.Sprintf("job-local \"%s\"", name),
-				Status:   statusFail,
-				Message:  fmt.Sprintf(msgInvalidScheduleFmt, job.Schedule, err),
-				Hints: []string{
-					hintScheduleExamples,
-					hintScheduleTest,
-				},
-			})
-		}
+		jobs = append(jobs, jobSchedule{jobLocal, name, job.Schedule})
 	}
-
-	// Check exec jobs
 	for name, job := range conf.ExecJobs {
-		if err := validateCronSchedule(job.Schedule); err != nil {
-			allValid = false
-			report.Healthy = false
-			report.Checks = append(report.Checks, CheckResult{
-				Category: categoryJobSchedules,
-				Name:     fmt.Sprintf("job-exec \"%s\"", name),
-				Status:   statusFail,
-				Message:  fmt.Sprintf(msgInvalidScheduleFmt, job.Schedule, err),
-				Hints: []string{
-					hintScheduleExamples,
-					hintScheduleTest,
-				},
-			})
-		}
+		jobs = append(jobs, jobSchedule{jobExec, name, job.Schedule})
 	}
-
-	// Check service-run jobs
 	for name, job := range conf.ServiceJobs {
-		if err := validateCronSchedule(job.Schedule); err != nil {
-			allValid = false
-			report.Healthy = false
-			report.Checks = append(report.Checks, CheckResult{
-				Category: categoryJobSchedules,
-				Name:     fmt.Sprintf("job-service-run \"%s\"", name),
-				Status:   statusFail,
-				Message:  fmt.Sprintf(msgInvalidScheduleFmt, job.Schedule, err),
-				Hints: []string{
-					hintScheduleExamples,
-					hintScheduleTest,
-				},
-			})
-		}
+		jobs = append(jobs, jobSchedule{jobServiceRun, name, job.Schedule})
+	}
+	for name, job := range conf.ComposeJobs {
+		jobs = append(jobs, jobSchedule{jobCompose, name, job.Schedule})
 	}
 
-	// Check compose jobs
-	for name, job := range conf.ComposeJobs {
-		if err := validateCronSchedule(job.Schedule); err != nil {
+	allValid := true
+	for _, j := range jobs {
+		if err := validateCronSchedule(j.schedule); err != nil {
 			allValid = false
 			report.Healthy = false
 			report.Checks = append(report.Checks, CheckResult{
 				Category: categoryJobSchedules,
-				Name:     fmt.Sprintf("job-compose \"%s\"", name),
+				Name:     fmt.Sprintf("%s \"%s\"", j.kind, j.name),
 				Status:   statusFail,
-				Message:  fmt.Sprintf(msgInvalidScheduleFmt, job.Schedule, err),
+				Message:  fmt.Sprintf(msgInvalidScheduleFmt, j.schedule, err),
 				Hints: []string{
 					hintScheduleExamples,
 					hintScheduleTest,
@@ -523,13 +468,11 @@ func (c *DoctorCommand) checkSchedules(report *DoctorReport) {
 	}
 
 	if allValid {
-		totalJobs := len(conf.RunJobs) + len(conf.LocalJobs) +
-			len(conf.ExecJobs) + len(conf.ServiceJobs) + len(conf.ComposeJobs)
 		report.Checks = append(report.Checks, CheckResult{
 			Category: categoryJobSchedules,
 			Name:     "All Schedules Valid",
 			Status:   statusPass,
-			Message:  fmt.Sprintf("%d schedule(s) validated", totalJobs),
+			Message:  fmt.Sprintf("%d schedule(s) validated", len(jobs)),
 		})
 	}
 }
@@ -644,36 +587,32 @@ func (c *DoctorCommand) outputHuman(report *DoctorReport) error {
 		if !exists {
 			continue
 		}
-
-		icon := getCategoryIcon(category)
-		c.Logger.Info(fmt.Sprintf("%s %s", icon, category))
-
+		c.Logger.Info(fmt.Sprintf("%s %s", getCategoryIcon(category), category))
 		for _, check := range checks {
-			statusIcon := getStatusIcon(check.Status)
-			if check.Message != "" {
-				c.Logger.Info(fmt.Sprintf("  %s %s: %s", statusIcon, check.Name, check.Message))
-			} else {
-				c.Logger.Info(fmt.Sprintf("  %s %s", statusIcon, check.Name))
-			}
-
-			// Output hints
-			for _, hint := range check.Hints {
-				c.Logger.Info(fmt.Sprintf("    → %s", hint))
-			}
+			c.logCheckResult(check)
 		}
 		c.Logger.Info("")
 	}
 
-	// Summary
-	failCount := 0
-	skipCount := 0
-	for _, check := range report.Checks {
-		if check.Status == statusFail {
-			failCount++
-		} else if check.Status == statusSkip {
-			skipCount++
-		}
+	return c.outputHumanSummary(report)
+}
+
+// logCheckResult prints a single check result line and its hints.
+func (c *DoctorCommand) logCheckResult(check CheckResult) {
+	statusIcon := getStatusIcon(check.Status)
+	if check.Message != "" {
+		c.Logger.Info(fmt.Sprintf("  %s %s: %s", statusIcon, check.Name, check.Message))
+	} else {
+		c.Logger.Info(fmt.Sprintf("  %s %s", statusIcon, check.Name))
 	}
+	for _, hint := range check.Hints {
+		c.Logger.Info(fmt.Sprintf("    → %s", hint))
+	}
+}
+
+// outputHumanSummary prints the pass/fail summary line and returns an error when unhealthy.
+func (c *DoctorCommand) outputHumanSummary(report *DoctorReport) error {
+	failCount, skipCount := countCheckStatuses(report.Checks)
 
 	if report.Healthy {
 		c.Logger.Info("Summary: All checks passed")
@@ -688,6 +627,19 @@ func (c *DoctorCommand) outputHuman(report *DoctorReport) error {
 		c.Logger.Info(fmt.Sprintf("  (%d check(s) skipped due to blockers)", skipCount))
 	}
 	return fmt.Errorf("health check failed")
+}
+
+// countCheckStatuses returns the number of failed and skipped checks.
+func countCheckStatuses(checks []CheckResult) (failCount, skipCount int) {
+	for _, check := range checks {
+		switch check.Status {
+		case statusFail:
+			failCount++
+		case statusSkip:
+			skipCount++
+		}
+	}
+	return failCount, skipCount
 }
 
 // getCategoryIcon returns emoji for category

--- a/cli/doctor.go
+++ b/cli/doctor.go
@@ -430,7 +430,7 @@ func (c *DoctorCommand) checkSchedules(report *DoctorReport) {
 		return
 	}
 
-	// scheduleMap maps job-type label prefix to (jobName→schedule) pairs.
+	// Collect every job's (kind, name, schedule) so all types validate in one loop.
 	type jobSchedule struct{ kind, name, schedule string }
 	var jobs []jobSchedule
 	for name, job := range conf.RunJobs {

--- a/cli/init.go
+++ b/cli/init.go
@@ -112,7 +112,7 @@ type runJobConfig struct {
 	Delete   bool
 }
 
-func (j *runJobConfig) Type() string { return "job-run" }
+func (j *runJobConfig) Type() string { return jobRun }
 func (j *runJobConfig) Name() string { return j.JobName }
 func (j *runJobConfig) ToINI(section *ini.Section) error {
 	section.Key("schedule").SetValue(j.Schedule)
@@ -138,7 +138,7 @@ type localJobConfig struct {
 	Dir      string
 }
 
-func (j *localJobConfig) Type() string { return "job-local" }
+func (j *localJobConfig) Type() string { return jobLocal }
 func (j *localJobConfig) Name() string { return j.JobName }
 func (j *localJobConfig) ToINI(section *ini.Section) error {
 	section.Key("schedule").SetValue(j.Schedule)
@@ -390,6 +390,18 @@ func (c *InitCommand) promptRunJob() (*runJobConfig, error) {
 		return nil, err //nolint:wrapcheck // promptui errors are user interaction failures, not internal errors
 	}
 
+	if err := c.promptRunJobOptionals(job); err != nil {
+		return nil, err
+	}
+
+	return job, nil
+}
+
+// promptRunJobOptionals prompts for the optional fields of a run job: volume,
+// network, and whether to delete the container after execution.
+func (c *InitCommand) promptRunJobOptionals(job *runJobConfig) error {
+	var err error
+
 	// Volume (optional)
 	volumePrompt := promptui.Prompt{
 		Label:   "Volume mounts (optional, format: /host/path:/container/path)",
@@ -397,7 +409,7 @@ func (c *InitCommand) promptRunJob() (*runJobConfig, error) {
 	}
 	job.Volume, err = volumePrompt.Run()
 	if err != nil && !errors.Is(err, promptui.ErrAbort) {
-		return nil, err //nolint:wrapcheck // promptui errors are user interaction failures, not internal errors
+		return err //nolint:wrapcheck // promptui errors are user interaction failures, not internal errors
 	}
 
 	// Network (optional)
@@ -407,7 +419,7 @@ func (c *InitCommand) promptRunJob() (*runJobConfig, error) {
 	}
 	job.Network, err = networkPrompt.Run()
 	if err != nil && !errors.Is(err, promptui.ErrAbort) {
-		return nil, err //nolint:wrapcheck // promptui errors are user interaction failures, not internal errors
+		return err //nolint:wrapcheck // promptui errors are user interaction failures, not internal errors
 	}
 
 	// Delete container after execution
@@ -418,8 +430,7 @@ func (c *InitCommand) promptRunJob() (*runJobConfig, error) {
 	}
 	_, err = deletePrompt.Run()
 	job.Delete = err == nil
-
-	return job, nil
+	return nil
 }
 
 // promptLocalJob prompts for job-local configuration

--- a/cli/version.go
+++ b/cli/version.go
@@ -33,9 +33,14 @@ func VersionString() string {
 		return "ofelia dev"
 	}
 
-	var parts []string
-	parts = append(parts, info.GoVersion)
+	return fmt.Sprintf("ofelia dev (%s)", strings.Join(devBuildParts(info), ", "))
+}
 
+// devBuildParts assembles the parenthesised components for a dev-build version
+// string: Go toolchain version, short VCS revision, and "dirty" when there are
+// uncommitted changes.
+func devBuildParts(info *debug.BuildInfo) []string {
+	parts := []string{info.GoVersion}
 	var vcsRev, vcsModified string
 	for _, s := range info.Settings {
 		switch s.Key {
@@ -56,8 +61,7 @@ func VersionString() string {
 	if vcsModified != "" {
 		parts = append(parts, vcsModified)
 	}
-
-	return fmt.Sprintf("ofelia dev (%s)", strings.Join(parts, ", "))
+	return parts
 }
 
 // VersionCommand prints version information.

--- a/config/validator.go
+++ b/config/validator.go
@@ -203,45 +203,22 @@ func (cv *Validator2) Validate() error {
 
 // validateStruct recursively validates struct fields based on tags
 func (cv *Validator2) validateStruct(v *Validator, obj any, path string) {
-	val := reflect.ValueOf(obj)
-	if val.Kind() == reflect.Pointer {
-		if val.IsNil() {
-			return
-		}
-		val = val.Elem()
-	}
-
-	if val.Kind() != reflect.Struct {
+	val, ok := derefToStruct(obj)
+	if !ok {
 		return
 	}
 
 	typ := val.Type()
 	for fieldType := range typ.Fields() {
-		field := val.FieldByIndex(fieldType.Index)
-		fieldName := fieldType.Name
-
-		// Build field path for nested structs
-		fieldPath := fieldName
-		if path != "" {
-			fieldPath = path + "." + fieldName
-		}
-
 		// Skip unexported fields
 		if !fieldType.IsExported() {
 			continue
 		}
 
-		// Get field tags
-		gcfgTag := fieldType.Tag.Get("gcfg")
+		field := val.FieldByIndex(fieldType.Index)
 		mapstructureTag := fieldType.Tag.Get("mapstructure")
 		defaultTag := fieldType.Tag.Get("default")
-
-		// Use gcfg or mapstructure tag as field name if available
-		if gcfgTag != "" && gcfgTag != "-" {
-			fieldPath = gcfgTag
-		} else if mapstructureTag != "" && mapstructureTag != "-" && mapstructureTag != ",squash" {
-			fieldPath = mapstructureTag
-		}
+		fieldPath := resolveFieldPath(path, fieldType.Name, fieldType.Tag.Get("gcfg"), mapstructureTag)
 
 		// Handle nested structs
 		if field.Kind() == reflect.Struct && mapstructureTag != ",squash" {
@@ -252,6 +229,43 @@ func (cv *Validator2) validateStruct(v *Validator, obj any, path string) {
 		// Validate based on field type and value
 		cv.validateField(v, field, fieldPath, defaultTag)
 	}
+}
+
+// derefToStruct dereferences a pointer (if any) and returns the underlying
+// struct Value. It returns (zero, false) if obj is nil, a nil pointer, or
+// not a struct.
+func derefToStruct(obj any) (reflect.Value, bool) {
+	val := reflect.ValueOf(obj)
+	if val.Kind() == reflect.Pointer {
+		if val.IsNil() {
+			return reflect.Value{}, false
+		}
+		val = val.Elem()
+	}
+	if val.Kind() != reflect.Struct {
+		return reflect.Value{}, false
+	}
+	return val, true
+}
+
+// resolveFieldPath returns the canonical config key for a struct field.
+// It prefers the gcfg tag, then mapstructure (unless it is a squash
+// directive), and falls back to the Go field name. It also prepends
+// the parent path when non-empty.
+func resolveFieldPath(parentPath, fieldName, gcfgTag, mapstructureTag string) string {
+	fieldPath := fieldName
+	if parentPath != "" {
+		fieldPath = parentPath + "." + fieldName
+	}
+
+	// Use gcfg or mapstructure tag as field name if available
+	if gcfgTag != "" && gcfgTag != "-" {
+		return gcfgTag
+	}
+	if mapstructureTag != "" && mapstructureTag != "-" && mapstructureTag != ",squash" {
+		return mapstructureTag
+	}
+	return fieldPath
 }
 
 // validateField validates individual fields based on their type and tags

--- a/core/adapters/docker/client.go
+++ b/core/adapters/docker/client.go
@@ -281,37 +281,10 @@ func NewClientWithConfig(config *ClientConfig) (*Client, error) {
 		return nil, fmt.Errorf("creating docker client: %w", err)
 	}
 
-	// Fail-closed for tcp+tls:// without USABLE TLS material. tcp+tls:// is
-	// an EXPLICIT TLS opt-in. Invoke resolveTLSConfig so a typo or missing
-	// cert files at the path also fails closed at startup. See #627 / #646.
-	if scheme == schemeTCPTLS {
-		if !hasTLSMaterial(config) {
-			return nil, fmt.Errorf(
-				"%w: set DOCKER_CERT_PATH (or ClientConfig.TLSCertPath); see docs/TROUBLESHOOTING.md",
-				ErrTCPTLSRequiresCertMaterial,
-			)
-		}
-		if _, tlsErr := resolveTLSConfig(config); tlsErr != nil {
-			return nil, fmt.Errorf(
-				"%w: cert material at the configured path is unreadable or invalid; see docs/TROUBLESHOOTING.md: %w",
-				ErrTCPTLSRequiresCertMaterial, tlsErr,
-			)
-		}
-	}
-
-	// Fail-closed for https:// when TLS material IS configured but unloadable.
-	// Asymmetry vs tcp+tls://: https:// without ANY material is fine (operator
-	// uses system CA), so we only gate when hasTLSMaterial reports true.
-	// Without this gate, applyDockerTLS warns-and-continues with TLSClientConfig
-	// nil and the SDK dials with Go default TLS — system CA, no client cert —
-	// silently downgrading declared mTLS to unauthenticated TLS. See #653.
-	if scheme == schemeHTTPS && hasTLSMaterial(config) {
-		if _, tlsErr := resolveTLSConfig(config); tlsErr != nil {
-			return nil, fmt.Errorf(
-				"%w: cert material at the configured path is unreadable or invalid; see docs/TROUBLESHOOTING.md: %w",
-				ErrHTTPSRequiresUsableCertMaterial, tlsErr,
-			)
-		}
+	// Fail-closed for tcp+tls:// without USABLE TLS material, and for https://
+	// when material is configured but unloadable. See #627 / #646 / #653.
+	if err := validateTLSMaterial(scheme, config); err != nil {
+		return nil, err
 	}
 
 	// Mirror the docker CLI: when the host scheme is plain tcp:// AND TLS
@@ -654,6 +627,47 @@ func applyHTTPTransport(transport *http.Transport, cfg *ClientConfig, host strin
 // disableHTTP2AutoConfig call here.
 func applyPlainTransport(transport *http.Transport, _ *ClientConfig, _ string) {
 	transport.ForceAttemptHTTP2 = false
+}
+
+// validateTLSMaterial enforces the fail-closed TLS gates for NewClientWithConfig:
+//
+//   - tcp+tls://: requires TLS material to be both present and loadable (#627/#646).
+//   - https://: when TLS material IS configured, it must be loadable (#653).
+//     https:// without ANY material is fine (operator uses system CA).
+func validateTLSMaterial(scheme string, config *ClientConfig) error {
+	// Fail-closed for tcp+tls:// without USABLE TLS material. tcp+tls:// is
+	// an EXPLICIT TLS opt-in. Invoke resolveTLSConfig so a typo or missing
+	// cert files at the path also fails closed at startup. See #627 / #646.
+	if scheme == schemeTCPTLS {
+		if !hasTLSMaterial(config) {
+			return fmt.Errorf(
+				"%w: set DOCKER_CERT_PATH (or ClientConfig.TLSCertPath); see docs/TROUBLESHOOTING.md",
+				ErrTCPTLSRequiresCertMaterial,
+			)
+		}
+		if _, tlsErr := resolveTLSConfig(config); tlsErr != nil {
+			return fmt.Errorf(
+				"%w: cert material at the configured path is unreadable or invalid; see docs/TROUBLESHOOTING.md: %w",
+				ErrTCPTLSRequiresCertMaterial, tlsErr,
+			)
+		}
+	}
+
+	// Fail-closed for https:// when TLS material IS configured but unloadable.
+	// Asymmetry vs tcp+tls://: https:// without ANY material is fine (operator
+	// uses system CA), so we only gate when hasTLSMaterial reports true.
+	// Without this gate, applyDockerTLS warns-and-continues with TLSClientConfig
+	// nil and the SDK dials with Go default TLS — system CA, no client cert —
+	// silently downgrading declared mTLS to unauthenticated TLS. See #653.
+	if scheme == schemeHTTPS && hasTLSMaterial(config) {
+		if _, tlsErr := resolveTLSConfig(config); tlsErr != nil {
+			return fmt.Errorf(
+				"%w: cert material at the configured path is unreadable or invalid; see docs/TROUBLESHOOTING.md: %w",
+				ErrHTTPSRequiresUsableCertMaterial, tlsErr,
+			)
+		}
+	}
+	return nil
 }
 
 // upgradeTCPToHTTPSIfTLSMaterial mirrors the docker CLI's silent scheme

--- a/core/adapters/docker/event.go
+++ b/core/adapters/docker/event.go
@@ -48,61 +48,71 @@ func (s *EventServiceAdapter) Subscribe(ctx context.Context, filter domain.Event
 		return eventCh, errCh
 	}
 
-	go func() {
-		defer close(eventCh)
-		defer close(errCh)
-
-		// Build filters
-		opts := events.ListOptions{}
-		if !filter.Since.IsZero() {
-			opts.Since = filter.Since.Format(time.RFC3339Nano)
-		}
-		if !filter.Until.IsZero() {
-			opts.Until = filter.Until.Format(time.RFC3339Nano)
-		}
-		if len(filter.Filters) > 0 {
-			opts.Filters = filters.NewArgs()
-			for key, values := range filter.Filters {
-				for _, v := range values {
-					opts.Filters.Add(key, v)
-				}
-			}
-		}
-
-		// Subscribe to events from SDK
-		// The SDK handles cleanup automatically when context is canceled
-		sdkEventCh, sdkErrCh := s.client.Events(ctx, opts)
-
-		for {
-			select {
-			case <-ctx.Done():
-				// Context canceled - clean exit
-				return
-
-			case err := <-sdkErrCh:
-				if err != nil {
-					errCh <- convertError(err)
-				}
-				return
-
-			case sdkEvent, ok := <-sdkEventCh:
-				if !ok {
-					// Channel closed
-					return
-				}
-
-				// Convert and send event
-				event := convertFromSDKEvent(&sdkEvent)
-				select {
-				case eventCh <- event:
-				case <-ctx.Done():
-					return
-				}
-			}
-		}
-	}()
+	go s.streamEvents(ctx, filter, eventCh, errCh)
 
 	return eventCh, errCh
+}
+
+// buildEventListOptions converts a domain.EventFilter into the SDK events.ListOptions.
+func buildEventListOptions(filter domain.EventFilter) events.ListOptions {
+	opts := events.ListOptions{}
+	if !filter.Since.IsZero() {
+		opts.Since = filter.Since.Format(time.RFC3339Nano)
+	}
+	if !filter.Until.IsZero() {
+		opts.Until = filter.Until.Format(time.RFC3339Nano)
+	}
+	if len(filter.Filters) > 0 {
+		opts.Filters = filters.NewArgs()
+		for key, values := range filter.Filters {
+			for _, v := range values {
+				opts.Filters.Add(key, v)
+			}
+		}
+	}
+	return opts
+}
+
+// streamEvents drives the event loop for Subscribe. It is launched as a
+// goroutine and owns both eventCh and errCh until it returns (deferred
+// closes guarantee exactly-once close).
+func (s *EventServiceAdapter) streamEvents(ctx context.Context, filter domain.EventFilter, eventCh chan domain.Event, errCh chan error) {
+	defer close(eventCh)
+	defer close(errCh)
+
+	opts := buildEventListOptions(filter)
+
+	// Subscribe to events from SDK
+	// The SDK handles cleanup automatically when context is canceled
+	sdkEventCh, sdkErrCh := s.client.Events(ctx, opts)
+
+	for {
+		select {
+		case <-ctx.Done():
+			// Context canceled - clean exit
+			return
+
+		case err := <-sdkErrCh:
+			if err != nil {
+				errCh <- convertError(err)
+			}
+			return
+
+		case sdkEvent, ok := <-sdkEventCh:
+			if !ok {
+				// Channel closed
+				return
+			}
+
+			// Convert and send event
+			event := convertFromSDKEvent(&sdkEvent)
+			select {
+			case eventCh <- event:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
 }
 
 // SubscribeWithCallback subscribes to events with a callback.

--- a/core/adapters/docker/service.go
+++ b/core/adapters/docker/service.go
@@ -189,19 +189,22 @@ func (s *SwarmServiceAdapter) WaitForServiceTasks(ctx context.Context, serviceID
 				continue
 			}
 
-			// Check if all tasks are in terminal state
-			allTerminal := true
-			for _, task := range tasks {
-				if !task.Status.State.IsTerminalState() {
-					allTerminal = false
-					break
-				}
-			}
-			if allTerminal {
+			if allTasksTerminal(tasks) {
 				return tasks, nil
 			}
 		}
 	}
+}
+
+// allTasksTerminal returns true when every task in the slice has reached a
+// terminal state. Returns true for an empty slice (vacuously true).
+func allTasksTerminal(tasks []domain.Task) bool {
+	for _, task := range tasks {
+		if !task.Status.State.IsTerminalState() {
+			return false
+		}
+	}
+	return true
 }
 
 // Conversion functions
@@ -322,18 +325,7 @@ func convertTaskTemplateToSwarm(src *domain.TaskSpec, dst *swarm.TaskSpec) {
 	}
 
 	if src.Placement != nil {
-		dst.Placement = &swarm.Placement{
-			Constraints: src.Placement.Constraints,
-		}
-		for _, pref := range src.Placement.Preferences {
-			sp := swarm.PlacementPreference{}
-			if pref.Spread != nil {
-				sp.Spread = &swarm.SpreadOver{
-					SpreadDescriptor: pref.Spread.SpreadDescriptor,
-				}
-			}
-			dst.Placement.Preferences = append(dst.Placement.Preferences, sp)
-		}
+		dst.Placement = convertPlacementToSwarm(src.Placement)
 	}
 
 	if src.LogDriver != nil {
@@ -349,6 +341,23 @@ func convertTaskTemplateToSwarm(src *domain.TaskSpec, dst *swarm.TaskSpec) {
 			Aliases: n.Aliases,
 		})
 	}
+}
+
+// convertPlacementToSwarm converts a domain Placement to the SDK swarm.Placement.
+func convertPlacementToSwarm(src *domain.Placement) *swarm.Placement {
+	dst := &swarm.Placement{
+		Constraints: src.Constraints,
+	}
+	for _, pref := range src.Preferences {
+		sp := swarm.PlacementPreference{}
+		if pref.Spread != nil {
+			sp.Spread = &swarm.SpreadOver{
+				SpreadDescriptor: pref.Spread.SpreadDescriptor,
+			}
+		}
+		dst.Preferences = append(dst.Preferences, sp)
+	}
+	return dst
 }
 
 // convertFromSwarmService translates a Docker SDK *swarm.Service to its
@@ -471,18 +480,7 @@ func convertTaskTemplateFromSwarm(src *swarm.TaskSpec, dst *domain.TaskSpec) {
 	}
 
 	if src.Placement != nil {
-		dst.Placement = &domain.Placement{
-			Constraints: src.Placement.Constraints,
-		}
-		for _, pref := range src.Placement.Preferences {
-			dp := domain.PlacementPreference{}
-			if pref.Spread != nil {
-				dp.Spread = &domain.SpreadOver{
-					SpreadDescriptor: pref.Spread.SpreadDescriptor,
-				}
-			}
-			dst.Placement.Preferences = append(dst.Placement.Preferences, dp)
-		}
+		dst.Placement = convertPlacementFromSwarm(src.Placement)
 	}
 
 	if src.LogDriver != nil {
@@ -491,6 +489,23 @@ func convertTaskTemplateFromSwarm(src *swarm.TaskSpec, dst *domain.TaskSpec) {
 			Options: src.LogDriver.Options,
 		}
 	}
+}
+
+// convertPlacementFromSwarm converts an SDK swarm.Placement to the domain Placement.
+func convertPlacementFromSwarm(src *swarm.Placement) *domain.Placement {
+	dst := &domain.Placement{
+		Constraints: src.Constraints,
+	}
+	for _, pref := range src.Preferences {
+		dp := domain.PlacementPreference{}
+		if pref.Spread != nil {
+			dp.Spread = &domain.SpreadOver{
+				SpreadDescriptor: pref.Spread.SpreadDescriptor,
+			}
+		}
+		dst.Preferences = append(dst.Preferences, dp)
+	}
+	return dst
 }
 
 // convertFromSwarmTask translates a Docker SDK *swarm.Task to its domain

--- a/core/clock.go
+++ b/core/clock.go
@@ -212,33 +212,32 @@ func (c *FakeClock) findEarliestEvent() *time.Time {
 	var earliest *time.Time
 
 	for _, t := range c.tickers {
-		if t.stopped {
-			continue
-		}
-		if earliest == nil || t.nextTick.Before(*earliest) {
-			tick := t.nextTick
-			earliest = &tick
+		if !t.stopped {
+			earliest = updateEarliest(earliest, t.nextTick)
 		}
 	}
 
 	for _, t := range c.timers {
-		if t.stopped || t.fired {
-			continue
-		}
-		if earliest == nil || t.deadline.Before(*earliest) {
-			d := t.deadline
-			earliest = &d
+		if !t.stopped && !t.fired {
+			earliest = updateEarliest(earliest, t.deadline)
 		}
 	}
 
 	for _, w := range c.waiters {
-		if earliest == nil || w.deadline.Before(*earliest) {
-			d := w.deadline
-			earliest = &d
-		}
+		earliest = updateEarliest(earliest, w.deadline)
 	}
 
 	return earliest
+}
+
+// updateEarliest returns a pointer to the earlier of current and candidate.
+// If current is nil, candidate is always returned.
+func updateEarliest(current *time.Time, candidate time.Time) *time.Time {
+	if current == nil || candidate.Before(*current) {
+		t := candidate
+		return &t
+	}
+	return current
 }
 
 func (c *FakeClock) fireTickers() {

--- a/core/docker_sdk_provider.go
+++ b/core/docker_sdk_provider.go
@@ -189,27 +189,44 @@ func (p *SDKDockerProvider) WaitContainer(ctx context.Context, containerID strin
 			p.recordError("wait_container")
 			return -1, fmt.Errorf("waiting for container: %w", ctx.Err())
 		case err, ok := <-errCh:
-			if !ok {
-				// errCh closed, continue waiting for response
-				errCh = nil
-				continue
-			}
-			if err != nil {
-				p.recordError("wait_container")
-				return -1, WrapContainerError("wait", containerID, err)
+			if newErrCh, done, exitCode, exitErr := p.handleWaitErrCh(containerID, errCh, err, ok); done {
+				return exitCode, exitErr
+			} else {
+				errCh = newErrCh
 			}
 		case resp, ok := <-respCh:
-			if !ok {
-				// respCh closed without response, unexpected
-				return -1, WrapContainerError("wait", containerID, ErrResponseChannelClosed)
-			}
-			if resp.Error != nil && resp.Error.Message != "" {
-				p.recordError("wait_container")
-				return resp.StatusCode, WrapContainerError("wait", containerID, fmt.Errorf("%w: %s", ErrUnexpected, resp.Error.Message))
-			}
-			return resp.StatusCode, nil
+			exitCode, err := p.handleWaitRespCh(containerID, resp, ok)
+			return exitCode, err
 		}
 	}
+}
+
+// handleWaitErrCh processes one receive from the error channel of WaitContainer.
+// Returns (newErrCh, done, exitCode, err): when done is true the caller should
+// return (exitCode, err); when done is false the caller should replace errCh with newErrCh.
+func (p *SDKDockerProvider) handleWaitErrCh(containerID string, errCh <-chan error, err error, ok bool) (<-chan error, bool, int64, error) {
+	if !ok {
+		// errCh closed, continue waiting for response
+		return nil, false, 0, nil
+	}
+	if err != nil {
+		p.recordError("wait_container")
+		return nil, true, -1, WrapContainerError("wait", containerID, err)
+	}
+	return errCh, false, 0, nil
+}
+
+// handleWaitRespCh processes one receive from the response channel of WaitContainer.
+func (p *SDKDockerProvider) handleWaitRespCh(containerID string, resp domain.WaitResponse, ok bool) (int64, error) {
+	if !ok {
+		// respCh closed without response, unexpected
+		return -1, WrapContainerError("wait", containerID, ErrResponseChannelClosed)
+	}
+	if resp.Error != nil && resp.Error.Message != "" {
+		p.recordError("wait_container")
+		return resp.StatusCode, WrapContainerError("wait", containerID, fmt.Errorf("%w: %s", ErrUnexpected, resp.Error.Message))
+	}
+	return resp.StatusCode, nil
 }
 
 // GetContainerLogs retrieves container logs.

--- a/core/envfile.go
+++ b/core/envfile.go
@@ -38,34 +38,9 @@ func ParseEnvFile(path string) ([]string, error) {
 	buf := make([]byte, 64*1024)
 	scanner.Buffer(buf, 1024*1024) // Support long values (certs, JSON blobs)
 	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-
-		// Skip blank lines and comments
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
+		if entry, ok := parseEnvLine(scanner.Text()); ok {
+			result = append(result, entry)
 		}
-
-		// Strip "export " prefix
-		line = strings.TrimPrefix(line, "export ")
-
-		// Must contain = to be a valid env assignment
-		idx := strings.IndexByte(line, '=')
-		if idx <= 0 {
-			continue // skip lines without = or with empty key (e.g., "=value")
-		}
-
-		key := line[:idx]
-		value := line[idx+1:]
-
-		// Strip surrounding quotes from value
-		if len(value) >= 2 {
-			if (value[0] == '"' && value[len(value)-1] == '"') ||
-				(value[0] == '\'' && value[len(value)-1] == '\'') {
-				value = value[1 : len(value)-1]
-			}
-		}
-
-		result = append(result, key+"="+value)
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -73,6 +48,40 @@ func ParseEnvFile(path string) ([]string, error) {
 	}
 
 	return result, nil
+}
+
+// parseEnvLine parses a single env-file line into a KEY=VALUE entry.
+// Returns the entry and true on success; returns "", false for blank lines,
+// comments, and lines without a valid key=value assignment.
+func parseEnvLine(raw string) (string, bool) {
+	line := strings.TrimSpace(raw)
+
+	// Skip blank lines and comments
+	if line == "" || strings.HasPrefix(line, "#") {
+		return "", false
+	}
+
+	// Strip "export " prefix
+	line = strings.TrimPrefix(line, "export ")
+
+	// Must contain = to be a valid env assignment
+	idx := strings.IndexByte(line, '=')
+	if idx <= 0 {
+		return "", false // skip lines without = or with empty key (e.g., "=value")
+	}
+
+	key := line[:idx]
+	value := line[idx+1:]
+
+	// Strip surrounding quotes from value
+	if len(value) >= 2 {
+		if (value[0] == '"' && value[len(value)-1] == '"') ||
+			(value[0] == '\'' && value[len(value)-1] == '\'') {
+			value = value[1 : len(value)-1]
+		}
+	}
+
+	return key + "=" + value, true
 }
 
 // ResolveEnvFrom inspects a running Docker container and returns its env vars.

--- a/core/retry.go
+++ b/core/retry.go
@@ -90,8 +90,10 @@ func (re *RetryExecutor) ExecuteWithRetry(job Job, ctx *Context, runFunc func(*C
 	attempt := 0
 
 	for attempt <= config.MaxRetries {
+		// Execute the job
 		err := runFunc(ctx)
 
+		// Success
 		if err == nil {
 			re.recordRetrySuccess(job.GetName(), attempt)
 			return nil
@@ -111,6 +113,7 @@ func (re *RetryExecutor) ExecuteWithRetry(job Job, ctx *Context, runFunc func(*C
 			"job", job.GetName(), "attempt", attempt+1, "maxRetries", config.MaxRetries+1,
 			"error", err, "backoff", delay)
 
+		// Record retry attempt in metrics
 		re.recordRetryAttempt(job.GetName(), attempt+1)
 
 		// Wait before retry, honoring scheduler / job cancellation so
@@ -133,6 +136,7 @@ func (re *RetryExecutor) ExecuteWithRetry(job Job, ctx *Context, runFunc func(*C
 	re.logger.Error(fmt.Sprintf("Job %s failed after %d retries: %v",
 		job.GetName(), config.MaxRetries+1, lastErr))
 
+	// Record final failure in metrics
 	re.recordRetryAttempt(job.GetName(), config.MaxRetries+1)
 
 	return fmt.Errorf("job failed after %d attempts: %w", config.MaxRetries+1, lastErr)

--- a/core/retry.go
+++ b/core/retry.go
@@ -90,18 +90,10 @@ func (re *RetryExecutor) ExecuteWithRetry(job Job, ctx *Context, runFunc func(*C
 	attempt := 0
 
 	for attempt <= config.MaxRetries {
-		// Execute the job
 		err := runFunc(ctx)
 
-		// Success
 		if err == nil {
-			if attempt > 0 {
-				re.logger.Info(fmt.Sprintf("Job %s succeeded after %d retries", job.GetName(), attempt))
-				// Record retry success in metrics
-				if re.metrics != nil {
-					re.metrics.RecordJobRetry(job.GetName(), attempt, true)
-				}
-			}
+			re.recordRetrySuccess(job.GetName(), attempt)
 			return nil
 		}
 
@@ -119,10 +111,7 @@ func (re *RetryExecutor) ExecuteWithRetry(job Job, ctx *Context, runFunc func(*C
 			"job", job.GetName(), "attempt", attempt+1, "maxRetries", config.MaxRetries+1,
 			"error", err, "backoff", delay)
 
-		// Record retry attempt in metrics
-		if re.metrics != nil {
-			re.metrics.RecordJobRetry(job.GetName(), attempt+1, false)
-		}
+		re.recordRetryAttempt(job.GetName(), attempt+1)
 
 		// Wait before retry, honoring scheduler / job cancellation so
 		// SIGTERM drains promptly even mid-retry. Pre-fix this was a bare
@@ -144,12 +133,26 @@ func (re *RetryExecutor) ExecuteWithRetry(job Job, ctx *Context, runFunc func(*C
 	re.logger.Error(fmt.Sprintf("Job %s failed after %d retries: %v",
 		job.GetName(), config.MaxRetries+1, lastErr))
 
-	// Record final failure in metrics
-	if re.metrics != nil {
-		re.metrics.RecordJobRetry(job.GetName(), config.MaxRetries+1, false)
-	}
+	re.recordRetryAttempt(job.GetName(), config.MaxRetries+1)
 
 	return fmt.Errorf("job failed after %d attempts: %w", config.MaxRetries+1, lastErr)
+}
+
+// recordRetrySuccess logs and records a metric for a successful retry.
+func (re *RetryExecutor) recordRetrySuccess(jobName string, attempt int) {
+	if attempt > 0 {
+		re.logger.Info(fmt.Sprintf("Job %s succeeded after %d retries", jobName, attempt))
+		if re.metrics != nil {
+			re.metrics.RecordJobRetry(jobName, attempt, true)
+		}
+	}
+}
+
+// recordRetryAttempt records a failed retry attempt in metrics.
+func (re *RetryExecutor) recordRetryAttempt(jobName string, attempt int) {
+	if re.metrics != nil {
+		re.metrics.RecordJobRetry(jobName, attempt, false)
+	}
 }
 
 // calculateDelay calculates the retry delay based on configuration

--- a/core/shutdown.go
+++ b/core/shutdown.go
@@ -113,46 +113,11 @@ func (sm *ShutdownManager) Shutdown() error {
 	var shutdownErrors []error
 
 	for _, priority := range priorities {
-		groupHooks := groups[priority]
-		var wg sync.WaitGroup
-		errChan := make(chan error, len(groupHooks))
-
-		for _, hook := range groupHooks {
-			wg.Add(1)
-			go func(h ShutdownHook) {
-				defer wg.Done()
-
-				sm.logger.Debug(fmt.Sprintf("Executing shutdown hook: %s (priority: %d)", h.Name, h.Priority))
-
-				if err := h.Hook(ctx); err != nil {
-					sm.logger.Error(fmt.Sprintf("Shutdown hook '%s' failed: %v", h.Name, err))
-					errChan <- fmt.Errorf("hook %s: %w", h.Name, err)
-				} else {
-					sm.logger.Debug(fmt.Sprintf("Shutdown hook '%s' completed successfully", h.Name))
-				}
-			}(hook)
-		}
-
-		// Wait for all hooks in this group with timeout enforcement.
-		// Without this select, a hook that ignores its context could block forever.
-		done := make(chan struct{})
-		go func() {
-			wg.Wait()
-			close(done)
-		}()
-
-		select {
-		case <-done:
-			// Group completed normally
-		case <-ctx.Done():
-			sm.logger.Error(fmt.Sprintf("Graceful shutdown timed out after %v (waiting for priority %d hooks)", sm.timeout, priority))
+		errs, timedOut := sm.runHookGroup(ctx, groups[priority], priority)
+		if timedOut {
 			return ErrShutdownTimeout
 		}
-
-		close(errChan)
-		for err := range errChan {
-			shutdownErrors = append(shutdownErrors, err)
-		}
+		shutdownErrors = append(shutdownErrors, errs...)
 	}
 
 	sm.logger.Info("Graceful shutdown completed successfully")
@@ -162,6 +127,53 @@ func (sm *ShutdownManager) Shutdown() error {
 	}
 
 	return nil
+}
+
+// runHookGroup runs all hooks in a priority group concurrently and waits for
+// them to finish or for ctx to expire. It returns collected errors and a bool
+// indicating whether the context deadline was exceeded before all hooks finished.
+func (sm *ShutdownManager) runHookGroup(ctx context.Context, hooks []ShutdownHook, priority int) ([]error, bool) {
+	var wg sync.WaitGroup
+	errChan := make(chan error, len(hooks))
+
+	for _, hook := range hooks {
+		wg.Add(1)
+		go func(h ShutdownHook) {
+			defer wg.Done()
+
+			sm.logger.Debug(fmt.Sprintf("Executing shutdown hook: %s (priority: %d)", h.Name, h.Priority))
+
+			if err := h.Hook(ctx); err != nil {
+				sm.logger.Error(fmt.Sprintf("Shutdown hook '%s' failed: %v", h.Name, err))
+				errChan <- fmt.Errorf("hook %s: %w", h.Name, err)
+			} else {
+				sm.logger.Debug(fmt.Sprintf("Shutdown hook '%s' completed successfully", h.Name))
+			}
+		}(hook)
+	}
+
+	// Wait for all hooks in this group with timeout enforcement.
+	// Without this select, a hook that ignores its context could block forever.
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Group completed normally
+	case <-ctx.Done():
+		sm.logger.Error(fmt.Sprintf("Graceful shutdown timed out after %v (waiting for priority %d hooks)", sm.timeout, priority))
+		return nil, true
+	}
+
+	close(errChan)
+	var errs []error
+	for err := range errChan {
+		errs = append(errs, err)
+	}
+	return errs, false
 }
 
 // ShutdownChan returns a channel that's closed when shutdown starts

--- a/middlewares/preset.go
+++ b/middlewares/preset.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log/slog"
 	"net/http"
@@ -329,46 +330,9 @@ func (l *PresetLoader) loadFromURL(url string) (*Preset, error) {
 		return nil, fmt.Errorf("preset URL validation failed: %w", err)
 	}
 
-	// Fetch from remote with context
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	data, err := l.fetchURL(url)
 	if err != nil {
-		return nil, fmt.Errorf("create request for %s: %w", url, err)
-	}
-
-	// Use the cached *http.Client constructed in NewPresetLoader so bursty
-	// preset fetches reuse the underlying connection pool. The transport was
-	// produced by TransportFactory() at construction time so the TLS / proxy
-	// posture stays consistent with webhook delivery. The request-level
-	// deadline is already set by the context above, so we don't add a
-	// Client.Timeout.
-	resp, err := l.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("fetch preset from %s: %w", url, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fetch preset from %s: HTTP %d", url, resp.StatusCode)
-	}
-
-	// Read body with size limit (1MB)
-	const maxSize = 1024 * 1024
-	data := make([]byte, 0, 4096)
-	buf := make([]byte, 4096)
-	for {
-		n, err := resp.Body.Read(buf)
-		if n > 0 {
-			data = append(data, buf[:n]...)
-			if len(data) > maxSize {
-				return nil, fmt.Errorf("preset file too large (max %d bytes)", maxSize)
-			}
-		}
-		if err != nil {
-			break
-		}
+		return nil, err
 	}
 
 	preset, err := ParsePreset(data)
@@ -382,6 +346,60 @@ func (l *PresetLoader) loadFromURL(url string) (*Preset, error) {
 	}
 
 	return preset, nil
+}
+
+// fetchURL performs the HTTP GET for the given URL and returns the body,
+// enforcing a 1 MB size limit. It uses the cached HTTP client so that
+// bursty preset fetches reuse the underlying connection pool. The transport
+// was produced by TransportFactory() at construction time so the TLS/proxy
+// posture stays consistent with webhook delivery.
+func (l *PresetLoader) fetchURL(url string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request for %s: %w", url, err)
+	}
+
+	// The request-level deadline is already set by the context above, so we
+	// don't add a Client.Timeout.
+	resp, err := l.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch preset from %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch preset from %s: HTTP %d", url, resp.StatusCode)
+	}
+
+	return readBodyWithLimit(resp.Body)
+}
+
+// readBodyWithLimit reads from r up to maxPresetSize bytes, returning an error
+// if the body exceeds the limit. Any read error (including non-EOF) stops the
+// loop and the accumulated data is returned; this matches the original inline
+// behavior in loadFromURL which broke on any error and passed partial data to
+// ParsePreset rather than surfacing the read failure.
+func readBodyWithLimit(r io.Reader) ([]byte, error) {
+	// Read body with size limit (1MB)
+	const maxPresetSize = 1024 * 1024
+	data := make([]byte, 0, 4096)
+	buf := make([]byte, 4096)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			data = append(data, buf[:n]...)
+			if len(data) > maxPresetSize {
+				return nil, fmt.Errorf("preset file too large (max %d bytes)", maxPresetSize)
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+	return data, nil //nolint:nilerr // partial/error reads are tolerated to match original loadFromURL semantics
 }
 
 // isTrustedSource checks if a preset source matches the trusted sources pattern

--- a/middlewares/preset_cache.go
+++ b/middlewares/preset_cache.go
@@ -297,37 +297,45 @@ func (c *PresetCache) Cleanup() error {
 	}
 
 	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != yamlExt {
-			continue
-		}
-
-		// Skip preset files, only process metadata
-		if !isMetaFile(entry.Name()) {
-			continue
-		}
-
-		metaPath := filepath.Join(c.cacheDir, entry.Name())
-		metaData, err := os.ReadFile(metaPath) // #nosec G304 -- path is constructed from controlled cache directory
-		if err != nil {
-			continue
-		}
-
-		var meta cacheMetadata
-		if err := yaml.Unmarshal(metaData, &meta); err != nil {
-			// Invalid metadata, remove
-			_ = os.Remove(metaPath)
-			continue
-		}
-
-		if now.After(meta.ExpiresAt) {
-			// Remove expired files
-			_ = os.Remove(metaPath)
-			presetPath := metaPath[:len(metaPath)-len(metaFileSuffix)] + ".yaml"
-			_ = os.Remove(presetPath)
-		}
+		c.cleanupDiskEntry(entry, now)
 	}
 
 	return nil
+}
+
+// cleanupDiskEntry removes a single cache entry from disk if it is expired or
+// has invalid metadata. Only metadata files (.meta.yaml) are processed; plain
+// preset files are skipped (they are removed together with their paired
+// metadata file when expiry is detected).
+func (c *PresetCache) cleanupDiskEntry(entry os.DirEntry, now time.Time) {
+	if entry.IsDir() || filepath.Ext(entry.Name()) != yamlExt {
+		return
+	}
+
+	// Skip preset files, only process metadata
+	if !isMetaFile(entry.Name()) {
+		return
+	}
+
+	metaPath := filepath.Join(c.cacheDir, entry.Name())
+	metaData, err := os.ReadFile(metaPath) // #nosec G304 -- path is constructed from controlled cache directory
+	if err != nil {
+		return
+	}
+
+	var meta cacheMetadata
+	if err := yaml.Unmarshal(metaData, &meta); err != nil {
+		// Invalid metadata, remove
+		_ = os.Remove(metaPath)
+		return
+	}
+
+	if now.After(meta.ExpiresAt) {
+		// Remove expired files
+		_ = os.Remove(metaPath)
+		presetPath := metaPath[:len(metaPath)-len(metaFileSuffix)] + ".yaml"
+		_ = os.Remove(presetPath)
+	}
 }
 
 // isMetaFile checks if a filename is a metadata file

--- a/middlewares/restore.go
+++ b/middlewares/restore.go
@@ -182,8 +182,14 @@ func processHistoryFile(
 
 	// Verify path is within save folder (defense in depth for G304)
 	absPath, absErr := filepath.Abs(path)
-	if absErr != nil || !strings.HasPrefix(absPath, absSaveFolder) {
+	if absErr != nil {
 		return nil // Intentionally skip invalid paths
+	}
+	// Use filepath.Rel rather than a string prefix so "/tmp/save_other" is not
+	// treated as inside "/tmp/save" (partial-name match).
+	rel, relErr := filepath.Rel(absSaveFolder, absPath)
+	if relErr != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return nil // Intentionally skip paths outside the save folder
 	}
 
 	// Parse the JSON file

--- a/middlewares/restore.go
+++ b/middlewares/restore.go
@@ -94,30 +94,11 @@ func RestoreHistory(saveFolder string, maxAge time.Duration, jobs []core.Job, lo
 	restoredCount := 0
 	restoredJobCount := 0
 	for jobName, jobEntries := range entriesByJob {
-		job, exists := jobsByName[jobName]
-		if !exists {
-			logger.Debug(fmt.Sprintf("Skipping history for unknown job %q", jobName))
-			continue
+		n := restoreJobEntries(jobName, jobEntries, jobsByName, logger)
+		if n > 0 {
+			restoredCount += n
+			restoredJobCount++
 		}
-
-		// Sort by date ascending (oldest first) so SetLastRun works correctly
-		sort.Slice(jobEntries, func(i, j int) bool {
-			return jobEntries[i].Execution.Date.Before(jobEntries[j].Execution.Date)
-		})
-
-		// Check if job supports SetLastRun
-		setter, ok := job.(interface{ SetLastRun(*core.Execution) })
-		if !ok {
-			logger.Debug(fmt.Sprintf("Job %q does not support history restoration", jobName))
-			continue
-		}
-
-		// Restore each execution
-		for _, entry := range jobEntries {
-			setter.SetLastRun(entry.Execution)
-			restoredCount++
-		}
-		restoredJobCount++
 	}
 
 	if restoredCount > 0 {
@@ -125,6 +106,35 @@ func RestoreHistory(saveFolder string, maxAge time.Duration, jobs []core.Job, lo
 	}
 
 	return nil
+}
+
+// restoreJobEntries applies the saved executions for a single job to its
+// in-memory history. It returns the number of executions restored (0 if the
+// job is unknown or does not support SetLastRun).
+func restoreJobEntries(jobName string, jobEntries []*restoredEntry, jobsByName map[string]core.Job, logger *slog.Logger) int {
+	job, exists := jobsByName[jobName]
+	if !exists {
+		logger.Debug(fmt.Sprintf("Skipping history for unknown job %q", jobName))
+		return 0
+	}
+
+	// Check if job supports SetLastRun
+	setter, ok := job.(interface{ SetLastRun(*core.Execution) })
+	if !ok {
+		logger.Debug(fmt.Sprintf("Job %q does not support history restoration", jobName))
+		return 0
+	}
+
+	// Sort by date ascending (oldest first) so SetLastRun works correctly
+	sort.Slice(jobEntries, func(i, j int) bool {
+		return jobEntries[i].Execution.Date.Before(jobEntries[j].Execution.Date)
+	})
+
+	// Restore each execution
+	for _, entry := range jobEntries {
+		setter.SetLastRun(entry.Execution)
+	}
+	return len(jobEntries)
 }
 
 // parseHistoryFiles scans the save folder for JSON files and parses them.
@@ -138,45 +148,57 @@ func parseHistoryFiles(saveFolder string, cutoff time.Time, logger *slog.Logger)
 	}
 
 	err = filepath.Walk(saveFolder, func(path string, info os.FileInfo, walkErr error) error {
-		if walkErr != nil {
-			return nil //nolint:nilerr // Intentionally skip inaccessible files
+		entry := processHistoryFile(path, info, walkErr, absSaveFolder, cutoff, logger)
+		if entry != nil {
+			entries = append(entries, entry)
 		}
-
-		// Only process .json files
-		if info.IsDir() || !strings.HasSuffix(info.Name(), ".json") {
-			return nil
-		}
-
-		// Skip files older than cutoff based on modification time (quick filter)
-		if info.ModTime().Before(cutoff) {
-			return nil
-		}
-
-		// Verify path is within save folder (defense in depth for G304)
-		absPath, absErr := filepath.Abs(path)
-		if absErr != nil || !strings.HasPrefix(absPath, absSaveFolder) {
-			return nil //nolint:nilerr // Intentionally skip invalid paths
-		}
-
-		// Parse the JSON file
-		entry, err := parseHistoryFile(absPath)
-		if err != nil {
-			logger.Debug(fmt.Sprintf("Skipping invalid history file %q: %v", path, err))
-			return nil
-		}
-
-		// Skip if execution date is too old
-		if entry.Execution.Date.Before(cutoff) {
-			return nil
-		}
-
-		entries = append(entries, entry)
 		return nil
 	})
 	if err != nil {
 		return entries, fmt.Errorf("walk save folder: %w", err)
 	}
 	return entries, nil
+}
+
+// processHistoryFile evaluates a single Walk entry and returns a parsed
+// restoredEntry when the file passes all filters, or nil to skip it.
+func processHistoryFile(
+	path string, info os.FileInfo, walkErr error,
+	absSaveFolder string, cutoff time.Time, logger *slog.Logger,
+) *restoredEntry {
+	if walkErr != nil {
+		return nil // Intentionally skip inaccessible files
+	}
+
+	// Only process .json files
+	if info.IsDir() || !strings.HasSuffix(info.Name(), ".json") {
+		return nil
+	}
+
+	// Skip files older than cutoff based on modification time (quick filter)
+	if info.ModTime().Before(cutoff) {
+		return nil
+	}
+
+	// Verify path is within save folder (defense in depth for G304)
+	absPath, absErr := filepath.Abs(path)
+	if absErr != nil || !strings.HasPrefix(absPath, absSaveFolder) {
+		return nil // Intentionally skip invalid paths
+	}
+
+	// Parse the JSON file
+	entry, err := parseHistoryFile(absPath)
+	if err != nil {
+		logger.Debug(fmt.Sprintf("Skipping invalid history file %q: %v", path, err))
+		return nil
+	}
+
+	// Skip if execution date is too old
+	if entry.Execution.Date.Before(cutoff) {
+		return nil
+	}
+
+	return entry
 }
 
 // parseHistoryFile reads and parses a single JSON history file.

--- a/web/server.go
+++ b/web/server.go
@@ -324,6 +324,9 @@ func mapJobSource(m reflect.Value, name string) (string, bool) {
 		return "", false
 	}
 	if jv.Kind() == reflect.Pointer {
+		if jv.IsNil() {
+			return "", false
+		}
 		jv = jv.Elem()
 	}
 	src := jv.FieldByName("JobSource")

--- a/web/server.go
+++ b/web/server.go
@@ -121,6 +121,39 @@ func NewServer(addr string, s *core.Scheduler, cfg any, provider core.DockerProv
 	return NewServerWithAuth(addr, s, cfg, provider, nil)
 }
 
+// setupAuth initializes the token manager, rate limiter, and trusted
+// proxies on server from authCfg. Returns an error only when token
+// manager construction fails (caller should return nil on error).
+func setupAuth(server *Server, authCfg *SecureAuthConfig) error {
+	tokenExpiry := authCfg.TokenExpiry
+	if tokenExpiry == 0 {
+		tokenExpiry = 24
+	}
+	tm, err := NewSecureTokenManager(authCfg.SecretKey, tokenExpiry)
+	if err != nil {
+		return err
+	}
+	server.tokenManager = tm
+
+	maxAttempts := authCfg.MaxAttempts
+	if maxAttempts == 0 {
+		maxAttempts = 5
+	}
+	server.loginLimiter = NewRateLimiter(maxAttempts, maxAttempts)
+
+	// Parse trusted proxy CIDRs for X-Forwarded-For handling
+	if len(authCfg.TrustedProxies) > 0 {
+		tp, tpErr := ParseTrustedProxies(authCfg.TrustedProxies)
+		if tpErr != nil {
+			server.scheduler.Logger.Error("failed to parse trusted proxies", "error", tpErr)
+		} else {
+			server.trustedProxies = tp
+			server.scheduler.Logger.Info("trusted proxies configured", "count", len(tp))
+		}
+	}
+	return nil
+}
+
 func NewServerWithAuth(addr string, s *core.Scheduler, cfg any, provider core.DockerProvider, authCfg *SecureAuthConfig) *Server {
 	server := &Server{
 		addr:       addr,
@@ -132,32 +165,9 @@ func NewServerWithAuth(addr string, s *core.Scheduler, cfg any, provider core.Do
 	}
 
 	if authCfg != nil && authCfg.Enabled {
-		tokenExpiry := authCfg.TokenExpiry
-		if tokenExpiry == 0 {
-			tokenExpiry = 24
-		}
-		tm, err := NewSecureTokenManager(authCfg.SecretKey, tokenExpiry)
-		if err != nil {
+		if err := setupAuth(server, authCfg); err != nil {
 			s.Logger.Error("failed to initialize token manager", "error", err)
 			return nil
-		}
-		server.tokenManager = tm
-
-		maxAttempts := authCfg.MaxAttempts
-		if maxAttempts == 0 {
-			maxAttempts = 5
-		}
-		server.loginLimiter = NewRateLimiter(maxAttempts, maxAttempts)
-
-		// Parse trusted proxy CIDRs for X-Forwarded-For handling
-		if len(authCfg.TrustedProxies) > 0 {
-			tp, tpErr := ParseTrustedProxies(authCfg.TrustedProxies)
-			if tpErr != nil {
-				s.Logger.Error("failed to parse trusted proxies", "error", tpErr)
-			} else {
-				server.trustedProxies = tp
-				s.Logger.Info("trusted proxies configured", "count", len(tp))
-			}
 		}
 	}
 
@@ -302,6 +312,27 @@ type apiJob struct {
 	Config   json.RawMessage `json:"config"`
 }
 
+// mapJobSource looks up name in the map field m and returns the
+// JobSource string for that entry, if any. Returns ("", false) when
+// m is not a valid map or the entry/field is absent.
+func mapJobSource(m reflect.Value, name string) (string, bool) {
+	if !m.IsValid() || m.Kind() != reflect.Map {
+		return "", false
+	}
+	jv := m.MapIndex(reflect.ValueOf(name))
+	if !jv.IsValid() {
+		return "", false
+	}
+	if jv.Kind() == reflect.Pointer {
+		jv = jv.Elem()
+	}
+	src := jv.FieldByName("JobSource")
+	if !src.IsValid() {
+		return "", false
+	}
+	return src.String(), true
+}
+
 func jobOrigin(cfg any, name string) string {
 	if cfg == nil {
 		return ""
@@ -315,18 +346,8 @@ func jobOrigin(cfg any, name string) string {
 	}
 	fields := []string{"RunJobs", "ExecJobs", "ServiceJobs", "LocalJobs", "ComposeJobs"}
 	for _, f := range fields {
-		m := v.FieldByName(f)
-		if m.IsValid() && m.Kind() == reflect.Map {
-			jv := m.MapIndex(reflect.ValueOf(name))
-			if jv.IsValid() {
-				if jv.Kind() == reflect.Pointer {
-					jv = jv.Elem()
-				}
-				src := jv.FieldByName("JobSource")
-				if src.IsValid() {
-					return src.String()
-				}
-			}
+		if src, ok := mapJobSource(v.FieldByName(f), name); ok {
+			return src
 		}
 	}
 	return ""
@@ -366,6 +387,47 @@ func jobType(j core.Job) string {
 // scheduleRunCount is the number of next/previous execution times returned per job.
 const scheduleRunCount = 5
 
+// newAPIExecution converts a core.Execution into its API representation.
+// Returns nil when lr is nil.
+func newAPIExecution(lr *core.Execution) *apiExecution {
+	if lr == nil {
+		return nil
+	}
+	errStr := ""
+	if lr.Error != nil {
+		errStr = lr.Error.Error()
+	}
+	return &apiExecution{
+		Date:     lr.Date,
+		Duration: lr.Duration,
+		Failed:   lr.Failed,
+		Skipped:  lr.Skipped,
+		Error:    errStr,
+		Stdout:   lr.GetStdout(),
+		Stderr:   lr.GetStderr(),
+	}
+}
+
+// computeRunTimes returns the next/prev run-time slices for job.
+// Triggered-only jobs, disabled (paused) jobs, and jobs without a cron
+// entry return empty (non-nil) slices.
+func (s *Server) computeRunTimes(job core.Job, now time.Time) (next, prev []time.Time) {
+	if s.scheduler.GetDisabledJob(job.GetName()) == nil {
+		entry := s.scheduler.EntryByName(job.GetName())
+		if entry.Valid() && entry.Schedule != nil && !cron.IsTriggered(entry.Schedule) {
+			next = cron.NextN(entry.Schedule, now, scheduleRunCount)
+			prev = cron.PrevN(entry.Schedule, now, scheduleRunCount)
+		}
+	}
+	if next == nil {
+		next = []time.Time{}
+	}
+	if prev == nil {
+		prev = []time.Time{}
+	}
+	return next, prev
+}
+
 // buildAPIJobs converts a slice of core.Job into apiJob payloads.
 func (s *Server) buildAPIJobs(list []core.Job) []apiJob {
 	now := time.Now()
@@ -373,43 +435,10 @@ func (s *Server) buildAPIJobs(list []core.Job) []apiJob {
 	for _, job := range list {
 		var execInfo *apiExecution
 		if lrGetter, ok := job.(interface{ GetLastRun() *core.Execution }); ok {
-			if lr := lrGetter.GetLastRun(); lr != nil {
-				errStr := ""
-				if lr.Error != nil {
-					errStr = lr.Error.Error()
-				}
-				stdout := lr.GetStdout()
-				stderr := lr.GetStderr()
-				execInfo = &apiExecution{
-					Date:     lr.Date,
-					Duration: lr.Duration,
-					Failed:   lr.Failed,
-					Skipped:  lr.Skipped,
-					Error:    errStr,
-					Stdout:   stdout,
-					Stderr:   stderr,
-				}
-			}
+			execInfo = newAPIExecution(lrGetter.GetLastRun())
 		}
 
-		// Compute next/prev execution times from the cron schedule.
-		// Triggered-only jobs (detected via cron.IsTriggered on the entry's schedule),
-		// disabled (paused) jobs, and jobs without a cron entry return empty slices.
-		var nextRuns, prevRuns []time.Time
-		if s.scheduler.GetDisabledJob(job.GetName()) == nil {
-			entry := s.scheduler.EntryByName(job.GetName())
-			if entry.Valid() && entry.Schedule != nil && !cron.IsTriggered(entry.Schedule) {
-				nextRuns = cron.NextN(entry.Schedule, now, scheduleRunCount)
-				prevRuns = cron.PrevN(entry.Schedule, now, scheduleRunCount)
-			}
-		}
-		if nextRuns == nil {
-			nextRuns = []time.Time{}
-		}
-		if prevRuns == nil {
-			prevRuns = []time.Time{}
-		}
-
+		nextRuns, prevRuns := s.computeRunTimes(job, now)
 		origin := s.jobOrigin(job.GetName())
 		cfgBytes, _ := json.Marshal(job)
 		jobs = append(jobs, apiJob{
@@ -717,69 +746,86 @@ func (s *Server) updateJobHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(status)
 }
 
+func (s *Server) newRunJobFromRequest(req *jobRequest) (core.Job, error) {
+	if s.provider == nil {
+		return nil, fmt.Errorf("docker provider unavailable for run job")
+	}
+	j := core.NewRunJob(s.provider)
+	j.Name = req.Name
+	j.Schedule = req.Schedule
+	j.Command = req.Command
+	j.Image = req.Image
+	j.Container = req.Container
+	return j, nil
+}
+
+func (s *Server) newExecJobFromRequest(req *jobRequest) (core.Job, error) {
+	if s.provider == nil {
+		return nil, fmt.Errorf("docker provider unavailable for exec job")
+	}
+	j := core.NewExecJob(s.provider)
+	j.Name = req.Name
+	j.Schedule = req.Schedule
+	j.Command = req.Command
+	j.Container = req.Container
+	return j, nil
+}
+
+// newComposeJobFromRequest validates compose job parameters and builds the job.
+func newComposeJobFromRequest(req *jobRequest) (core.Job, error) {
+	validator := config.NewCommandValidator()
+	if req.File != "" {
+		if err := validator.ValidateFilePath(req.File); err != nil {
+			return nil, fmt.Errorf("invalid compose file path: %w", err)
+		}
+	}
+	if err := validator.ValidateServiceName(req.Service); err != nil {
+		return nil, fmt.Errorf("invalid service name: %w", err)
+	}
+	if req.Command != "" {
+		cmdArgs := args.GetArgs(req.Command)
+		if err := validator.ValidateCommandArgs(cmdArgs); err != nil {
+			return nil, fmt.Errorf("invalid command arguments: %w", err)
+		}
+	}
+	j := &core.ComposeJob{}
+	j.Name = req.Name
+	j.Schedule = req.Schedule
+	j.Command = req.Command
+	j.File = req.File
+	j.Service = req.Service
+	j.Exec = req.ExecFlag
+	return j, nil
+}
+
+// newLocalJobFromRequest validates local job command and builds the job.
+// Note: Empty commands will be caught at runtime by LocalJob.buildCommand()
+func newLocalJobFromRequest(req *jobRequest) (core.Job, error) {
+	if req.Command != "" {
+		// Validate local job command if provided to prevent injection attacks
+		validator := config.NewCommandValidator()
+		cmdArgs := args.GetArgs(req.Command)
+		if err := validator.ValidateCommandArgs(cmdArgs); err != nil {
+			return nil, fmt.Errorf("invalid command arguments: %w", err)
+		}
+	}
+	j := &core.LocalJob{}
+	j.Name = req.Name
+	j.Schedule = req.Schedule
+	j.Command = req.Command
+	return j, nil
+}
+
 func (s *Server) jobFromRequest(req *jobRequest) (core.Job, error) {
 	switch req.Type {
 	case "run":
-		if s.provider == nil {
-			return nil, fmt.Errorf("docker provider unavailable for run job")
-		}
-		j := core.NewRunJob(s.provider)
-		j.Name = req.Name
-		j.Schedule = req.Schedule
-		j.Command = req.Command
-		j.Image = req.Image
-		j.Container = req.Container
-		return j, nil
+		return s.newRunJobFromRequest(req)
 	case "exec":
-		if s.provider == nil {
-			return nil, fmt.Errorf("docker provider unavailable for exec job")
-		}
-		j := core.NewExecJob(s.provider)
-		j.Name = req.Name
-		j.Schedule = req.Schedule
-		j.Command = req.Command
-		j.Container = req.Container
-		return j, nil
+		return s.newExecJobFromRequest(req)
 	case "compose":
-		// Validate compose job parameters
-		validator := config.NewCommandValidator()
-		if req.File != "" {
-			if err := validator.ValidateFilePath(req.File); err != nil {
-				return nil, fmt.Errorf("invalid compose file path: %w", err)
-			}
-		}
-		if err := validator.ValidateServiceName(req.Service); err != nil {
-			return nil, fmt.Errorf("invalid service name: %w", err)
-		}
-		if req.Command != "" {
-			cmdArgs := args.GetArgs(req.Command)
-			if err := validator.ValidateCommandArgs(cmdArgs); err != nil {
-				return nil, fmt.Errorf("invalid command arguments: %w", err)
-			}
-		}
-		j := &core.ComposeJob{}
-		j.Name = req.Name
-		j.Schedule = req.Schedule
-		j.Command = req.Command
-		j.File = req.File
-		j.Service = req.Service
-		j.Exec = req.ExecFlag
-		return j, nil
+		return newComposeJobFromRequest(req)
 	case "", "local":
-		// Validate local job command if provided to prevent injection attacks
-		// Note: Empty commands will be caught at runtime by LocalJob.buildCommand()
-		if req.Command != "" {
-			validator := config.NewCommandValidator()
-			cmdArgs := args.GetArgs(req.Command)
-			if err := validator.ValidateCommandArgs(cmdArgs); err != nil {
-				return nil, fmt.Errorf("invalid command arguments: %w", err)
-			}
-		}
-		j := &core.LocalJob{}
-		j.Name = req.Name
-		j.Schedule = req.Schedule
-		j.Command = req.Command
-		return j, nil
+		return newLocalJobFromRequest(req)
 	default:
 		return nil, fmt.Errorf("unknown job type %q", req.Type)
 	}


### PR DESCRIPTION
Final batch of SonarCloud `go:S3776` cognitive-complexity reductions — the **remaining ~31 production functions** (16–31) plus both `go:S107` too-many-parameter findings. Follows #723 (mechanical) and #724 (4 worst offenders). After this, **every production function is ≤15 cognitive complexity** (verified with `gocognit`, which matches SonarCloud's metric exactly).

Behavior-preserving extractions only (helper functions, early-return flattening, small parameter structs). No logic changes.

## What changed, by package

- **cli** — `BuildFromFile`, `parseIni`, `iniConfigUpdate`, `syncJobMap`, `parseGlobalAndDocker`, `logJobUnknownKeyWarnings`, `persistedJobToScheduler`, `start`, `watchEvents`, `GetDockerContainers`, `watchConfig`, `outputHuman`, `checkSchedules`, `parseWebhookConfig`, `extractMapstructureKeysFromType`, `VersionString`, `promptRunJob`
- **web** — `jobFromRequest`, `buildAPIJobs`, `NewServerWithAuth`, `jobOrigin`
- **core/adapters/docker** — `Subscribe`, `WaitForServiceTasks`, `convertTaskTemplateFromSwarm`, `convertTaskTemplateToSwarm`, `NewClientWithConfig`
- **core** — `ExecuteWithRetry`, `findEarliestEvent`, `Shutdown`, `ParseEnvFile`, `WaitContainer`
- **middlewares / config** — `loadFromURL`, `RestoreHistory`, `parseHistoryFiles`, `Cleanup`, `validateStruct`

### S107 (parameter counts)
- `applyJobParameterToJobMaps`: 10 → 6 params (bundled the five job maps into a `containerJobMaps` struct; grafted onto #724's decomposition)
- `buildJobMiddlewares`: 8 → 5 params (bundled notification configs into a `jobNotificationConfigs` struct)

## Provenance & verification
This batch was produced by parallel per-package refactoring, then reconciled onto the post-#723/#724 `main` (some helpers were re-pointed at the `metaFileSuffix`/`msgInvalidScheduleFmt` constants introduced in #723, and the `applyJobParameterToJobMaps` struct refactor was grafted onto #724's `splitContainers` decomposition).

- `gocognit` — **no production function > 15**
- `go build ./...`, `go vet ./...`, `golangci-lint run ./...` — clean (0 issues)
- `go test ./... -count=1` — all 14 packages pass
- `gosec` — no new findings (the 3 reported are pre-existing: 2× cookie `G124`, 1× `G117` in untouched code)