### PR TITLE
docs: give every package a doc comment and enforce it

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,7 +66,6 @@ linters:
         - name: blank-imports
           disabled: true
         - name: package-comments
-          disabled: true
         - name: var-naming
         - name: exported
         - name: if-return
@@ -84,7 +83,6 @@ linters:
   exclusions:
     generated: lax
     presets:
-      - comments
       - common-false-positives
       - legacy
       - std-error-handling
@@ -230,6 +228,9 @@ linters:
           - paralleltest
           - tparallel
         path: e2e/.*_test\.go
+      - linters:
+          - revive
+        text: '^exported: '
     paths:
       - third_party$
       - builtin$

--- a/cli/doc.go
+++ b/cli/doc.go
@@ -1,0 +1,7 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+// Package cli wires the daemon together: it parses flags and the INI
+// configuration, discovers jobs from Docker container labels, reconciles the
+// scheduler when either source changes, and owns the process lifecycle.
+package cli

--- a/config/doc.go
+++ b/config/doc.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+// Package config validates and sanitizes values that reach the daemon from
+// untrusted sources, most importantly the shell commands attached to jobs.
+package config

--- a/core/doc.go
+++ b/core/doc.go
@@ -1,0 +1,8 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+// Package core holds the scheduler and the job types it runs: ExecJob (in a
+// running container), RunJob (in a fresh container), RunServiceJob (as a Swarm
+// service) and LocalJob (on the host). Docker access goes through the port
+// interfaces in core/ports so the scheduler stays independent of the SDK.
+package core

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+// Ofelia is a job scheduler for Docker hosts, and a replacement for cron in
+// container environments. Jobs are declared in an INI file, through labels on
+// the containers themselves, or at runtime through the web API, and run either
+// inside an existing container, in a fresh one, on the host, or as a Swarm
+// service.
+//
+// Run the daemon with:
+//
+//	ofelia daemon --config=/etc/ofelia.conf
+//
+// Job results can be captured and forwarded by middlewares (log files, e-mail,
+// Slack, generic webhooks), and the daemon optionally serves a web UI and REST
+// API for inspecting and managing jobs.
+//
+// See https://github.com/netresearch/ofelia for configuration reference and
+// deployment guides.
+package main

--- a/metrics/doc.go
+++ b/metrics/doc.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+// Package metrics exposes scheduler and job statistics in Prometheus format,
+// plus HTTP middleware that records request metrics for the web server.
+package metrics

--- a/middlewares/doc.go
+++ b/middlewares/doc.go
@@ -1,0 +1,7 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+// Package middlewares implements the hooks that run around a job execution and
+// report its outcome: writing logs and JSON reports to disk, sending e-mail,
+// and posting to Slack or a generic webhook endpoint.
+package middlewares

--- a/static/doc.go
+++ b/static/doc.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+// Package static embeds the compiled assets of the web interface so the daemon
+// ships as a single binary.
+package static

--- a/test/doc.go
+++ b/test/doc.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+// Package test provides helpers shared across the test suites, such as a logger
+// that captures records for assertions.
+package test

--- a/web/doc.go
+++ b/web/doc.go
@@ -1,0 +1,6 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+// Package web serves the browser interface and the REST API used to inspect
+// jobs, trigger runs, and manage jobs created at runtime.
+package web


### PR DESCRIPTION
Fixes the "no documentation" state on [pkg.go.dev](https://pkg.go.dev/github.com/netresearch/ofelia).

## Why the page was empty

Not an indexing or license problem — there genuinely was no documentation. `go doc .` returned nothing.

The module root is `package main`, and the only comment above the package clause is the SPDX header:

```go
// Copyright (c) 2025-2026 Netresearch DTT GmbH
// SPDX-License-Identifier: MIT
                              ← blank line
package main
```

Go treats a comment block as package documentation only when it is immediately adjacent to the `package` clause. The blank line separates it, so there was no doc comment. (The blank line is correct — without it pkg.go.dev would render the copyright header as the package description.)

Nine of fifteen packages were in that state: the root plus `cli`, `config`, `core`, `metrics`, `middlewares`, `static`, `test`, `web`. The packages added more recently (`core/adapters/*`, `core/domain`, `core/ports`, `core/persist`, `test/testutil`) already had comments.

## What this changes

A `doc.go` per undocumented package, describing what it actually does rather than restating its name. The root one doubles as the command's documentation, which is what pkg.go.dev renders for a command module:

```
Ofelia is a job scheduler for Docker hosts, and a replacement for cron in
container environments. Jobs are declared in an INI file, through labels on the
containers themselves, or at runtime through the web API, and run either inside
an existing container, in a fresh one, on the host, or as a Swarm service.
...
```

## Making it stick

Documentation that nothing enforces drifts back, which is how this happened: revive's `package-comments` rule was already in `.golangci.yml` — explicitly `disabled: true`.

Enabling it was not enough. The rule stayed silent because the `comments` exclusion preset filtered it out. Removing that preset makes the rule effective, but also surfaces **50** findings about missing comments on exported symbols — a separate and much larger question. So the exported-symbol rule keeps its current exemption through a targeted exclusion (`text: '^exported: '`), and only the package-comment requirement becomes blocking.

Net config change is three lines:

```diff
       - name: package-comments
-        disabled: true
...
-      - comments
+      - linters:
+          - revive
+        text: '^exported: '
```

## Verification

Enforcement proven in both directions, not assumed:

| | Result |
|---|---|
| with the doc files | `golangci-lint run` → **0 issues** |
| with one `doc.go` deleted | exactly **1** finding: `package-comments: should have a package comment` |

Also: `go doc .` now returns the command documentation; `go list -f '{{.Doc}}' ./...` reports a synopsis for all 15 packages; build and vet clean under the default and `integration` tags; `go test -race ./...` 14/14.

Note that pkg.go.dev will still show the previous release until a tag containing this lands — the page currently serves v0.27.0 and has not yet picked up v0.28.0.