### PR TITLE
feat(save): make log file/folder permissions configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ See [Architecture overview](docs/architecture.md) for details about the schedule
 
 - `save-folder` - directory in which the reports shall be written. The folder is created automatically if it doesn't exist using an equivalent of `mkdir -p`.
 - `save-only-on-error` - only save a report if the execution was not successful.
+- `save-mode` - octal file mode for the per-execution log/JSON files (default `0600`, readable only by the daemon uid because job output may contain secrets/PII). Set a wider value such as `0644` to let non-root operators or a shared group read the logs on the host. Accepts `0644`, `0o644` or `644`. Like `save-folder`, this is **not** in the global Docker-label allow-list, so a container cannot change the daemon-wide default.
+- `save-folder-mode` - octal directory mode for `save-folder` (default `0750`). Accepts the same formats as `save-mode`. Applies only when Ofelia creates the folder; an existing `save-folder` keeps its current permissions (`mkdir -p` semantics).
 
 - `webhook-webhooks` - comma-separated list of webhook names to apply to every job by default.
 - `webhook-default-preset` - preset name used when a webhook configuration omits `preset` (default: `json-post`, the bundled JSON POST preset that lets `url = ...` work without authoring a custom preset). Set to empty (`webhook-default-preset =`) to opt out — webhooks must then declare `preset` explicitly or attachment fails. See [Webhook Documentation](docs/webhooks.md#custom-webhooks-url-only-no-custom-preset).

--- a/cli/config.go
+++ b/cli/config.go
@@ -694,6 +694,12 @@ func (c *Config) mergeSaveDefaults(job *middlewares.SaveConfig) {
 	if job.SaveOnlyOnError == nil && global.SaveOnlyOnError != nil {
 		job.SaveOnlyOnError = new(*global.SaveOnlyOnError)
 	}
+	if job.SaveMode == "" {
+		job.SaveMode = global.SaveMode
+	}
+	if job.SaveFolderMode == "" {
+		job.SaveFolderMode = global.SaveFolderMode
+	}
 }
 
 // UserContainerDefault is the sentinel value that explicitly requests the container's default user,

--- a/cli/config_global_merge.go
+++ b/cli/config_global_merge.go
@@ -178,6 +178,14 @@ func mergeSaveGlobals(dst, src *middlewares.SaveConfig) bool {
 		dst.RestoreHistoryMaxAge = src.RestoreHistoryMaxAge
 		changed = true
 	}
+	if dst.SaveMode == "" && src.SaveMode != "" {
+		dst.SaveMode = src.SaveMode
+		changed = true
+	}
+	if dst.SaveFolderMode == "" && src.SaveFolderMode != "" {
+		dst.SaveFolderMode = src.SaveFolderMode
+		changed = true
+	}
 	return changed
 }
 

--- a/cli/config_global_merge_test.go
+++ b/cli/config_global_merge_test.go
@@ -181,6 +181,8 @@ func TestMergeSaveGlobals_LabelFillsEmpty(t *testing.T) {
 		SaveOnlyOnError:      &srcOnly,
 		RestoreHistory:       &srcRestore,
 		RestoreHistoryMaxAge: 12 * time.Hour,
+		SaveMode:             "0644",
+		SaveFolderMode:       "0755",
 	}
 
 	changed := mergeSaveGlobals(&dst, &src)
@@ -192,6 +194,8 @@ func TestMergeSaveGlobals_LabelFillsEmpty(t *testing.T) {
 	require.NotNil(t, dst.RestoreHistory)
 	assert.False(t, *dst.RestoreHistory, "label-set RestoreHistory pointer must be inherited verbatim, including false")
 	assert.Equal(t, 12*time.Hour, dst.RestoreHistoryMaxAge)
+	assert.Equal(t, "0644", dst.SaveMode, "empty INI save-mode must inherit from label")
+	assert.Equal(t, "0755", dst.SaveFolderMode, "empty INI save-folder-mode must inherit from label")
 }
 
 // TestMergeSaveGlobals_INIWins pins the precedence half for Save fields.
@@ -205,6 +209,8 @@ func TestMergeSaveGlobals_INIWins(t *testing.T) {
 		SaveOnlyOnError:      &iniOnly,
 		RestoreHistory:       &iniRestore,
 		RestoreHistoryMaxAge: 6 * time.Hour,
+		SaveMode:             "0600",
+		SaveFolderMode:       "0750",
 	}
 	srcOnly := true
 	srcRestore := false
@@ -213,6 +219,8 @@ func TestMergeSaveGlobals_INIWins(t *testing.T) {
 		SaveOnlyOnError:      &srcOnly,
 		RestoreHistory:       &srcRestore,
 		RestoreHistoryMaxAge: 48 * time.Hour,
+		SaveMode:             "0644",
+		SaveFolderMode:       "0755",
 	}
 
 	changed := mergeSaveGlobals(&dst, &src)
@@ -224,6 +232,8 @@ func TestMergeSaveGlobals_INIWins(t *testing.T) {
 	require.NotNil(t, dst.RestoreHistory)
 	assert.True(t, *dst.RestoreHistory)
 	assert.Equal(t, 6*time.Hour, dst.RestoreHistoryMaxAge)
+	assert.Equal(t, "0600", dst.SaveMode, "INI save-mode wins over label")
+	assert.Equal(t, "0750", dst.SaveFolderMode, "INI save-folder-mode wins over label")
 }
 
 // TestMergeSchedulingGlobals_LabelFillsEmpty pins log-level / max-runtime /

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -1033,6 +1033,8 @@ func TestMergeSaveDefaults(t *testing.T) {
 	cfg := NewConfig(test.NewTestLogger())
 	cfg.Global.SaveConfig.SaveFolder = "/var/log/ofelia"
 	cfg.Global.SaveConfig.SaveOnlyOnError = new(true)
+	cfg.Global.SaveConfig.SaveMode = "0644"
+	cfg.Global.SaveConfig.SaveFolderMode = "0755"
 
 	// Job without save settings inherits from global
 	jobSave := middlewares.SaveConfig{}
@@ -1040,13 +1042,17 @@ func TestMergeSaveDefaults(t *testing.T) {
 	assert.Equal(t, "/var/log/ofelia", jobSave.SaveFolder)
 	require.NotNil(t, jobSave.SaveOnlyOnError, "Global save-only-on-error=true should propagate to job")
 	assert.True(t, *jobSave.SaveOnlyOnError)
+	assert.Equal(t, "0644", jobSave.SaveMode, "Global save-mode should propagate to job")
+	assert.Equal(t, "0755", jobSave.SaveFolderMode, "Global save-folder-mode should propagate to job")
 
-	// Job with explicit folder keeps its own
-	jobSave2 := middlewares.SaveConfig{SaveFolder: "/custom/logs"}
+	// Job with explicit folder/mode keeps its own
+	jobSave2 := middlewares.SaveConfig{SaveFolder: "/custom/logs", SaveMode: "0600"}
 	cfg.mergeSaveDefaults(&jobSave2)
 	assert.Equal(t, "/custom/logs", jobSave2.SaveFolder)
 	require.NotNil(t, jobSave2.SaveOnlyOnError)
 	assert.True(t, *jobSave2.SaveOnlyOnError, "SaveOnlyOnError should still inherit")
+	assert.Equal(t, "0600", jobSave2.SaveMode, "Job explicit save-mode must not be overridden by global")
+	assert.Equal(t, "0755", jobSave2.SaveFolderMode, "Unset save-folder-mode should still inherit from global")
 
 	// Job can explicitly override to false
 	jobSave3 := middlewares.SaveConfig{SaveOnlyOnError: new(false)}
@@ -1060,4 +1066,6 @@ func TestMergeSaveDefaults(t *testing.T) {
 	cfgEmpty.mergeSaveDefaults(&jobSave4)
 	assert.Empty(t, jobSave4.SaveFolder)
 	assert.Nil(t, jobSave4.SaveOnlyOnError)
+	assert.Empty(t, jobSave4.SaveMode)
+	assert.Empty(t, jobSave4.SaveFolderMode)
 }

--- a/cli/config_webhook_label_parity_test.go
+++ b/cli/config_webhook_label_parity_test.go
@@ -99,6 +99,22 @@ func TestGlobalLabelAllowList_OmitsSSRFSensitiveWebhookKeys(t *testing.T) {
 	}
 }
 
+// TestGlobalLabelAllowList_OmitsSavePermissionKeys asserts that the save
+// permission keys (#729) stay out of the Docker label allow-list, mirroring
+// save-folder. A scheduled container must not be able to change the
+// daemon-wide save-folder permissions via a [global] label. This catches a
+// future allow-list edit that accidentally exposes them.
+func TestGlobalLabelAllowList_OmitsSavePermissionKeys(t *testing.T) {
+	t.Parallel()
+
+	forbidden := []string{"save-folder", "save-mode", "save-folder-mode"}
+	for _, key := range forbidden {
+		assert.Falsef(t, globalLabelAllowList[key],
+			"globalLabelAllowList must NOT contain %q — save permissions are INI-only at global scope (#729)",
+			key)
+	}
+}
+
 // TestGlobalLabelAllowList_AllowsOperationallyTunableWebhookKeys is the
 // positive counterpart to the SSRF guard above: the webhook-* keys that are
 // safe to set from a service-container label MUST be present in the

--- a/config/validator.go
+++ b/config/validator.go
@@ -322,6 +322,8 @@ func (cv *Validator2) validateSpecificStringField(v *Validator, path string, str
 		cv.validateImageField(v, path, str)
 	case "save-folder", "working_dir":
 		cv.validatePathField(v, path, str)
+	case "save-mode", "save-folder-mode":
+		cv.validateFileModeField(v, path, str)
 	}
 }
 
@@ -400,6 +402,27 @@ func (cv *Validator2) validatePathField(v *Validator, path string, str string) {
 	}
 }
 
+// validateFileModeField validates octal file/directory mode fields
+// (save-mode, save-folder-mode). Mirrors middlewares.parseFileMode: accepts an
+// optional 0o/0O prefix, interprets the remainder as octal, and rejects values
+// outside the permission bits (0000-0777). The parser lives in the middlewares
+// package too, but config cannot import it (core->config import cycle), so this
+// stays a self-contained check.
+func (cv *Validator2) validateFileModeField(v *Validator, path, str string) {
+	if strings.TrimSpace(str) == "" {
+		return // empty resolves to the secure default downstream
+	}
+	trimmed := strings.TrimPrefix(strings.TrimPrefix(strings.TrimSpace(str), "0o"), "0O")
+	mode, err := strconv.ParseUint(trimmed, 8, 32)
+	if err != nil {
+		v.AddError(path, str, "invalid octal file mode (e.g. 0644)")
+		return
+	}
+	if mode > 0o777 {
+		v.AddError(path, str, "file mode out of range: only permission bits 0000-0777 are allowed")
+	}
+}
+
 // validateIntField validates integer type fields
 func (cv *Validator2) validateIntField(v *Validator, field reflect.Value, path string) {
 	val := field.Int()
@@ -425,7 +448,7 @@ func (cv *Validator2) validateSliceField(v *Validator, field reflect.Value, path
 func (cv *Validator2) isOptionalField(path string) bool {
 	optionalFields := []string{
 		"smtp-user", "smtp-password", "email-to", "email-from",
-		"slack-webhook", "save-folder",
+		"slack-webhook", "save-folder", "save-mode", "save-folder-mode",
 		"restore-history", "restore-history-max-age",
 		"container", "service", "image", "user", "network",
 		"environment", "secrets", "volumes", "working_dir",

--- a/config/validator.go
+++ b/config/validator.go
@@ -322,6 +322,14 @@ func (cv *Validator2) validateSpecificStringField(v *Validator, path string, str
 		cv.validateImageField(v, path, str)
 	case "save-folder", "working_dir":
 		cv.validatePathField(v, path, str)
+	// NOTE: save-mode/save-folder-mode (like save-folder and the other keys in
+	// this switch) only reach here when reflected from a non-squashed config.
+	// validateStruct skips ",squash"-embedded structs, so for the production
+	// Config — where SaveConfig is squash-embedded — these are not validated at
+	// load time. The authoritative guard is the runtime resolver
+	// (SaveConfig.GetSaveFileMode/GetSaveFolderMode), which fails the save with a
+	// clear error. This wiring is defense-in-depth, kept consistent with the
+	// sibling cases.
 	case "save-mode", "save-folder-mode":
 		cv.validateFileModeField(v, path, str)
 	}

--- a/config/validator_boundary_test.go
+++ b/config/validator_boundary_test.go
@@ -361,6 +361,42 @@ func TestValidator2ValidateIntField(t *testing.T) {
 	}
 }
 
+// TestValidator2ValidateFileModeField tests octal mode validation for
+// save-mode / save-folder-mode.
+func TestValidator2ValidateFileModeField(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		value     string
+		wantError bool
+	}{
+		{"empty allowed", "", false},
+		{"octal with leading zero", "0644", false},
+		{"octal 0o prefix", "0o755", false},
+		{"bare octal", "750", false},
+		{"max perm bits", "0777", false},
+		{"special bits rejected", "1777", true},
+		{"non-octal digit", "0888", true},
+		{"garbage", "rwx", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cv := &Validator2{sanitizer: NewSanitizer()}
+			v := NewValidator()
+
+			cv.validateFileModeField(v, "save-mode", tt.value)
+
+			if v.HasErrors() != tt.wantError {
+				t.Errorf("validateFileModeField(save-mode, %q) hasError = %v, want %v",
+					tt.value, v.HasErrors(), tt.wantError)
+			}
+		})
+	}
+}
+
 // TestValidator2ValidateStringFieldDefaults tests string field with defaults
 func TestValidator2ValidateStringFieldDefaults(t *testing.T) {
 	t.Parallel()
@@ -411,7 +447,7 @@ func TestValidator2IsOptionalField(t *testing.T) {
 
 	optionalFields := []string{
 		"smtp-user", "smtp-password", "email-to", "email-from",
-		"slack-webhook", "save-folder",
+		"slack-webhook", "save-folder", "save-mode", "save-folder-mode",
 		"container", "service", "image", "user", "network",
 		"environment", "secrets", "volumes", "working_dir",
 		"log-level",

--- a/config/validator_boundary_test.go
+++ b/config/validator_boundary_test.go
@@ -381,6 +381,9 @@ func TestValidator2ValidateFileModeField(t *testing.T) {
 		{"garbage", "rwx", true},
 	}
 
+	if len(tests) < 8 {
+		t.Fatalf("table accidentally emptied — validateFileModeField would be untested: got %d cases", len(tests))
+	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -888,6 +888,16 @@ command = export-data.sh
 save-folder = /var/log/ofelia/exports
 save-only-on-error = false
 
+# File/directory permissions for saved output (octal). Defaults are
+# security-hardened: 0600 files (daemon-uid only) and 0750 folder. Widen them
+# when a non-root operator or shared group must read the logs on the host.
+# Accepts 0644, 0o644 or 644. Like save-folder, these are not in the global
+# Docker-label allow-list, so a container cannot change the daemon-wide default.
+# save-folder-mode applies only when Ofelia creates the folder; an existing
+# folder keeps its current permissions (mkdir -p semantics).
+save-mode = 0644          # default 0600
+save-folder-mode = 0755   # default 0750
+
 # History restoration on startup (set on the [global] section)
 # - restore-history: enable/disable replaying saved executions on daemon start
 #   (default: enabled when save-folder is set)

--- a/middlewares/save.go
+++ b/middlewares/save.go
@@ -5,12 +5,28 @@ package middlewares
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/netresearch/ofelia/core"
+)
+
+// ErrFileModeRange is returned when a configured save-mode/save-folder-mode
+// carries bits outside the permission range (0000-0777).
+var ErrFileModeRange = errors.New("file mode out of range: only permission bits 0000-0777 are allowed")
+
+// Default permissions for save-folder output. These match the security-hardened
+// defaults (gosec G301/G306): logs are readable only by the daemon's uid because
+// job output may contain secrets/PII. Operators can widen them via save-mode /
+// save-folder-mode when their environment needs shared or non-root read access.
+const (
+	defaultSaveFileMode   os.FileMode = 0o600
+	defaultSaveFolderMode os.FileMode = 0o750
 )
 
 // SaveConfig configuration for the Save middleware
@@ -29,6 +45,50 @@ type SaveConfig struct {
 	// RestoreHistoryMaxAge defines the maximum age of execution history to restore on startup.
 	// Only executions newer than this duration are restored. Defaults to 24 hours.
 	RestoreHistoryMaxAge time.Duration `gcfg:"restore-history-max-age" mapstructure:"restore-history-max-age"`
+	// SaveMode is the octal file mode applied to the per-execution log/JSON files.
+	// Parsed as octal (e.g. "0644", "0o644" or "644"). Empty uses the secure
+	// default 0600 (readable only by the daemon uid). Set a wider mode to allow
+	// non-root operators or a shared group to read logs on the host.
+	SaveMode string `gcfg:"save-mode" mapstructure:"save-mode"`
+	// SaveFolderMode is the octal directory mode applied when creating SaveFolder.
+	// Parsed as octal (e.g. "0755"). Empty uses the secure default 0750.
+	SaveFolderMode string `gcfg:"save-folder-mode" mapstructure:"save-folder-mode"`
+}
+
+// parseFileMode parses an octal permission string (e.g. "0644", "0o644" or
+// "644") into an os.FileMode. Only the permission bits (<= 0777) are accepted;
+// special bits (setuid/setgid/sticky) are intentionally rejected as the save
+// middleware writes plain log files. An empty string is rejected — callers
+// resolve the default before calling this.
+func parseFileMode(s string) (os.FileMode, error) {
+	trimmed := strings.TrimSpace(s)
+	// Accept an optional 0o/0O prefix; the remainder is always interpreted as octal.
+	trimmed = strings.TrimPrefix(trimmed, "0o")
+	trimmed = strings.TrimPrefix(trimmed, "0O")
+	v, err := strconv.ParseUint(trimmed, 8, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid octal file mode %q: %w", s, err)
+	}
+	if v > 0o777 {
+		return 0, fmt.Errorf("%q: %w", s, ErrFileModeRange)
+	}
+	return os.FileMode(v), nil
+}
+
+// GetSaveFileMode resolves the mode for output files, defaulting to 0600.
+func (c *SaveConfig) GetSaveFileMode() (os.FileMode, error) {
+	if strings.TrimSpace(c.SaveMode) == "" {
+		return defaultSaveFileMode, nil
+	}
+	return parseFileMode(c.SaveMode)
+}
+
+// GetSaveFolderMode resolves the mode for the save folder, defaulting to 0750.
+func (c *SaveConfig) GetSaveFolderMode() (os.FileMode, error) {
+	if strings.TrimSpace(c.SaveFolderMode) == "" {
+		return defaultSaveFolderMode, nil
+	}
+	return parseFileMode(c.SaveFolderMode)
 }
 
 // RestoreHistoryEnabled returns whether history restoration is enabled.
@@ -92,7 +152,16 @@ func (m *Save) saveToDisk(ctx *core.Context) error {
 		return fmt.Errorf("invalid save folder: %w", err)
 	}
 
-	if err := os.MkdirAll(m.SaveFolder, 0o750); err != nil {
+	folderMode, err := m.GetSaveFolderMode()
+	if err != nil {
+		return fmt.Errorf("invalid save-folder-mode: %w", err)
+	}
+	fileMode, err := m.GetSaveFileMode()
+	if err != nil {
+		return fmt.Errorf("invalid save-mode: %w", err)
+	}
+
+	if err := os.MkdirAll(m.SaveFolder, folderMode); err != nil {
 		return fmt.Errorf("mkdir %q: %w", m.SaveFolder, err)
 	}
 
@@ -105,38 +174,37 @@ func (m *Save) saveToDisk(ctx *core.Context) error {
 	))
 
 	e := ctx.Execution
-	err := m.writeFile(e.ErrorStream.Bytes(), fmt.Sprintf("%s.stderr.log", root))
-	if err != nil {
+	if err := m.writeFile(e.ErrorStream.Bytes(), fmt.Sprintf("%s.stderr.log", root), fileMode); err != nil {
 		return fmt.Errorf("write stderr log: %w", err)
 	}
 
-	err = m.writeFile(e.OutputStream.Bytes(), fmt.Sprintf("%s.stdout.log", root))
-	if err != nil {
+	if err := m.writeFile(e.OutputStream.Bytes(), fmt.Sprintf("%s.stdout.log", root), fileMode); err != nil {
 		return fmt.Errorf("write stdout log: %w", err)
 	}
 
-	err = m.saveContextToDisk(ctx, fmt.Sprintf("%s.json", root))
-	if err != nil {
+	if err := m.saveContextToDisk(ctx, fmt.Sprintf("%s.json", root), fileMode); err != nil {
 		return fmt.Errorf("write context json: %w", err)
 	}
 
 	return nil
 }
 
-func (m *Save) saveContextToDisk(ctx *core.Context, filename string) error {
+func (m *Save) saveContextToDisk(ctx *core.Context, filename string, mode os.FileMode) error {
 	js, _ := json.MarshalIndent(map[string]any{
 		notificationVarJob:       ctx.Job,
 		notificationVarExecution: ctx.Execution,
 	}, "", "  ")
 
-	if err := m.writeFile(js, filename); err != nil {
+	if err := m.writeFile(js, filename, mode); err != nil {
 		return fmt.Errorf("write json file: %w", err)
 	}
 	return nil
 }
 
-func (m *Save) writeFile(data []byte, filename string) error {
-	if err := os.WriteFile(filename, data, 0o600); err != nil {
+func (m *Save) writeFile(data []byte, filename string, mode os.FileMode) error {
+	// mode is operator-configured (save-mode) and defaults to 0600; parseFileMode
+	// caps it at 0777, so it can never grant special bits.
+	if err := os.WriteFile(filename, data, mode); err != nil { // #nosec G306 -- mode is operator-configured, defaults to 0600
 		return fmt.Errorf("write file %q: %w", filename, err)
 	}
 	return nil

--- a/middlewares/save_mode_unix_test.go
+++ b/middlewares/save_mode_unix_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+//go:build unix
+
+// These tests assert on-disk Unix permission bits and neutralize the process
+// umask via syscall.Umask, which only exists on unix GOOS. Ofelia ships a
+// Windows binary (see .goreleaser.yml), so keep them out of the Windows build.
+package middlewares
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSaveAppliesConfiguredModes(t *testing.T) {
+	// Not parallel: neutralizes the process umask so mode assertions are
+	// deterministic regardless of the CI environment's umask.
+	defer syscall.Umask(syscall.Umask(0))
+	ctx, job := setupSaveTestContext(t)
+
+	dir := filepath.Join(t.TempDir(), "logs")
+
+	ctx.Start()
+	ctx.Stop(nil)
+
+	job.Name = testNameFoo
+	ctx.Execution.Date = time.Time{}
+
+	m := NewSave(&SaveConfig{SaveFolder: dir, SaveMode: "0644", SaveFolderMode: "0755"})
+	require.NoError(t, m.Run(ctx))
+
+	di, err := os.Stat(dir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), di.Mode().Perm(), "folder uses save-folder-mode")
+
+	fi, err := os.Stat(filepath.Join(dir, "00010101_000000_"+testNameFoo+".stdout.log"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), fi.Mode().Perm(), "log file uses save-mode")
+}
+
+func TestSaveDefaultModesAre0600And0750(t *testing.T) {
+	// Not parallel: neutralizes the process umask (see TestSaveAppliesConfiguredModes).
+	defer syscall.Umask(syscall.Umask(0))
+	ctx, job := setupSaveTestContext(t)
+
+	dir := filepath.Join(t.TempDir(), "logs")
+
+	ctx.Start()
+	ctx.Stop(nil)
+
+	job.Name = testNameFoo
+	ctx.Execution.Date = time.Time{}
+
+	m := NewSave(&SaveConfig{SaveFolder: dir})
+	require.NoError(t, m.Run(ctx))
+
+	di, err := os.Stat(dir)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o750), di.Mode().Perm())
+
+	fi, err := os.Stat(filepath.Join(dir, "00010101_000000_"+testNameFoo+".stdout.log"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), fi.Mode().Perm())
+}

--- a/middlewares/save_test.go
+++ b/middlewares/save_test.go
@@ -203,6 +203,79 @@ func TestSaveConfig_GetRestoreHistoryMaxAge_NegativeReturnsDefault(t *testing.T)
 	assert.Equal(t, 24*time.Hour, cfg.GetRestoreHistoryMaxAge())
 }
 
+func TestSaveConfig_GetSaveFileMode_DefaultAndCustom(t *testing.T) {
+	t.Parallel()
+
+	def, err := (&SaveConfig{}).GetSaveFileMode()
+	require.NoError(t, err)
+	assert.Equal(t, defaultSaveFileMode, def, "empty save-mode resolves to 0600")
+
+	custom, err := (&SaveConfig{SaveMode: "0644"}).GetSaveFileMode()
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o644), custom)
+}
+
+func TestSaveConfig_GetSaveFolderMode_DefaultAndCustom(t *testing.T) {
+	t.Parallel()
+
+	def, err := (&SaveConfig{}).GetSaveFolderMode()
+	require.NoError(t, err)
+	assert.Equal(t, defaultSaveFolderMode, def, "empty save-folder-mode resolves to 0750")
+
+	custom, err := (&SaveConfig{SaveFolderMode: "0755"}).GetSaveFolderMode()
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), custom)
+}
+
+func TestParseFileMode(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in      string
+		want    os.FileMode
+		wantErr bool
+	}{
+		{in: "0644", want: 0o644},
+		{in: "0o644", want: 0o644},
+		{in: "0O644", want: 0o644},
+		{in: "644", want: 0o644},
+		{in: " 0755 ", want: 0o755},
+		{in: "0", want: 0},
+		{in: "0777", want: 0o777},
+		{in: "1777", wantErr: true}, // special bits rejected
+		{in: "0888", wantErr: true}, // not octal
+		{in: "abc", wantErr: true},
+		{in: "", wantErr: true},
+	}
+	for _, tc := range cases {
+		got, err := parseFileMode(tc.in)
+		if tc.wantErr {
+			require.Errorf(t, err, "parseFileMode(%q) should error", tc.in)
+			continue
+		}
+		require.NoErrorf(t, err, "parseFileMode(%q)", tc.in)
+		assert.Equalf(t, tc.want, got, "parseFileMode(%q)", tc.in)
+	}
+}
+
+func TestSaveInvalidModeReturnsError(t *testing.T) {
+	t.Parallel()
+	ctx, job := setupSaveTestContext(t)
+
+	dir := filepath.Join(t.TempDir(), "logs")
+
+	ctx.Start()
+	ctx.Stop(nil)
+
+	job.Name = testNameFoo
+	ctx.Execution.Date = time.Time{}
+
+	m := &Save{SaveConfig{SaveFolder: dir, SaveMode: "not-octal"}}
+	err := m.saveToDisk(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "save-mode")
+}
+
 func TestSaveRunOnlyOnError_Saves(t *testing.T) {
 	t.Parallel()
 	ctx, job := setupSaveTestContext(t)

--- a/middlewares/save_test.go
+++ b/middlewares/save_test.go
@@ -247,6 +247,7 @@ func TestParseFileMode(t *testing.T) {
 		{in: "abc", wantErr: true},
 		{in: "", wantErr: true},
 	}
+	require.GreaterOrEqual(t, len(cases), 11, "table accidentally emptied — parseFileMode would be untested")
 	for _, tc := range cases {
 		got, err := parseFileMode(tc.in)
 		if tc.wantErr {
@@ -260,20 +261,35 @@ func TestParseFileMode(t *testing.T) {
 
 func TestSaveInvalidModeReturnsError(t *testing.T) {
 	t.Parallel()
-	ctx, job := setupSaveTestContext(t)
 
-	dir := filepath.Join(t.TempDir(), "logs")
+	// Both sibling mode resolvers must surface a clear, attributable error.
+	cases := []struct {
+		name    string
+		cfg     SaveConfig
+		wantMsg string
+	}{
+		{"invalid save-mode", SaveConfig{SaveMode: "not-octal"}, "save-mode"},
+		{"invalid save-folder-mode", SaveConfig{SaveFolderMode: "not-octal"}, "save-folder-mode"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, job := setupSaveTestContext(t)
 
-	ctx.Start()
-	ctx.Stop(nil)
+			dir := filepath.Join(t.TempDir(), "logs")
+			ctx.Start()
+			ctx.Stop(nil)
+			job.Name = testNameFoo
+			ctx.Execution.Date = time.Time{}
 
-	job.Name = testNameFoo
-	ctx.Execution.Date = time.Time{}
-
-	m := &Save{SaveConfig{SaveFolder: dir, SaveMode: "not-octal"}}
-	err := m.saveToDisk(ctx)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "save-mode")
+			cfg := tc.cfg
+			cfg.SaveFolder = dir
+			m := &Save{cfg}
+			err := m.saveToDisk(ctx)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantMsg)
+		})
+	}
 }
 
 func TestSaveRunOnlyOnError_Saves(t *testing.T) {

--- a/middlewares/uncovered_ext_test.go
+++ b/middlewares/uncovered_ext_test.go
@@ -999,7 +999,7 @@ func TestSave_WriteFile_Error(t *testing.T) {
 	t.Parallel()
 
 	s := &Save{}
-	err := s.writeFile([]byte("data"), "/nonexistent/path/file.txt")
+	err := s.writeFile([]byte("data"), "/nonexistent/path/file.txt", defaultSaveFileMode)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "write file")
 }
@@ -1012,7 +1012,7 @@ func TestSave_SaveContextToDisk_WriteError(t *testing.T) {
 	ctx.Start()
 	ctx.Stop(nil)
 
-	err := s.saveContextToDisk(ctx, "/nonexistent/path/file.json")
+	err := s.saveContextToDisk(ctx, "/nonexistent/path/file.json", defaultSaveFileMode)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "write json file")
 }


### PR DESCRIPTION
## Summary

Makes the `save` middleware's output permissions configurable, resolving #729.

Since commit `5211e54b` (clearing gosec G301/G306), the middleware hardcoded log files to `0600` and the save folder to `0750`, with no override. That makes captured job logs readable only by the daemon uid (root by default) — breaking any workflow where a non-root operator or shared group needs to read the logs on the host, and a behavioral regression vs. `mcuadros/ofelia` (which wrote `0644`).

Rather than revert (which would re-trip gosec and weaken the default for everyone), this adds opt-in config keys while keeping the hardened defaults.

## Changes

Two new optional `[global]`/per-job INI keys, parsed as octal:

```ini
save-folder = /var/log/ofelia/
save-mode = 0644          ; default 0600 (files: *.stdout.log/*.stderr.log/*.json)
save-folder-mode = 0755   ; default 0750 (the save folder)
```

- Accept `0644`, `0o644` or `644`; capped at `0777` (special setuid/sticky bits rejected).
- Validated at write time by the resolvers (`GetSaveFileMode`/`GetSaveFolderMode`), which fail the save with a clear, attributable error — no silent fallback to a wrong mode. (Config-load validation is wired in for completeness but, like the existing `save-folder`/`email-to` keys, does not fire for the squash-embedded `SaveConfig`; the runtime resolver is the authoritative guard.)
- Inherit global→job exactly like `save-folder`.

## Security

`save-mode`/`save-folder-mode` are deliberately **not** in the global Docker-label allow-list (mirroring `save-folder`), so a scheduled container cannot change the daemon-wide default. A regression test (`TestGlobalLabelAllowList_OmitsSavePermissionKeys`) pins this.

Note: per standard `mkdir -p` semantics, `save-folder-mode` only applies when Ofelia **creates** the folder; an existing (e.g. bind-mounted) folder keeps its current permissions. Documented in README and CONFIGURATION.md.

## Tests

- Octal parser edge cases (`0o`-prefix, bare, special-bit/non-octal rejection, `0777` boundary).
- Default vs. custom modes asserted on disk, umask-neutralized (in a `//go:build unix` file — `syscall.Umask` and Unix mode bits don't exist on the Windows release target).
- Config-validator octal cases; allow-list omission regression test.
- Global→job inheritance of both keys, in `mergeSaveDefaults` and `mergeSaveGlobals` (label-fills-empty and INI-wins).
- Both runtime mode-resolver error branches (`save-mode` and `save-folder-mode`) assert an attributable error.
- Minimum-count guards on the parser case tables (per review feedback).

## Verification

`go build ./...`, full `go test ./...` (linux), `GOOS=windows go vet ./...`, and `golangci-lint` all pass locally. (The local pre-push smoke hook hangs in the unrelated `core/adapters/docker` integration package on my WSL2 Docker box; this PR touches no files under `core/`.)

Closes #729


