### PR TITLE
fix(core): make the circuit-breaker boundary test deterministic

### DIFF
--- a/core/resilience.go
+++ b/core/resilience.go
@@ -129,6 +129,11 @@ type CircuitBreaker struct {
 	totalSuccesses uint64
 	lastOpenedAt   time.Time
 	openDuration   time.Duration
+
+	// now supplies the current time. It is always time.Now outside tests;
+	// the seam exists so the reset-timeout boundary can be exercised
+	// deterministically instead of by sleeping close to it.
+	now func() time.Time
 }
 
 // NewCircuitBreaker creates a new circuit breaker
@@ -139,6 +144,7 @@ func NewCircuitBreaker(name string, maxFailures uint32, resetTimeout time.Durati
 		resetTimeout:     resetTimeout,
 		halfOpenMaxCalls: 1,
 		state:            StateClosed,
+		now:              time.Now,
 	}
 }
 
@@ -172,7 +178,7 @@ func (cb *CircuitBreaker) beforeCall() error {
 
 	case StateOpen:
 		// Check if we should transition to half-open
-		if time.Since(cb.lastFailureTime) > cb.resetTimeout {
+		if cb.now().Sub(cb.lastFailureTime) > cb.resetTimeout {
 			cb.transitionToHalfOpen()
 			return nil
 		}
@@ -230,7 +236,7 @@ func (cb *CircuitBreaker) onFailure() {
 	atomic.AddUint64(&cb.totalFailures, 1)
 
 	cb.failures++
-	cb.lastFailureTime = time.Now()
+	cb.lastFailureTime = cb.now()
 
 	switch cb.state {
 	case StateClosed:
@@ -250,7 +256,7 @@ func (cb *CircuitBreaker) onFailure() {
 // transitionToOpen transitions the circuit breaker to open state
 func (cb *CircuitBreaker) transitionToOpen() {
 	cb.state = StateOpen
-	cb.lastOpenedAt = time.Now()
+	cb.lastOpenedAt = cb.now()
 	cb.failures = 0
 	cb.successCount = 0
 	cb.halfOpenCalls = 0
@@ -264,7 +270,7 @@ func (cb *CircuitBreaker) transitionToHalfOpen() {
 
 	// Track how long we were open
 	if !cb.lastOpenedAt.IsZero() {
-		cb.openDuration += time.Since(cb.lastOpenedAt)
+		cb.openDuration += cb.now().Sub(cb.lastOpenedAt)
 	}
 }
 

--- a/core/resilience_mutation_test.go
+++ b/core/resilience_mutation_test.go
@@ -315,17 +315,23 @@ func TestRetry_BackoffCalculation(t *testing.T) {
 //
 //	CONDITIONALS_BOUNDARY at line 173:37 (time.Since(cb.lastFailureTime) > cb.resetTimeout)
 //
-// If > is changed to >=, then the transition happens at exactly the timeout.
-// We test that the circuit does NOT transition when time.Since == timeout (approximately)
-// and DOES transition when time.Since > timeout.
+// If > is changed to >=, the transition happens at exactly the timeout. The
+// breaker's clock is driven directly rather than slept against: sleeping to
+// just-below the boundary made the test depend on the scheduler returning
+// within a few tens of milliseconds, which it does not guarantee on a loaded
+// runner (see #750). Driving the clock also lets the exact-boundary case be
+// asserted, which no amount of sleeping could do reliably.
 func TestCircuitBreaker_HalfOpenTransitionBoundary(t *testing.T) {
 	t.Parallel()
 
-	// Use a short timeout for testing
 	timeout := 100 * time.Millisecond
 	cb := NewCircuitBreaker("boundary-test", 1, timeout)
 
-	// Trip the circuit breaker
+	base := time.Now()
+	current := base
+	cb.now = func() time.Time { return current }
+
+	// Trip the circuit breaker.
 	cb.Execute(func() error {
 		return errors.New("fail")
 	})
@@ -333,18 +339,23 @@ func TestCircuitBreaker_HalfOpenTransitionBoundary(t *testing.T) {
 		t.Fatal("expected circuit to be open")
 	}
 
-	// Wait slightly less than the timeout - should still be open
-	time.Sleep(timeout - 30*time.Millisecond)
-	err := cb.Execute(func() error { return nil })
-	if err == nil {
-		t.Error("expected error when timeout has not elapsed")
+	// Just below the timeout: still open.
+	current = base.Add(timeout - time.Nanosecond)
+	if err := cb.Execute(func() error { return nil }); err == nil {
+		t.Error("expected error just below the reset timeout")
 	}
 
-	// Wait past the timeout - should transition to half-open and allow call
-	time.Sleep(60 * time.Millisecond) // total wait > timeout
-	err = cb.Execute(func() error { return nil })
-	if err != nil {
-		t.Errorf("expected no error after timeout elapsed, got %v", err)
+	// Exactly at the timeout: still open, because the comparison is strictly
+	// greater. This is the mutation the test exists to catch.
+	current = base.Add(timeout)
+	if err := cb.Execute(func() error { return nil }); err == nil {
+		t.Error("expected error at exactly the reset timeout (> not >=)")
+	}
+
+	// Past the timeout: transitions to half-open and allows the call.
+	current = base.Add(timeout + time.Nanosecond)
+	if err := cb.Execute(func() error { return nil }); err != nil {
+		t.Errorf("expected no error past the reset timeout, got %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #750.

`TestCircuitBreaker_HalfOpenTransitionBoundary` tripped a breaker with a 100ms reset timeout, slept 70ms, and asserted the breaker was still open. The whole margin was 30ms of wall clock, and `time.Sleep` guarantees only a lower bound — so on a loaded runner the sleep overshoots, the breaker legitimately transitions to half-open, and the assertion fires. It failed exactly that way on the v0.28.0 release PR (#749), which changed nothing but `CHANGELOG.md`.

## Approach

`CircuitBreaker` gets a `now func() time.Time` seam, defaulting to `time.Now` in `NewCircuitBreaker`. That constructor is the only place a `CircuitBreaker` is built (verified by grep), so no caller can reach a nil clock. The four time reads inside the breaker go through it. Production behavior is unchanged.

The test drives that clock instead of sleeping.

## This strengthens the test rather than relaxing it

The mutation the test exists to kill is `>` → `>=` on the reset-timeout comparison. The sleep-based version stepped from 70ms straight to 130ms, so it never observed the boundary itself — it caught the mutation only indirectly. The rewrite asserts three points exactly: just below the timeout, **at** the timeout, and just past it. The exact-timeout case is precisely where the mutation hides.

Proven both directions:

| | Result |
|---|---|
| 50 consecutive runs, unmodified | pass, 8ms total (was ~280ms per run) |
| with `>` changed to `>=` | **fails** at `expected error at exactly the reset timeout (> not >=)` |

## Verification

- `go test -run TestCircuitBreaker_HalfOpenTransitionBoundary -count=50 ./core/` — pass
- `go test -race ./...` — 14/14
- `go test -tags=integration ./...` — 14/14
- build + vet clean under default and `integration` tags
- `golangci-lint run` — 0 issues