### PR TITLE
fix(web): default RunJob.Delete to true for API-created and persisted jobs

### DIFF
--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -614,6 +614,10 @@ func (c *DaemonCommand) buildPersistedRunJob(name string, j *persist.Job, provid
 	rj.Command = j.Command
 	rj.Image = j.Image
 	rj.Container = j.Container
+	// Same gap as newRunJobFromRequest (web/server.go): Delete's "true" default only
+	// applies through the config.ini decoder, and persisted API jobs are rebuilt here on
+	// every daemon restart without going through it.
+	rj.Delete = "true"
 	return rj, nil
 }
 

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/creasty/defaults"
 	"github.com/gobs/args"
 
 	cfgvalidator "github.com/netresearch/ofelia/config"
@@ -609,15 +610,13 @@ func (c *DaemonCommand) buildPersistedRunJob(name string, j *persist.Job, provid
 		return nil, fmt.Errorf("docker provider unavailable for run job")
 	}
 	rj := core.NewRunJob(provider)
+	// struct-tag defaults are only applied by the config decoder — apply them here too.
+	_ = defaults.Set(rj)
 	rj.Name = name
 	rj.Schedule = j.Schedule
 	rj.Command = j.Command
 	rj.Image = j.Image
 	rj.Container = j.Container
-	// Same gap as newRunJobFromRequest (web/server.go): Delete's "true" default only
-	// applies through the config.ini decoder, and persisted API jobs are rebuilt here on
-	// every daemon restart without going through it.
-	rj.Delete = "true"
 	return rj, nil
 }
 

--- a/cli/daemon_persisted_run_job_delete_default_test.go
+++ b/cli/daemon_persisted_run_job_delete_default_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/netresearch/ofelia/core"
+	"github.com/netresearch/ofelia/core/persist"
+)
+
+// TestBuildPersistedRunJob_DefaultsDelete pins the restore-path half of
+// the container-leak fix. buildPersistedRunJob rebuilds a persisted
+// job-run on every daemon restart (initPersistStore -> newDaemonForPersistTest
+// et al.) through a path entirely separate from newRunJobFromRequest
+// (web/server.go) — a job created before this fix, or reloaded across
+// any restart, would keep leaking containers even after the API path
+// was patched if this path is not fixed too.
+func TestBuildPersistedRunJob_DefaultsDelete(t *testing.T) {
+	t.Parallel()
+
+	c := newDaemonForPersistTest(t)
+	job, err := c.buildPersistedRunJob("persisted-run-job", &persist.Job{
+		Type:     persist.JobTypeRun,
+		Schedule: "@hourly",
+		Image:    "busybox",
+	}, &mockDockerProvider{})
+	if err != nil {
+		t.Fatalf("buildPersistedRunJob: %v", err)
+	}
+
+	rj, ok := job.(*core.RunJob)
+	if !ok {
+		t.Fatalf("expected *core.RunJob, got %T", job)
+	}
+	if rj.Delete != "true" {
+		t.Fatalf("Delete = %q, want \"true\" — persisted run jobs must clean up their container on every restart", rj.Delete)
+	}
+}

--- a/web/server.go
+++ b/web/server.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/creasty/defaults"
 	"github.com/gobs/args"
 	cron "github.com/netresearch/go-cron"
 
@@ -754,17 +755,13 @@ func (s *Server) newRunJobFromRequest(req *jobRequest) (core.Job, error) {
 		return nil, fmt.Errorf("docker provider unavailable for run job")
 	}
 	j := core.NewRunJob(s.provider)
+	// struct-tag defaults are only applied by the config decoder — apply them here too.
+	_ = defaults.Set(j)
 	j.Name = req.Name
 	j.Schedule = req.Schedule
 	j.Command = req.Command
 	j.Image = req.Image
 	j.Container = req.Container
-	// RunJob.Delete only gets its "true" default (core/runjob.go) via the config.ini
-	// decoder's default-tag handling; jobs built here from a jobRequest never go through
-	// that decoder, so Delete was left at its zero value ("") and deleteContainer() treated
-	// that as false — the container from every API-created run job was left behind,
-	// colliding with the next run's `docker create` on the same name.
-	j.Delete = "true"
 	return j, nil
 }
 

--- a/web/server.go
+++ b/web/server.go
@@ -759,6 +759,12 @@ func (s *Server) newRunJobFromRequest(req *jobRequest) (core.Job, error) {
 	j.Command = req.Command
 	j.Image = req.Image
 	j.Container = req.Container
+	// RunJob.Delete only gets its "true" default (core/runjob.go) via the config.ini
+	// decoder's default-tag handling; jobs built here from a jobRequest never go through
+	// that decoder, so Delete was left at its zero value ("") and deleteContainer() treated
+	// that as false — the container from every API-created run job was left behind,
+	// colliding with the next run's `docker create` on the same name.
+	j.Delete = "true"
 	return j, nil
 }
 

--- a/web/server_run_job_delete_default_test.go
+++ b/web/server_run_job_delete_default_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package web
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/netresearch/ofelia/core"
+)
+
+// TestNewRunJobFromRequest_DefaultsDelete pins the fix for the
+// container-leak bug: jobRequest has no "delete" field, and unlike
+// config.ini-sourced jobs (whose RunJob.Delete defaults to "true" via
+// the decoder's default-tag handling), a job built here from the API
+// request used to leave Delete at its zero value (""). deleteContainer
+// treats that as false, so every API-created run job's container was
+// left behind and collided with the next run's `docker create` on the
+// same name ("resource conflict"). Delete must default to "true" here
+// to match the config.ini behavior.
+func TestNewRunJobFromRequest_DefaultsDelete(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	s := NewServer("", core.NewScheduler(logger), nil, newHangingDockerProvider())
+
+	job, err := s.newRunJobFromRequest(&jobRequest{
+		Name:     "api-run-job",
+		Type:     "run",
+		Schedule: "@hourly",
+		Image:    "busybox",
+	})
+	if err != nil {
+		t.Fatalf("newRunJobFromRequest: %v", err)
+	}
+
+	rj, ok := job.(*core.RunJob)
+	if !ok {
+		t.Fatalf("expected *core.RunJob, got %T", job)
+	}
+	if rj.Delete != "true" {
+		t.Fatalf("Delete = %q, want \"true\" — API-created run jobs must clean up their container like config.ini ones do", rj.Delete)
+	}
+}


### PR DESCRIPTION
## Summary

`RunJob.Delete` (`core/runjob.go`) only gets its `"true"` default through the config.ini decoder's `default` struct tag. Jobs built directly from a `jobRequest` (`newRunJobFromRequest`, `web/server.go`) or rebuilt from the state file on daemon restart (`buildPersistedRunJob`, `cli/daemon.go`) never go through that decoder, so `Delete` is left at its zero value (`""`). `deleteContainer()` (`core/runjob.go`) treats that as `false` via `strconv.ParseBool("")`, so the container from every `type=run` job created through the web API is left behind after it finishes.

On the next scheduled run, `docker create` fails because a container with that name already exists:

```
job run: creating container: create container "<name>": resource conflict
```

`jobRequest` doesn't expose a `delete` field to work around this at the call site, and the two construction paths (live API creation vs. state-file restore on restart) are independent, so both needed the same one-line fix to match the behavior config.ini users already get by default.

Found and reproduced against a real deployment (a daily ETL job created through the web UI started failing every day once its previous container was left behind — confirmed with `docker ps -a` showing the `Exited (0)` container days after its last run, and by reading the source to trace why).

## Changes

- `web/server.go`: `newRunJobFromRequest` now sets `j.Delete = "true"`.
- `cli/daemon.go`: `buildPersistedRunJob` now sets `rj.Delete = "true"`.
- Added a regression test for each path asserting the constructed `*core.RunJob` has `Delete == "true"`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./web/... ./cli/...` (full package suites, not just the new tests)
- [x] `gofmt -l .` clean
- [x] Manually reproduced end-to-end against a local build: created a `type=run` job via `POST /api/jobs/create`, ran it twice in a row (second run previously failed with `resource conflict`, now succeeds and container is removed both times); also verified across a daemon restart (`buildPersistedRunJob` path) with `OFELIA_STATE_FILE` set — same result.