### PR TITLE
docs(architecture): adopt ofelia-relevant scheduler examples cut from go-development-skill

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,20 +4,97 @@ Ofelia is built around a pluggable scheduler that manages different job types an
 
 ## Scheduler
 
-The scheduler wraps [robfig/cron](https://github.com/robfig/cron) and keeps track of all registered jobs. It runs them according to their cron expressions and exposes methods to start or stop execution. Each job is wrapped so execution metadata and middleware can be handled.
+The scheduler wraps [`netresearch/go-cron`](https://github.com/netresearch/go-cron)
+(a maintained fork of `robfig/cron` with a DAG engine, pause/resume, and
+`@triggered` schedules) and keeps track of all registered jobs. It runs them
+according to their cron expressions and exposes methods to start or stop
+execution. Each job is wrapped so execution metadata and middleware can be
+handled.
+
+Jobs are registered by name for O(1) lookup, update and removal.
+`AddJobWithTags` builds `cron.JobOption`s before handing the job to go-cron:
+
+```go
+opts := []cron.JobOption{cron.WithName(j.GetName())}
+if len(tags) > 0 {
+    opts = append(opts, cron.WithTags(tags...))
+}
+if j.ShouldRunOnStartup() {
+    opts = append(opts, cron.WithRunImmediately())
+}
+id, err := s.cron.AddJob(j.GetSchedule(), &jobWrapper{s, j}, opts...)
+```
+
+Removal waits for any in-flight run to finish before the job is dropped from
+scheduler state, and update replaces the entry in place by name:
+
+```go
+s.cron.RemoveByName(j.GetName())
+s.cron.WaitForJobByName(j.GetName())
+```
+
+See `core/scheduler.go` (`AddJobWithTags`, `RemoveJob`, `UpdateJob`, `DisableJob`/`EnableJob`).
 
 ## Job types
 
-Jobs implement a common interface and can be executed in several ways:
+Every job type implements the `Job` interface (`core/common.go`) and embeds
+`BareJob` for the shared bookkeeping (name, schedule, execution history, retry
+config, middleware chain), so a new job type only has to add its own config
+fields and a `Run` method:
 
-- **`exec`** – run a command inside an existing container similar to `docker exec`.
-- **`run`** – start a new container for every execution.
-- **`local`** – execute a command on the host where Ofelia runs.
-- **`service-run`** – run a one‑off service in a Docker swarm.
+```go
+type Job interface {
+    GetName() string
+    GetSchedule() string
+    GetCommand() string
+    Run(*Context) error
+    Middlewares() []Middleware
+    Use(...Middleware)
+    // ... history, retry and cron-id accessors
+}
+
+type ExecJob struct {
+    BareJob   `mapstructure:",squash"`
+    Provider  DockerProvider
+    Container string `hash:"true"`
+    // ... exec-specific fields (User, Environment, WorkingDir, ...)
+}
+```
+
+Jobs can be executed in several ways:
+
+- **`exec`** (`core/execjob.go`) – run a command inside an existing container
+  similar to `docker exec`.
+- **`run`** (`core/runjob.go`) – start a new container for every execution.
+- **`local`** (`core/localjob.go`) – execute a command on the host where
+  Ofelia runs.
+- **`service-run`** (`core/runservice.go`) – run a one‑off service in a
+  Docker swarm.
 
 ## Middleware
 
-Middleware hooks are executed around every job. Ofelia provides built-in middleware for logging via mail, saving execution reports and sending Slack messages. Custom middleware can be added by implementing the interface in `core` and attaching it to the scheduler or to individual jobs.
+Middleware is a chain-of-responsibility, not a wrapper function: each
+`Middleware.Run(*Context)` must call `ctx.Next()` to continue to the next
+middleware and, once the chain is exhausted, to the job itself.
+
+```go
+type Middleware interface {
+    Run(*Context) error   // MUST call ctx.Next() to continue the chain
+    ContinueOnStop() bool // run even after the execution was already stopped?
+}
+```
+
+Attach middleware globally via `Scheduler.Use(...)` or per-job via
+`Job.Use(...)`; global middleware propagates to every job. Middleware is
+deduplicated by type, so attaching the same middleware twice is a no-op —
+implementations that legitimately need multiple instances (e.g. several
+webhook destinations) opt into per-instance dedup via a `Key() string` method.
+Ofelia provides built-in middleware for logging via mail, saving execution
+reports, sending Slack messages and webhooks, deduplicating overlapping runs,
+and skipping already-running jobs. Custom middleware can be added by
+implementing the interface in `core` and attaching it to the scheduler or to
+individual jobs. See `core/common.go` (`Context.Next`, `Middleware`) and
+`middlewares/` for the built-in implementations.
 
 ## HTTP interfaces
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -77,6 +77,11 @@ Middleware is a chain-of-responsibility, not a wrapper function: each
 `Middleware.Run(*Context)` must call `ctx.Next()` to continue to the next
 middleware and, once the chain is exhausted, to the job itself.
 
+Short-circuiting (e.g. the overlap middleware skipping an already-running job)
+is done by calling `ctx.Stop(err)`, not by omitting `ctx.Next()`: the middleware
+still calls `ctx.Next()`, and `doNext()` then stops advancing to any subsequent
+middleware whose `ContinueOnStop()` is false (`core/common.go`).
+
 ```go
 type Middleware interface {
     Run(*Context) error   // MUST call ctx.Next() to continue the chain


### PR DESCRIPTION
## What

netresearch/go-development-skill#44 cut its generic Go job-scheduler tutorial
code (bitmask parser options, a fictional `BareJob`/`ExecJob`/`RunJob`/`LocalJob`
hierarchy, a middleware-wrapper chain, a `go-cron`-backed scheduler core loop,
retry/circuit-breaker/timeout wrappers, a REST jobs API) as not
Netresearch-specific — most of it was invented tutorial content, and the rest
duplicated `go-cron`'s own docs. The PR's `architecture.md` left a note to
move the genuinely ofelia-relevant parts here (netresearch/ofelia#739).

Most of the cut content doesn't apply as-is: ofelia's real resilience story
(`core/resilient_job.go`, `core/retry.go` — circuit breaker, rate limiter,
bulkhead, per-job retry config) and its REST API
(`web/server.go`, already documented in `docs/architecture.md`'s "HTTP
interfaces" section) are richer than the generic tutorial and didn't need
porting. What *is* genuinely missing from `docs/architecture.md` is code-level
grounding for the three sections that already exist there in prose only:

- **Scheduler**: named-job registration/removal against `go-cron`
  (`cron.JobOption`s, `RemoveByName` + `WaitForJobByName`), sourced from
  `core/scheduler.go` (`AddJobWithTags`, `RemoveJob`). Also corrects a stale
  claim — the doc said the scheduler wraps `robfig/cron`; it actually wraps
  `netresearch/go-cron`, a maintained fork (per this repo's own `AGENTS.md`
  and `core/scheduler.go`'s import).
- **Job types**: the real `Job` interface and `BareJob` embedding pattern
  (`core/common.go`, `core/execjob.go`) that every job type (`exec`, `run`,
  `local`, `service-run`) actually implements.
- **Middleware**: the real chain-of-responsibility (`Middleware.Run` +
  `ctx.Next()`), which is a `Context`-driven chain, not the function-wrapper
  style (`func(Job) Job`) the cut tutorial used — worth documenting precisely
  because it's a different (and non-obvious) shape from the generic pattern.

## Where it landed

`docs/architecture.md`, not `docs/INTEGRATION_PATTERNS.md`. That file is
purely end-user job configuration (INI/`docker-compose` labels) — the cut
content is Go-internals material for someone extending or understanding
ofelia's own code, and `docs/architecture.md` already had matching
"Scheduler" / "Job types" / "Middleware" section headers with zero code
examples, so it's where this has the most context.

## Verification

- `npx markdownlint-cli2 docs/architecture.md` — 2 pre-existing findings
  (line-length on an untouched line, trailing blank at EOF), 0 new.
- All added code snippets are copied/trimmed from the actual current source
  (`core/scheduler.go`, `core/common.go`, `core/execjob.go`), not invented.
- No CI markdown-lint job exists in this repo to gate on.

Closes #739
