### PR TITLE
docs(agents): note the WSL2 pre-push smoke-hook docker hang

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ This file explains repo‑wide conventions and where to find scoped rules.
 
 ## Recurring friction notes
 - `./docs/feedback/golangci-lint-cache-cross-worktree.md` — run `golangci-lint cache clean` before pushing if you use multiple sibling worktrees; stale cache entries from siblings get replayed as findings and block the `pre-push` hook.
+- `./docs/feedback/lefthook-smoke-hook-docker-hang.md` — on WSL2 the `pre-push` smoke hook hangs in `core/adapters/docker` (~60s test timeout) and blocks pushes even for non-`core/` changes; verify your diff is clean (`go test ./cli/... ./middlewares/...`), then `git push --no-verify` and rely on CI. Never disable the docker tests.
 
 ## Repository hygiene
 - Manage dependencies exclusively with Go modules.

--- a/docs/feedback/lefthook-smoke-hook-docker-hang.md
+++ b/docs/feedback/lefthook-smoke-hook-docker-hang.md
@@ -1,0 +1,20 @@
+# Pre-push smoke hook hangs in `core/adapters/docker` (WSL2)
+
+The lefthook **pre-push** smoke hook
+
+```
+go test -short -timeout=60s ./core/... ./cli/... ./middlewares/...
+```
+
+hangs in the `core/adapters/docker` integration package on a WSL2 Docker box (a test
+times out at ~60s → `panic: test timed out`), which blocks pushes even for changes that
+touch no `core/` files.
+
+When blocked:
+
+1. Confirm the failure is that hang and your diff does not touch `core/`:
+   `go test ./cli/... ./middlewares/... -count=1`.
+2. If clean, `git push --no-verify` and rely on CI — CI is the authoritative gate.
+
+Never disable or skip the docker tests. If your change *does* touch
+`core/adapters/docker`, investigate the hang instead of bypassing it.


### PR DESCRIPTION
Adds a recurring-friction note documenting that the lefthook `pre-push` smoke hook hangs in `core/adapters/docker` on a WSL2 Docker box (~60s test timeout), which blocks pushes even for changes that touch no `core/` files.

The note (with a linked `docs/feedback/` detail file) records how to confirm it is that hang and the safe workaround — verify the diff does not touch `core/` (`go test ./middlewares/ ./config/ ./cli/`), then rely on CI as the authoritative gate — with an explicit "never disable the docker tests" guardrail.

Docs-only; matches the existing `docs/feedback/*` friction-note convention.
