### PR TITLE
docs: document every exported symbol and stop capping lint output

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -228,9 +228,6 @@ linters:
           - paralleltest
           - tparallel
         path: e2e/.*_test\.go
-      - linters:
-          - revive
-        text: '^exported: '
     paths:
       - third_party$
       - builtin$
@@ -253,3 +250,6 @@ formatters:
       - third_party$
       - builtin$
       - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/cli/config.go
+++ b/cli/config.go
@@ -34,8 +34,14 @@ const (
 // JobSource indicates where a job configuration originated from.
 type JobSource string
 
+// Every job carries one of these so a reload can reconcile the two sources:
+// INI wins over labels — an INI job replaces a label-defined job of the same
+// name, and a label-defined job is ignored when an INI job already owns that
+// name. See reconcileParsedJob.
 const (
-	JobSourceINI   JobSource = "ini"
+	// JobSourceINI marks a job parsed from a [job-*] section of an INI file.
+	JobSourceINI JobSource = "ini"
+	// JobSourceLabel marks a job built from a container's ofelia.* labels.
 	JobSourceLabel JobSource = "label"
 )
 
@@ -105,6 +111,12 @@ type Config struct {
 	WebhookConfigs    *WebhookConfigs
 }
 
+// NewConfig returns a Config with empty job maps and every `default:` tag
+// applied, ready to be populated from an INI file or from container labels. The
+// webhook globals are seeded with their defaults and aliased into
+// WebhookConfigs.Global, so keys omitted from the [global] section keep those
+// defaults and later mutations of Global stay visible to the webhook subsystem.
+// No scheduler and no Docker connection exist yet — InitializeApp creates those.
 func NewConfig(logger *slog.Logger) *Config {
 	c := &Config{
 		ExecJobs:       make(map[string]*ExecJobConfig),
@@ -370,11 +382,14 @@ func getKnownKeysForJobType(jobType string) []string {
 	}
 }
 
-// BuildFromString builds a scheduler using the config from a string
-
 // newDockerHandler allows overriding Docker handler creation (e.g., for testing)
 var newDockerHandler = NewDockerHandler
 
+// BuildFromString is the in-memory counterpart of BuildFromFile: it parses
+// configStr as INI, warns about unknown keys, applies deprecation migrations
+// and, when strict validation is enabled, rejects an invalid configuration.
+// Jobs parsed here are marked JobSourceINI. It neither talks to Docker nor
+// creates a scheduler — call InitializeApp on the result for that.
 func BuildFromString(configStr string, logger *slog.Logger) (*Config, error) {
 	c := NewConfig(logger)
 	cfg, err := ini.LoadSources(ini.LoadOptions{AllowShadows: true, InsensitiveKeys: true}, []byte(configStr))
@@ -420,7 +435,12 @@ func BuildFromString(configStr string, logger *slog.Logger) (*Config, error) {
 	return c, nil
 }
 
-// Call this only once at app init
+// InitializeApp turns a parsed Config into a runnable daemon: it creates the
+// scheduler, sets up notification deduplication, connects to Docker and merges
+// the label-defined jobs, initializes the webhook manager once both sources are
+// known, then attaches the middlewares and registers every job. Returns an
+// error when the Docker connection or the webhook manager cannot be set up.
+// Call this only once at app init.
 func (c *Config) InitializeApp() error {
 	c.sh = core.NewScheduler(c.logger)
 
@@ -1200,7 +1220,10 @@ func (c *Config) iniConfigUpdate() error {
 	return nil
 }
 
-// ExecJobConfig contains all configuration params needed to build a ExecJob
+// ExecJobConfig contains all configuration params needed to build a ExecJob:
+// the core job fields plus the per-job notification and webhook middleware
+// settings, decoded as one flat key space from a [job-exec "name"] INI section
+// or from the ofelia.job-exec.<name>.* labels of a container.
 type ExecJobConfig struct {
 	core.ExecJob              `mapstructure:",squash"`
 	middlewares.OverlapConfig `mapstructure:",squash"`
@@ -1246,10 +1269,21 @@ func (c *ExecJobConfig) buildMiddlewares(logger *slog.Logger, wm *middlewares.We
 		wm, c.GetWebhookNames())
 }
 
-func (c *ExecJobConfig) GetJobSource() JobSource  { return c.JobSource }
+// GetJobSource reports where this job was defined, INI or container labels.
+// Reload reconciliation reads it to apply INI-over-label precedence; the zero
+// value means the origin was never recorded and no precedence rule applies.
+func (c *ExecJobConfig) GetJobSource() JobSource { return c.JobSource }
+
+// SetJobSource records where this job was defined. It is set by the parser
+// (INI) or by markJobSource (labels), never by the operator: the field is
+// excluded from mapstructure decoding, so no config key can spoof an origin.
 func (c *ExecJobConfig) SetJobSource(s JobSource) { c.JobSource = s }
 
-// RunServiceConfig contains all configuration params needed to build a RunJob
+// RunServiceConfig contains all configuration params needed to build a
+// RunServiceJob — a one-off Swarm service created from Image for each run and
+// (unless delete=false) removed again afterwards. Populated from a
+// [job-service-run "name"] INI section or the ofelia.job-service-run.<name>.*
+// container labels, together with the per-job middleware settings.
 type RunServiceConfig struct {
 	core.RunServiceJob        `mapstructure:",squash"`
 	middlewares.OverlapConfig `mapstructure:",squash"`
@@ -1260,9 +1294,19 @@ type RunServiceConfig struct {
 	JobSource                 JobSource `json:"-" mapstructure:"-"`
 }
 
-func (c *RunServiceConfig) GetJobSource() JobSource  { return c.JobSource }
+// GetJobSource reports where this job was defined, INI or container labels.
+func (c *RunServiceConfig) GetJobSource() JobSource { return c.JobSource }
+
+// SetJobSource records where this job was defined; see
+// ExecJobConfig.SetJobSource for who calls it and why it is not operator-settable.
 func (c *RunServiceConfig) SetJobSource(s JobSource) { c.JobSource = s }
 
+// RunJobConfig contains all configuration params needed to build a RunJob —
+// a container started for each run: created from Image and removed afterwards
+// (delete=true by default), or, when container is set, an existing container
+// that is started but neither created nor removed. Populated from a
+// [job-run "name"] INI section or the ofelia.job-run.<name>.* container labels,
+// together with the per-job middleware settings.
 type RunJobConfig struct {
 	core.RunJob               `mapstructure:",squash"`
 	middlewares.OverlapConfig `mapstructure:",squash"`
@@ -1279,7 +1323,11 @@ func (c *RunJobConfig) buildMiddlewares(logger *slog.Logger, wm *middlewares.Web
 		wm, c.GetWebhookNames())
 }
 
-func (c *RunJobConfig) GetJobSource() JobSource  { return c.JobSource }
+// GetJobSource reports where this job was defined, INI or container labels.
+func (c *RunJobConfig) GetJobSource() JobSource { return c.JobSource }
+
+// SetJobSource records where this job was defined; see
+// ExecJobConfig.SetJobSource for who calls it and why it is not operator-settable.
 func (c *RunJobConfig) SetJobSource(s JobSource) { c.JobSource = s }
 
 // Hash overrides BareJob.Hash() to include RunJob-specific fields
@@ -1291,7 +1339,12 @@ func (c *RunJobConfig) Hash() (string, error) {
 	return hash, nil
 }
 
-// LocalJobConfig contains all configuration params needed to build a RunJob
+// LocalJobConfig contains all configuration params needed to build a LocalJob
+// — a command run directly on the host Ofelia runs on, outside any container.
+// Populated from a [job-local "name"] INI section, or from
+// ofelia.job-local.<name>.* container labels only when the daemon opts in via
+// [global] allow-host-jobs-from-labels, since a labeled container could
+// otherwise make Ofelia execute arbitrary commands on the host.
 type LocalJobConfig struct {
 	core.LocalJob             `mapstructure:",squash"`
 	middlewares.OverlapConfig `mapstructure:",squash"`
@@ -1302,9 +1355,19 @@ type LocalJobConfig struct {
 	JobSource                 JobSource `json:"-" mapstructure:"-"`
 }
 
-func (c *LocalJobConfig) GetJobSource() JobSource  { return c.JobSource }
+// GetJobSource reports where this job was defined, INI or container labels.
+func (c *LocalJobConfig) GetJobSource() JobSource { return c.JobSource }
+
+// SetJobSource records where this job was defined; see
+// ExecJobConfig.SetJobSource for who calls it and why it is not operator-settable.
 func (c *LocalJobConfig) SetJobSource(s JobSource) { c.JobSource = s }
 
+// ComposeJobConfig contains all configuration params needed to build a
+// ComposeJob — a `docker compose -f <file> run --rm <service>` invocation, or
+// `exec <service>` when exec=true, shelled out on the host Ofelia runs on.
+// Populated from a [job-compose "name"] INI section, or from
+// ofelia.job-compose.<name>.* container labels only when the daemon opts in via
+// [global] allow-host-jobs-from-labels, for the same reason as LocalJobConfig.
 type ComposeJobConfig struct {
 	core.ComposeJob           `mapstructure:",squash"`
 	middlewares.OverlapConfig `mapstructure:",squash"`
@@ -1315,7 +1378,11 @@ type ComposeJobConfig struct {
 	JobSource                 JobSource `json:"-" mapstructure:"-"`
 }
 
-func (c *ComposeJobConfig) GetJobSource() JobSource  { return c.JobSource }
+// GetJobSource reports where this job was defined, INI or container labels.
+func (c *ComposeJobConfig) GetJobSource() JobSource { return c.JobSource }
+
+// SetJobSource records where this job was defined; see
+// ExecJobConfig.SetJobSource for who calls it and why it is not operator-settable.
 func (c *ComposeJobConfig) SetJobSource(s JobSource) { c.JobSource = s }
 
 func (c *LocalJobConfig) buildMiddlewares(logger *slog.Logger, wm *middlewares.WebhookManager) {
@@ -1336,6 +1403,12 @@ func (c *RunServiceConfig) buildMiddlewares(logger *slog.Logger, wm *middlewares
 		wm, c.GetWebhookNames())
 }
 
+// DockerConfig holds the daemon's Docker-side settings: which containers are
+// scanned for ofelia.* labels, how changes to them are detected (events,
+// polling, or both), how often the INI files are re-read, and how hard startup
+// tries to reach the daemon. Decoded from the [docker] INI section; most fields
+// are also settable via the daemon flags and OFELIA_DOCKER_* environment
+// variables named in the per-field comments. Consumed by NewDockerHandler.
 type DockerConfig struct {
 	Filters []string `mapstructure:"filters"`
 

--- a/cli/docker_config_handler.go
+++ b/cli/docker_config_handler.go
@@ -18,6 +18,10 @@ import (
 	"github.com/netresearch/ofelia/core/domain"
 )
 
+// ErrNoContainerWithOfeliaEnabled is returned by GetDockerContainers when the
+// label filter matched nothing. It is an expected steady state, not a failure:
+// callers report it at debug level and still push the (empty) container list on,
+// so label-defined jobs of a container that disappeared get unregistered.
 var ErrNoContainerWithOfeliaEnabled = errors.New("couldn't find containers with label 'ofelia.enabled=true'")
 
 // dockerStartupPingTimeout bounds the construction-time sanity Ping calls
@@ -33,6 +37,13 @@ const dockerStartupPingTimeout = 10 * time.Second
 // transports these as plain strings.
 const dockerEventTypeContainer = "container"
 
+// DockerHandler owns the daemon's Docker connection and watches for anything
+// that should change the job set: container start/stop events, optional
+// container polling, and the mod-time of the INI config files. Each watcher
+// runs in its own goroutine started by NewDockerHandler: the container watchers
+// hand the current ofelia-labeled containers to the notifier, the config
+// watcher triggers an INI reload when that notifier is a *Config. Callers must
+// call Shutdown to stop those goroutines and close the provider.
 type DockerHandler struct {
 	ctx            context.Context //nolint:containedctx // holds lifecycle for background goroutines
 	cancel         context.CancelFunc
@@ -106,6 +117,14 @@ func resolveConfig(cfg *DockerConfig, logger *slog.Logger) (configPoll, dockerPo
 	return configPoll, dockerPoll, fallback, useEvents
 }
 
+// NewDockerHandler connects to Docker and starts the watchers configured in
+// cfg. Pass a provider to use an existing connection; nil builds an SDK-backed
+// one. Either way the daemon is pinged before returning — bounded by
+// dockerStartupPingTimeout per attempt and retried per cfg.StartupRetryCount —
+// so an unreachable daemon fails here instead of silently later. A nil ctx is
+// treated as context.Background(); the handler derives a cancelable child from
+// it that Shutdown (or cancellation of ctx) uses to stop the watchers.
+// On error nothing is left running.
 func NewDockerHandler(
 	ctx context.Context, //nolint:contextcheck // external callers provide base context; we derive cancelable child
 	notifier dockerContainersUpdate,
@@ -363,6 +382,13 @@ func (c *DockerHandler) refreshContainerLabels() {
 	c.notifier.dockerContainersUpdate(labels)
 }
 
+// GetDockerContainers lists the containers labeled ofelia.enabled=true (plus
+// any configured filters), reduced to the name, creation time, state and the
+// ofelia.* labels of each (plus the Compose service label used for job naming).
+// Stopped containers are included only when include-stopped is set, containers
+// left with no relevant label are dropped, and a filter that matches nothing
+// yields ErrNoContainerWithOfeliaEnabled rather than an empty slice. Returns an
+// error for a malformed filter or a failing Docker call.
 func (c *DockerHandler) GetDockerContainers() ([]DockerContainerInfo, error) {
 	filters, err := c.buildContainerFilters()
 	if err != nil {
@@ -572,6 +598,11 @@ func (c *DockerHandler) processEventStream(
 // watchEventsInitialBackoff is the reset value for the watchEvents reconnect backoff.
 const watchEventsInitialBackoff = 1 * time.Second
 
+// Shutdown cancels the handler context, blocks until every watcher goroutine
+// has returned, then closes the Docker provider. The ctx argument exists for
+// the shutdown-hook signature and is not honored — the wait is unbounded.
+// Errors from closing the provider are logged, so the return is always nil.
+// Safe to call more than once.
 func (c *DockerHandler) Shutdown(ctx context.Context) error {
 	if c.cancel != nil {
 		c.cancel()

--- a/cli/hashpw.go
+++ b/cli/hashpw.go
@@ -13,6 +13,8 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+// HashPasswordCommand backs the `ofelia hash-password` subcommand, which
+// produces the bcrypt hash for the web UI's web-password-hash setting.
 type HashPasswordCommand struct {
 	Cost     int    `long:"cost" default:"12" description:"bcrypt cost factor (10-14 recommended)"`
 	LogLevel string `long:"log-level" env:"OFELIA_LOG_LEVEL" description:"Set log level"`
@@ -20,6 +22,12 @@ type HashPasswordCommand struct {
 	LevelVar *slog.LevelVar
 }
 
+// Execute prompts twice for a password (masked, minimum 8 characters), hashes
+// it with the configured bcrypt cost and prints the hash to stdout together
+// with the config-file and environment-variable snippets that use it. The
+// password is never echoed, logged or persisted. Returns an error when the
+// cost is outside the range bcrypt accepts, when a prompt is aborted, when the
+// two entries differ, or when hashing fails.
 func (c *HashPasswordCommand) Execute(_ []string) error {
 	if err := ApplyLogLevel(c.LogLevel, c.LevelVar); err != nil {
 		c.Logger.Warn(fmt.Sprintf("Failed to apply log level (using default): %v", err))

--- a/config/validator.go
+++ b/config/validator.go
@@ -173,7 +173,12 @@ func (v *Validator) ValidatePath(field, value string) {
 	}
 }
 
-// ConfigValidator validates complete configuration
+// Validator2 validates a whole configuration object by reflection, rather
+// than field by field. Validate walks the exported fields of the struct it
+// was given (recursing into nested structs), derives each field's config key
+// from its gcfg/mapstructure tag, and reports the collected problems through
+// a freshly built [Validator]. Only string, int/int64 and slice fields are
+// inspected; other kinds are skipped. Construct with NewConfigValidator.
 type Validator2 struct {
 	config    any
 	sanitizer *Sanitizer

--- a/core/adapters/docker/exec.go
+++ b/core/adapters/docker/exec.go
@@ -40,7 +40,6 @@ func (s *ExecServiceAdapter) checkClient() error {
 	return nil
 }
 
-// Create creates an exec instance.
 // consoleSize maps the domain's optional [height, width] pair onto the SDK's
 // ConsoleSize struct. A nil pointer yields the zero struct, which the daemon
 // reads as "use the default size" — the same meaning the nil pointer carried
@@ -60,6 +59,14 @@ func consoleSize(tty bool, size *[2]uint) client.ConsoleSize {
 	return client.ConsoleSize{Height: size[0], Width: size[1]}
 }
 
+// Create prepares an exec instance inside containerID and returns its exec ID.
+// It only creates the instance — nothing runs until Start is called with that
+// ID, and detaching is likewise decided there, not here.
+//
+// Returns ErrNilDockerClient when the adapter holds no SDK client,
+// ErrNilExecConfig when config is nil, and a domain-mapped error (convertError)
+// for Docker API failures. config.ConsoleSize is forwarded only when
+// config.Tty is set; see consoleSize.
 func (s *ExecServiceAdapter) Create(ctx context.Context, containerID string, config *domain.ExecConfig) (string, error) {
 	if err := s.checkClient(); err != nil {
 		return "", err

--- a/core/bare_job.go
+++ b/core/bare_job.go
@@ -9,6 +9,16 @@ import (
 	"sync/atomic"
 )
 
+// BareJob is the base type embedded by every job implementation (ExecJob,
+// RunJob, RunServiceJob, LocalJob, ComposeJob). It holds the fields the
+// scheduler reads — name, schedule, command, retry and dependency settings —
+// together with the middleware chain, the in-flight counter and a bounded
+// execution history, and supplies all of the Job interface except Run through
+// promoted methods. Embedders override Run to do the actual work.
+//
+// Field defaults come from the `default` struct tags applied during config
+// parsing. On a hand-built value HistoryLimit is 0, which keeps the history
+// unbounded.
 type BareJob struct {
 	Schedule string `hash:"true"`
 	Name     string `hash:"true"`
@@ -35,6 +45,9 @@ type BareJob struct {
 	cronID  uint64
 }
 
+// GetName returns the job's configured name. The name is the scheduler's
+// primary key: go-cron entry registration, lookup, removal, enable/disable and
+// manual triggering all address a job by it.
 func (j *BareJob) GetName() string {
 	return j.Name
 }
@@ -54,10 +67,17 @@ func (j *BareJob) GetOnFailure() []string {
 	return j.OnFailure
 }
 
+// GetSchedule returns the raw cron expression or keyword the job was configured
+// with, unparsed. Scheduler.AddJobWithTags rejects an empty schedule; the
+// @triggered, @manual and @none keywords register an entry that never fires on
+// its own (see IsTriggeredSchedule).
 func (j *BareJob) GetSchedule() string {
 	return j.Schedule
 }
 
+// GetCommand returns the configured command string. BareJob does not interpret
+// it — that is up to the embedding job type; the scheduler only uses it for log
+// messages and as part of the change-detection hash.
 func (j *BareJob) GetCommand() string {
 	return j.Command
 }
@@ -67,27 +87,44 @@ func (j *BareJob) ShouldRunOnStartup() bool {
 	return j.RunOnStartup
 }
 
+// Running returns the number of invocations currently in flight, as maintained
+// by NotifyStart and NotifyStop. Safe for concurrent use.
 func (j *BareJob) Running() int32 {
 	return atomic.LoadInt32(&j.running)
 }
 
+// NotifyStart increments the in-flight counter. Context.Start calls it when an
+// execution begins; every call must be paired with a NotifyStop or Running will
+// never return to zero. Safe for concurrent use.
 func (j *BareJob) NotifyStart() {
 	atomic.AddInt32(&j.running, 1)
 }
 
+// NotifyStop decrements the in-flight counter. Context.Stop calls it once the
+// execution has finished. Safe for concurrent use.
 func (j *BareJob) NotifyStop() {
 	atomic.AddInt32(&j.running, -1)
 }
 
+// GetCronJobID returns the go-cron entry ID assigned when the job was
+// registered, or 0 if it has not been added to a scheduler yet.
 func (j *BareJob) GetCronJobID() uint64 {
 	return j.cronID
 }
 
+// SetCronJobID records the go-cron entry ID for the job.
+// Scheduler.AddJobWithTags calls it right after registration. It is not
+// synchronized, so it must not be called while the job is scheduled.
 func (j *BareJob) SetCronJobID(id uint64) {
 	j.cronID = id
 }
 
-// Returns a hash of all the job attributes. Used to detect changes
+// Hash returns a change-detection key over the job's `hash:"true"` fields —
+// schedule, name, command and run-on-startup — so a reload can tell whether a
+// job definition actually changed. It is a plain concatenation produced by
+// GetHash, not a cryptographic digest, and returns an error if a tagged field
+// has a type GetHash cannot represent. Job types with extra significant fields
+// (RunJob) override this method.
 func (j *BareJob) Hash() (string, error) {
 	var hash string
 	if err := GetHash(reflect.TypeFor[BareJob](), reflect.ValueOf(j).Elem(), &hash); err != nil {

--- a/core/clock.go
+++ b/core/clock.go
@@ -10,6 +10,9 @@ import (
 	cron "github.com/netresearch/go-cron"
 )
 
+// Clock abstracts the parts of the time package that scheduling code depends
+// on, so tests can drive it with a FakeClock instead of waiting in real time.
+// Durations have the same meaning as in their time package counterparts.
 type Clock interface {
 	Now() time.Time
 	NewTicker(d time.Duration) Ticker
@@ -26,6 +29,8 @@ type Timer interface {
 	Reset(d time.Duration) bool
 }
 
+// Ticker delivers ticks on a channel at a fixed interval, mirroring
+// time.Ticker. Stop halts delivery but does not close the channel.
 type Ticker interface {
 	C() <-chan time.Time
 	Stop()
@@ -33,6 +38,7 @@ type Ticker interface {
 
 type realClock struct{}
 
+// NewRealClock returns a Clock backed directly by the time package.
 func NewRealClock() Clock {
 	return &realClock{}
 }
@@ -87,14 +93,22 @@ func (t *realTicker) Stop() {
 
 var defaultClock Clock = NewRealClock()
 
+// SetDefaultClock replaces the process-wide clock returned by GetDefaultClock.
+// It is not safe for concurrent use: call it from a test before any scheduler
+// is created and restore the previous clock afterwards.
 func SetDefaultClock(c Clock) {
 	defaultClock = c
 }
 
+// GetDefaultClock returns the clock used by schedulers that are created without
+// an explicit one. It is a real clock unless SetDefaultClock replaced it.
 func GetDefaultClock() Clock {
 	return defaultClock
 }
 
+// FakeClock is a Clock whose time only moves when Advance or Set is called.
+// Tickers, timers and After channels derived from it fire in chronological
+// order as time is moved forward. All methods are safe for concurrent use.
 type FakeClock struct {
 	mu       sync.RWMutex
 	now      time.Time
@@ -109,6 +123,7 @@ type waiter struct {
 	ch       chan time.Time
 }
 
+// NewFakeClock returns a FakeClock that reports start until it is advanced.
 func NewFakeClock(start time.Time) *FakeClock {
 	return &FakeClock{
 		now:      start,
@@ -116,12 +131,16 @@ func NewFakeClock(start time.Time) *FakeClock {
 	}
 }
 
+// Now returns the clock's current fake time.
 func (c *FakeClock) Now() time.Time {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.now
 }
 
+// NewTicker returns a Ticker that fires every d of fake time. Its channel holds
+// a single tick; ticks produced while that buffer is full are dropped, as with
+// time.Ticker. The ticker is tracked by the clock until it is stopped.
 func (c *FakeClock) NewTicker(d time.Duration) Ticker {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -136,6 +155,8 @@ func (c *FakeClock) NewTicker(d time.Duration) Ticker {
 	return ft
 }
 
+// NewTimer returns a Timer that fires once, d of fake time from now. Resetting
+// it schedules the next firing relative to the clock's time at that moment.
 func (c *FakeClock) NewTimer(d time.Duration) Timer {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -149,6 +170,8 @@ func (c *FakeClock) NewTimer(d time.Duration) Timer {
 	return ft
 }
 
+// After returns a channel that receives the fake time once d has elapsed on
+// this clock. A non-positive d delivers the current time immediately.
 func (c *FakeClock) After(d time.Duration) <-chan time.Time {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -166,6 +189,9 @@ func (c *FakeClock) After(d time.Duration) <-chan time.Time {
 	return ch
 }
 
+// Sleep blocks until the clock has moved d forward, returning at once for a
+// non-positive d. Only Advance or Set unblocks it, so the code advancing the
+// clock must run in another goroutine.
 func (c *FakeClock) Sleep(d time.Duration) {
 	if d <= 0 {
 		return
@@ -173,6 +199,8 @@ func (c *FakeClock) Sleep(d time.Duration) {
 	<-c.After(d)
 }
 
+// Advance moves the clock forward by d, stopping at each ticker, timer and
+// After deadline in the interval so events fire in chronological order.
 func (c *FakeClock) Advance(d time.Duration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -181,6 +209,8 @@ func (c *FakeClock) Advance(d time.Duration) {
 	c.advanceTo(target)
 }
 
+// Set moves the clock to t, firing the events in between as Advance does.
+// Setting a time in the past fires nothing and only changes what Now reports.
 func (c *FakeClock) Set(t time.Time) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -281,10 +311,14 @@ func (c *FakeClock) fireTimers() {
 	}
 }
 
+// WaitForAdvance blocks until an Advance or Set has completed. Completions are
+// buffered, so a call may return immediately for an earlier advance.
 func (c *FakeClock) WaitForAdvance() {
 	<-c.advanced
 }
 
+// TickerCount returns how many tickers created from this clock have not been
+// stopped, letting tests assert that scheduling code cleans up after itself.
 func (c *FakeClock) TickerCount() int {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -345,14 +379,21 @@ func (t *fakeTimer) Reset(d time.Duration) bool {
 	return wasActive
 }
 
+// CronClock is a FakeClock that also satisfies the clock interface of
+// github.com/netresearch/go-cron, which requires NewTimer to return a
+// cron.Timer. Pass it to cron.WithClock (see NewSchedulerWithClock) to step a
+// scheduler's cron engine through time from a test.
 type CronClock struct {
 	*FakeClock
 }
 
+// NewCronClock returns a CronClock over a fresh FakeClock starting at start.
 func NewCronClock(start time.Time) *CronClock {
 	return &CronClock{FakeClock: NewFakeClock(start)}
 }
 
+// NewTimer shadows FakeClock.NewTimer to return the embedded timer as a
+// cron.Timer. The timer itself is the same one FakeClock hands out.
 func (c *CronClock) NewTimer(d time.Duration) cron.Timer {
 	return c.FakeClock.NewTimer(d)
 }

--- a/core/common.go
+++ b/core/common.go
@@ -26,6 +26,15 @@ const (
 	logPrefix     = "[Job %q (%s)] %s"
 )
 
+// Job is the contract the scheduler requires of anything it can run. Embedding
+// BareJob provides every method here except Run through promoted methods, so a
+// job type normally implements Run only.
+//
+// GetName, GetSchedule and ShouldRunOnStartup are read at registration time;
+// Middlewares and Use manage the per-job middleware chain; Running, NotifyStart
+// and NotifyStop track in-flight invocations; GetCronJobID and SetCronJobID
+// carry the go-cron entry ID; Hash reports a change-detection key over the
+// job's configuration.
 type Job interface {
 	GetName() string
 	GetSchedule() string
@@ -43,6 +52,16 @@ type Job interface {
 	Hash() (string, error)
 }
 
+// Context carries everything a single job invocation needs: the owning
+// scheduler, the logger, the job, its Execution record, and the per-run
+// context.Context used for outbound calls (reach for it via RunContext, which
+// supplies a fallback when Ctx is unset).
+//
+// It also holds the cursor into the middleware chain, which is snapshotted from
+// the job at construction. A Context is therefore single-use — one per
+// invocation, never reused or shared — and not safe for concurrent use.
+// Construct it with NewContextWithContext, or NewContext when no parent context
+// is available.
 type Context struct {
 	Scheduler *Scheduler
 	Logger    *slog.Logger
@@ -103,11 +122,23 @@ func (c *Context) RunContext() context.Context {
 	return c.Ctx
 }
 
+// Start marks the execution as running, stamps its start time and increments
+// the job's in-flight counter. Call it once, before entering the middleware
+// chain via Next.
 func (c *Context) Start() {
 	c.Execution.Start()
 	c.Job.NotifyStart()
 }
 
+// Next advances the middleware chain by one step, running the next middleware
+// or, once the chain is exhausted, the job itself. Middleware Run
+// implementations must call it, otherwise the chain stalls and the job never
+// executes. Once the execution has stopped, only middlewares whose
+// ContinueOnStop reports true are still run.
+//
+// Next always returns nil. An error from a middleware or from the job is
+// recorded on the Execution through Stop rather than propagated, so callers
+// read the outcome from Execution.Failed and Execution.Error.
 func (c *Context) Next() error {
 	if err := c.doNext(); err != nil || c.executed {
 		c.Stop(err)
@@ -153,6 +184,11 @@ func (c *Context) getNext() (Middleware, bool) {
 	return c.middlewares[c.current-1], false
 }
 
+// Stop finalizes the execution with err — nil for success, ErrSkippedExecution
+// to mark it skipped, any other error to mark it failed — records the duration
+// and decrements the job's in-flight counter. Calling it on an execution that
+// has already stopped is a no-op, so both the middleware chain and the caller
+// may invoke it.
 func (c *Context) Stop(err error) {
 	if !c.Execution.IsRunning {
 		return
@@ -162,6 +198,10 @@ func (c *Context) Stop(err error) {
 	c.Job.NotifyStop()
 }
 
+// Log writes msg to the logger, prefixed with the job name and execution ID.
+// The level follows the execution's outcome: Error when it failed, Warn when it
+// was skipped, Info otherwise — so the level is only meaningful after Stop has
+// classified the execution.
 func (c *Context) Log(msg string) {
 	formatted := fmt.Sprintf(logPrefix, c.Job.GetName(), c.Execution.ID, msg)
 
@@ -175,6 +215,8 @@ func (c *Context) Log(msg string) {
 	}
 }
 
+// Warn writes msg at Warn level with the same job-name and execution-ID prefix
+// as Log, regardless of how the execution turned out.
 func (c *Context) Warn(msg string) {
 	formatted := fmt.Sprintf(logPrefix, c.Job.GetName(), c.Execution.ID, msg)
 	c.Logger.Warn(formatted)
@@ -390,11 +432,23 @@ func randomID() (string, error) {
 	return fmt.Sprintf("%x", b), nil
 }
 
+// HashmeTagName is the struct tag key GetHash inspects. A field takes part in
+// the job hash only when its `hash` tag is set to "true".
 const HashmeTagName = "hash"
 
 // hashmeTagEnabled is the struct tag value that enables hashing for a field.
 const hashmeTagEnabled = "true"
 
+// GetHash walks the fields of struct type t, taking values from v, and appends
+// a stable string form of every field tagged `hash:"true"` to *hash. Nested
+// struct fields are recursed into and contribute their own tagged fields. The
+// result is a concatenation used to detect configuration changes, not a
+// cryptographic digest — do not treat it as one.
+//
+// v must be the struct value matching t and hash must be non-nil; GetHash
+// appends to whatever is already there. It returns ErrUnsupportedFieldType for
+// a tagged field whose kind it cannot represent — supported kinds are string,
+// the signed integer kinds, bool, string slices, and pointer to string.
 func GetHash(t reflect.Type, v reflect.Value, hash *string) error {
 	for field := range t.Fields() {
 		fieldv := v.FieldByIndex(field.Index)

--- a/core/composejob.go
+++ b/core/composejob.go
@@ -12,6 +12,11 @@ import (
 	"github.com/netresearch/ofelia/config"
 )
 
+// ComposeJob runs a command through the `docker compose` CLI on the host
+// Ofelia itself runs on — `compose run --rm <service>` by default, or
+// `compose exec <service>` when Exec is set. Unlike the other job types it
+// shells out instead of talking to the Docker API, so the docker binary
+// must be on Ofelia's PATH.
 type ComposeJob struct {
 	BareJob `mapstructure:",squash"`
 	File    string `default:"compose.yml" gcfg:"file" mapstructure:"file" hash:"true"`
@@ -19,8 +24,17 @@ type ComposeJob struct {
 	Exec    bool   `default:"false" gcfg:"exec" mapstructure:"exec" hash:"true"`
 }
 
+// NewComposeJob returns an empty ComposeJob; the caller fills in File,
+// Service and the embedded BareJob.
 func NewComposeJob() *ComposeJob { return &ComposeJob{} }
 
+// Run executes the compose command and blocks until the child process exits.
+// File, Service and the parsed command arguments are checked for command
+// injection first, so a malformed job fails before any process is started.
+// Errors cover a rejected argument, a docker binary missing from PATH, and a
+// non-zero exit status. Output is streamed to the execution's stdout/stderr
+// streams. The child process is not tied to the run context: canceling the
+// run, or a max-runtime deadline, does not kill it.
 func (j *ComposeJob) Run(ctx *Context) error {
 	cmd, err := j.buildCommand(ctx)
 	if err != nil {

--- a/core/cron_utils.go
+++ b/core/cron_utils.go
@@ -5,15 +5,19 @@ package core
 
 import "log/slog"
 
-// Implement the cron logger interface
+// CronUtils adapts an slog.Logger to the logger interface expected by
+// github.com/netresearch/go-cron.
 type CronUtils struct {
 	Logger *slog.Logger
 }
 
+// NewCronUtils returns a CronUtils that forwards the cron engine's output to l.
 func NewCronUtils(l *slog.Logger) *CronUtils {
 	return &CronUtils{Logger: l}
 }
 
+// Info records an informational cron engine message. It logs at debug level,
+// keeping the engine's per-tick scheduling chatter out of ofelia's info output.
 func (c *CronUtils) Info(msg string, keysAndValues ...any) {
 	c.Logger.Debug(msg, keysAndValues...)
 }

--- a/core/domain/container.go
+++ b/core/domain/container.go
@@ -158,11 +158,13 @@ type Mount struct {
 // MountType represents the type of mount.
 type MountType string
 
+// Mount types accepted by Mount.Type and ServiceMount.Type. The values are the
+// mount-type strings the Docker API expects.
 const (
-	MountTypeBind   MountType = "bind"
-	MountTypeVolume MountType = "volume"
-	MountTypeTmpfs  MountType = "tmpfs"
-	MountTypeNpipe  MountType = "npipe"
+	MountTypeBind   MountType = "bind"   // host path mounted into the container
+	MountTypeVolume MountType = "volume" // named or anonymous Docker volume
+	MountTypeTmpfs  MountType = "tmpfs"  // in-memory filesystem, discarded with the container
+	MountTypeNpipe  MountType = "npipe"  // Windows named pipe
 )
 
 // BindOptions represents options for bind mounts.

--- a/core/domain/service.go
+++ b/core/domain/service.go
@@ -92,10 +92,12 @@ type ServiceRestartPolicy struct {
 // RestartCondition represents when to restart a task.
 type RestartCondition string
 
+// Conditions under which Swarm restarts a task. The values are the
+// restart-condition strings the Docker API expects.
 const (
-	RestartConditionNone      RestartCondition = "none"
-	RestartConditionOnFailure RestartCondition = "on-failure"
-	RestartConditionAny       RestartCondition = "any"
+	RestartConditionNone      RestartCondition = "none"       // never restart
+	RestartConditionOnFailure RestartCondition = "on-failure" // restart only after a non-zero exit
+	RestartConditionAny       RestartCondition = "any"        // restart regardless of exit status
 )
 
 // Placement represents placement constraints.
@@ -149,9 +151,11 @@ type EndpointSpec struct {
 // ResolutionMode represents the endpoint resolution mode.
 type ResolutionMode string
 
+// How clients resolve a service name to its tasks. The values are the
+// resolution-mode strings the Docker API expects.
 const (
-	ResolutionModeVIP   ResolutionMode = "vip"
-	ResolutionModeDNSRR ResolutionMode = "dnsrr"
+	ResolutionModeVIP   ResolutionMode = "vip"   // one virtual IP, load-balanced across the tasks
+	ResolutionModeDNSRR ResolutionMode = "dnsrr" // DNS round-robin over the task IPs, no virtual IP
 )
 
 // PortConfig represents a port configuration for a service.
@@ -166,6 +170,8 @@ type PortConfig struct {
 // PortProtocol represents the protocol for a port.
 type PortProtocol string
 
+// Transport protocols a published port can use. The values are the protocol
+// strings the Docker API expects.
 const (
 	PortProtocolTCP  PortProtocol = "tcp"
 	PortProtocolUDP  PortProtocol = "udp"
@@ -175,9 +181,11 @@ const (
 // PortPublishMode represents how a port is published.
 type PortPublishMode string
 
+// Where a published service port is reachable. The values are the
+// publish-mode strings the Docker API expects.
 const (
-	PortPublishModeIngress PortPublishMode = "ingress"
-	PortPublishModeHost    PortPublishMode = "host"
+	PortPublishModeIngress PortPublishMode = "ingress" // reachable on every swarm node via the routing mesh
+	PortPublishModeHost    PortPublishMode = "host"    // reachable only on nodes actually running a task
 )
 
 // ServiceEndpoint represents the endpoint info for a service.
@@ -217,6 +225,11 @@ type ContainerStatus struct {
 // TaskState represents the state of a task.
 type TaskState string
 
+// The lifecycle states a Swarm task moves through, listed in the order the
+// orchestrator normally reaches them. The values are the task-state strings
+// the Docker API reports. Complete, Shutdown, Failed, Rejected and Orphaned
+// are final — use TaskState.IsTerminalState rather than comparing against
+// them by hand.
 const (
 	TaskStateNew       TaskState = "new"
 	TaskStatePending   TaskState = "pending"

--- a/core/domain/system.go
+++ b/core/domain/system.go
@@ -81,12 +81,15 @@ type SwarmInfo struct {
 // LocalNodeState represents the state of the local Swarm node.
 type LocalNodeState string
 
+// Swarm membership states reported for the local node. The values are the
+// LocalNodeState strings the Docker API returns; an empty string means the
+// daemon did not report a state at all.
 const (
-	LocalNodeStateInactive LocalNodeState = "inactive"
-	LocalNodeStatePending  LocalNodeState = "pending"
-	LocalNodeStateActive   LocalNodeState = "active"
-	LocalNodeStateError    LocalNodeState = "error"
-	LocalNodeStateLocked   LocalNodeState = "locked"
+	LocalNodeStateInactive LocalNodeState = "inactive" // swarm mode is not enabled on this node
+	LocalNodeStatePending  LocalNodeState = "pending"  // joining a swarm, not yet a member
+	LocalNodeStateActive   LocalNodeState = "active"   // participating in a swarm
+	LocalNodeStateError    LocalNodeState = "error"    // swarm membership is broken; see SwarmInfo.Error
+	LocalNodeStateLocked   LocalNodeState = "locked"   // autolock is on; the manager needs unlocking first
 )
 
 // Peer represents a remote manager in the swarm.

--- a/core/execjob.go
+++ b/core/execjob.go
@@ -13,6 +13,10 @@ import (
 	"github.com/netresearch/ofelia/core/domain"
 )
 
+// ExecJob runs a command inside an already-running container via
+// `docker exec`. The container named by Container must exist and be running;
+// Ofelia neither creates nor removes it, so state left behind by the command
+// persists in that container. See Run for the cancellation limitation.
 type ExecJob struct {
 	BareJob   `mapstructure:",squash"`
 	Provider  DockerProvider `json:"-"` // SDK-based Docker provider
@@ -41,6 +45,9 @@ type ExecJob struct {
 	ConsoleWidth  uint `gcfg:"console-width" mapstructure:"console-width" hash:"true"`
 }
 
+// NewExecJob returns an ExecJob bound to provider, which is the Docker
+// connection the exec session is created on. Container, the embedded BareJob
+// and the remaining options are set by the caller.
 func NewExecJob(provider DockerProvider) *ExecJob {
 	return &ExecJob{
 		Provider: provider,

--- a/core/job_test_helpers.go
+++ b/core/job_test_helpers.go
@@ -16,6 +16,10 @@ type TestContainerMonitor struct {
 	waitForContainerFunc func(string, time.Duration) (*domain.ContainerState, error)
 }
 
+// WaitForContainer returns whatever the stubbed waitForContainerFunc yields
+// for containerID and maxRuntime. With no stub installed it returns a stopped
+// container with exit code 0 and no error, i.e. the success case, without
+// waiting.
 func (t *TestContainerMonitor) WaitForContainer(containerID string, maxRuntime time.Duration) (*domain.ContainerState, error) {
 	if t.waitForContainerFunc != nil {
 		return t.waitForContainerFunc(containerID, maxRuntime)
@@ -23,6 +27,9 @@ func (t *TestContainerMonitor) WaitForContainer(containerID string, maxRuntime t
 	return &domain.ContainerState{ExitCode: 0, Running: false}, nil
 }
 
+// SetUseEventsAPI accepts the events-API toggle and discards it. The stub's
+// behavior comes entirely from waitForContainerFunc, so there is no polling
+// path to switch away from.
 func (t *TestContainerMonitor) SetUseEventsAPI(use bool) {
 	// Test implementation - no-op
 }

--- a/core/localjob.go
+++ b/core/localjob.go
@@ -23,6 +23,11 @@ import (
 // bound for a disk read. See issues #638 / #655.
 const localJobEnvResolveTimeout = 10 * time.Second
 
+// LocalJob runs a command directly on the host Ofelia runs on, outside any
+// container. The child inherits Ofelia's own environment, extended by
+// EnvFile and Environment; EnvFrom is accepted but inert on this path
+// because no Docker provider is passed to the resolver (see
+// localJobEnvResolveTimeout).
 type LocalJob struct {
 	BareJob     `mapstructure:",squash"`
 	Dir         string   `hash:"true"`
@@ -31,10 +36,19 @@ type LocalJob struct {
 	EnvFrom     []string `gcfg:"env-from" mapstructure:"env-from," hash:"true"`
 }
 
+// NewLocalJob returns an empty LocalJob; the caller fills in the embedded
+// BareJob, Dir and the environment fields.
 func NewLocalJob() *LocalJob {
 	return &LocalJob{}
 }
 
+// Run looks up the binary on PATH, resolves the environment and executes the
+// command in Dir, blocking until the process exits. Returns ErrEmptyCommand
+// for an empty command, a lookup error when the binary is not on PATH, the
+// env-resolution error, or the process's exit error. Output is streamed to
+// the execution's stdout/stderr streams. The child process is not tied to the
+// run context: canceling the run, or a max-runtime deadline, does not kill
+// it.
 func (j *LocalJob) Run(ctx *Context) error {
 	cmd, err := j.buildCommand(ctx)
 	if err != nil {

--- a/core/performance_metrics.go
+++ b/core/performance_metrics.go
@@ -642,5 +642,8 @@ func (pm *PerformanceMetrics) GetSummaryReport() string {
 	return report
 }
 
-// Global enhanced metrics instance
+// GlobalPerformanceMetrics is the process-wide PerformanceMetrics instance,
+// created at package initialization for callers that have no recorder
+// injected. Its counters are shared by every user of the package, so Reset
+// affects all of them.
 var GlobalPerformanceMetrics = NewPerformanceMetrics()

--- a/core/persist/store.go
+++ b/core/persist/store.go
@@ -44,11 +44,14 @@ var ErrNullJobValue = errors.New("persist: job entry is null (expected object)")
 // naturally and so new types can be added without renumbering.
 type JobType string
 
+// The job kinds the API can create, and therefore the only values that
+// legitimately appear in a state file's `type` field. Each corresponds to an
+// INI section family (job-run, job-exec, job-local, job-compose).
 const (
-	JobTypeRun     JobType = "run"
-	JobTypeExec    JobType = "exec"
-	JobTypeLocal   JobType = "local"
-	JobTypeCompose JobType = "compose"
+	JobTypeRun     JobType = "run"     // start a fresh container from an image
+	JobTypeExec    JobType = "exec"    // exec a command inside an already-running container
+	JobTypeLocal   JobType = "local"   // run a command on the host ofelia itself runs on
+	JobTypeCompose JobType = "compose" // docker compose run/exec against a service in a compose file
 )
 
 // Job is the per-entry on-disk representation. Carries the union of

--- a/core/resilience.go
+++ b/core/resilience.go
@@ -90,9 +90,18 @@ func Retry(ctx context.Context, policy *RetryPolicy, fn func() error) error {
 // CircuitBreakerState represents the state of a circuit breaker
 type CircuitBreakerState int
 
+// The states a CircuitBreaker moves through: it starts closed, opens once
+// maxFailures consecutive failures have been recorded, and after resetTimeout
+// admits trial calls in half-open before closing or opening again.
 const (
+	// StateClosed passes every call through; a success clears the failure count.
 	StateClosed CircuitBreakerState = iota
+	// StateOpen rejects calls with ErrCircuitBreakerOpen until resetTimeout has
+	// elapsed since the last failure.
 	StateOpen
+	// StateHalfOpen admits up to halfOpenMaxCalls trial calls, rejecting the rest
+	// with ErrCircuitBreakerHalfOpen; a success closes the breaker, a failure
+	// reopens it.
 	StateHalfOpen
 )
 

--- a/core/runjob.go
+++ b/core/runjob.go
@@ -16,6 +16,11 @@ import (
 	"github.com/netresearch/ofelia/core/domain"
 )
 
+// RunJob runs a command in a container of its own: it ensures Image is
+// present, creates a container per run, starts it, waits for it to exit and
+// then removes it unless Delete is "false". Setting Container instead of
+// Image reuses an existing container by name — that one is started but never
+// created or removed by Ofelia. Validate requires one of the two.
 type RunJob struct {
 	BareJob  `mapstructure:",squash"`
 	Provider DockerProvider `json:"-"` // SDK-based Docker provider
@@ -80,6 +85,10 @@ type RunJob struct {
 	mu          sync.RWMutex // Protect containerID access
 }
 
+// NewRunJob returns a RunJob bound to provider, which is the Docker
+// connection the container is created and watched on. The caller sets Image
+// or Container plus the remaining fields; Validate rejects a job with
+// neither.
 func NewRunJob(provider DockerProvider) *RunJob {
 	return &RunJob{
 		Provider: provider,
@@ -134,6 +143,17 @@ func entrypointSlice(ep *string) []string {
 // for a healthy daemon, short enough to fail loudly on a wedged one.
 const jobCleanupTimeout = 30 * time.Second
 
+// Run creates or looks up the container, starts it and blocks until it exits,
+// then copies the logs produced since the start of this run to the
+// execution's output stream. It returns nil for exit code 0, ErrUnexpected
+// for -1, NonZeroExitError otherwise, and ErrMaxTimeRunning when MaxRuntime
+// or the run context expires before the container finishes.
+//
+// A container created by this run is removed before Run returns, unless
+// Delete is "false". If the run context has already expired at that point,
+// teardown switches to a fresh context (jobCleanupTimeout) and stops the
+// container before removing it, so an expired deadline does not leave the
+// container behind — see issue #655.
 func (j *RunJob) Run(ctx *Context) error {
 	pull, _ := strconv.ParseBool(j.Pull)
 	// Use the (deadline-bounded) middleware-chain context for cancellation

--- a/core/runservice.go
+++ b/core/runservice.go
@@ -19,6 +19,12 @@ import (
 
 // Note: The ServiceJob is loosely inspired by https://github.com/alexellis/jaas/
 
+// RunServiceJob runs a command as a one-shot Docker Swarm service: it creates
+// a service whose task has restart condition "none", polls that task until it
+// reaches a terminal state, and removes the service again unless Delete is
+// "false". The provider must be connected to a daemon acting as a Swarm
+// manager. Only the task's exit code is observed — unlike RunJob, no
+// container output is captured into the execution streams.
 type RunServiceJob struct {
 	BareJob  `mapstructure:",squash"`
 	Provider DockerProvider `json:"-"` // SDK-based Docker provider
@@ -44,6 +50,9 @@ type RunServiceJob struct {
 	MaxRuntime  time.Duration `gcfg:"max-runtime" mapstructure:"max-runtime"`
 }
 
+// NewRunServiceJob returns a RunServiceJob bound to provider, which is the
+// Docker connection the swarm service is created and polled on. The caller
+// sets the remaining fields; Image is mandatory (see Validate).
 func NewRunServiceJob(provider DockerProvider) *RunServiceJob {
 	return &RunServiceJob{Provider: provider}
 }
@@ -71,6 +80,18 @@ func (j *RunServiceJob) Validate() error {
 	return nil
 }
 
+// Run pulls the image, creates the swarm service and blocks while polling its
+// tasks every 500ms until one reaches a terminal state. It returns nil for
+// task exit code 0, ErrUnexpected for -1 and for ExitCodeSwarmError (no
+// terminal task observed), NonZeroExitError otherwise, and ErrMaxTimeRunning
+// when MaxRuntime elapses first.
+//
+// The service is removed before Run returns unless Delete is "false"; if the
+// run context has already expired, removal runs on a fresh context
+// (jobCleanupTimeout) so no orphan service is left scheduled — see issue
+// #655. A failed removal is returned as the error only when the run itself
+// succeeded; otherwise the run's own error wins and the removal failure is
+// logged.
 func (j *RunServiceJob) Run(ctx *Context) error {
 	// Use the (deadline-bounded) middleware-chain context for cancellation
 	// propagation. The fallback to context.Background() lives in
@@ -178,12 +199,20 @@ func (j *RunServiceJob) buildService(ctx context.Context) (string, error) {
 	return serviceID, nil
 }
 
+// Exit codes for swarm service execution states
+// These are Ofelia-specific codes, not from Docker Swarm API
+// They indicate failure modes that don't map to container exit codes
 const (
-	// Exit codes for swarm service execution states
-	// These are Ofelia-specific codes, not from Docker Swarm API
-	// They indicate failure modes that don't map to container exit codes
-	ExitCodeSwarmError = -999 // Swarm orchestration error (task not found, service unavailable)
-	ExitCodeTimeout    = -998 // Max runtime exceeded before task completion
+	// ExitCodeSwarmError marks a swarm orchestration error (task not found,
+	// service unavailable) rather than an exit code reported by a task. It is
+	// also the initial value the watcher holds, so it is what remains when the
+	// watcher stops before any task reached a terminal state; watchContainer
+	// maps it to ErrUnexpected.
+	ExitCodeSwarmError = -999
+	// ExitCodeTimeout marks max runtime exceeded before task completion. No
+	// code path assigns it today — the timeout path returns ErrMaxTimeRunning
+	// instead of an exit code.
+	ExitCodeTimeout = -998
 )
 
 func (j *RunServiceJob) watchContainer(ctx context.Context, jobCtx *Context, svcID string) error {

--- a/core/scheduler.go
+++ b/core/scheduler.go
@@ -17,8 +17,14 @@ import (
 const errFmtWrapQuoted = "%w: %q"
 
 var (
+	// ErrEmptyScheduler was returned by Start when it was called with no jobs
+	// registered. Start now accepts an empty scheduler, so nothing returns
+	// this error; it is retained for API compatibility.
 	ErrEmptyScheduler = errors.New("unable to start an empty scheduler")
-	ErrEmptySchedule  = errors.New("unable to add a job with an empty schedule")
+	// ErrEmptySchedule is returned by AddJob and AddJobWithTags when the job's
+	// schedule string is empty. Jobs meant to run only on demand must use
+	// @triggered, @manual or @none rather than an empty schedule.
+	ErrEmptySchedule = errors.New("unable to add a job with an empty schedule")
 )
 
 // IsTriggeredSchedule returns true if the schedule string indicates the job
@@ -29,6 +35,16 @@ func IsTriggeredSchedule(schedule string) bool {
 	return schedule == TriggeredSchedule || schedule == ManualSchedule || schedule == NoneSchedule
 }
 
+// Scheduler owns the set of registered jobs and drives them through go-cron.
+// It handles registration and removal, name-based lookup, enable/disable,
+// manual triggering, the global middleware chain propagated to every job,
+// retries, and a concurrency limit shared across all entries.
+//
+// Construct it with NewScheduler or one of its variants; a zero value has no
+// cron instance and cannot run jobs. Methods are safe for concurrent use, and
+// the exported Jobs and Removed slices are mutated under the scheduler's own
+// lock — copy them (GetActiveJobs, GetRemovedJobs) rather than ranging over
+// them from another goroutine.
 type Scheduler struct {
 	Jobs    []Job
 	Removed []Job
@@ -92,6 +108,11 @@ func (cs *concurrencySemaphore) getCap() int {
 	return cs.cap
 }
 
+// NewScheduler returns a Scheduler with default settings: no metrics recorder,
+// go-cron's default minimum @every interval (1s), the real clock, and a limit
+// of 10 concurrent jobs. It does not start the cron loop — call Start for that.
+// Use NewSchedulerWithMetrics, NewSchedulerWithOptions or NewSchedulerWithClock
+// to change those defaults.
 func NewScheduler(l *slog.Logger) *Scheduler {
 	return NewSchedulerWithOptions(l, nil, 0)
 }
@@ -266,6 +287,13 @@ func (s *Scheduler) SetMaxConcurrentJobs(maxJobs int) {
 	s.concurrencySem.resize(maxJobs)
 }
 
+// SetMetricsRecorder installs the recorder used for retry metrics and stores it
+// on the scheduler. It can be called at any time, including while running.
+//
+// It does not retrofit the go-cron observability hooks (job start, completion,
+// scheduling and workflow results): those are wired only when a recorder is
+// passed at construction time, so pass one to NewSchedulerWithMetrics or
+// NewSchedulerWithOptions if you want them.
 func (s *Scheduler) SetMetricsRecorder(recorder MetricsRecorder) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -275,18 +303,33 @@ func (s *Scheduler) SetMetricsRecorder(recorder MetricsRecorder) {
 	}
 }
 
+// SetClock replaces the clock stored on the scheduler. It exists for tests and
+// does not change the clock go-cron schedules with, which is fixed at
+// construction — use NewSchedulerWithClock to drive scheduling from a fake
+// clock.
 func (s *Scheduler) SetClock(c Clock) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.clock = c
 }
 
+// SetOnJobComplete registers a callback invoked after every job run with the
+// job's name and whether it succeeded (no error and the execution not marked
+// failed). Passing nil clears it. Only one callback is held; a second call
+// replaces the first.
+//
+// The callback runs synchronously on the job's own goroutine at the end of the
+// run, so it must not block. It may be changed while the scheduler is running:
+// each run snapshots it under the lock.
 func (s *Scheduler) SetOnJobComplete(callback func(jobName string, success bool)) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.onJobComplete = callback
 }
 
+// AddJob registers j under its configured name, equivalent to AddJobWithTags
+// with no tags. See AddJobWithTags for the registration semantics and the
+// errors returned.
 func (s *Scheduler) AddJob(j Job) error {
 	return s.AddJobWithTags(j)
 }
@@ -344,6 +387,10 @@ func (s *Scheduler) AddJobWithTags(j Job, tags ...string) error {
 	return nil
 }
 
+// RemoveJob deregisters j so it will not fire again, blocks until any in-flight
+// invocation has finished, then drops it from the active jobs and appends it to
+// Removed. Removal is by name, so a job that was never registered is silently
+// ignored. The error return is always nil and exists for API stability.
 func (s *Scheduler) RemoveJob(j Job) error {
 	s.Logger.Info(fmt.Sprintf(
 		"Job deregistered (will not fire again) %q - %q - %q - ID: %v",
@@ -423,6 +470,15 @@ func (s *Scheduler) GetJobsByTag(tag string) []Job {
 	return jobs
 }
 
+// Start wires the job dependency graph into go-cron and starts the cron loop.
+// It does not block — the loop runs on its own goroutine — and always returns
+// nil, including for a scheduler with no jobs registered. A failure to build
+// the dependency graph is logged rather than returned, so that one misconfigured
+// dependency cannot take down scheduling for every other job.
+//
+// Jobs configured to run on startup fire once here, dispatched by go-cron.
+// Starting an already-running scheduler is handled by go-cron and does not
+// double-start the loop.
 func (s *Scheduler) Start() error {
 	s.mu.Lock()
 
@@ -458,6 +514,11 @@ func (s *Scheduler) Start() error {
 // DefaultStopTimeout is the default timeout for graceful shutdown.
 const DefaultStopTimeout = 30 * time.Second
 
+// Stop stops the cron loop and blocks for up to DefaultStopTimeout (30s) while
+// running jobs finish. It returns an error wrapping ErrSchedulerTimeout if they
+// have not finished by then — the jobs are not killed and may still be running
+// when it returns. Use StopWithTimeout for a different bound, or StopAndWait to
+// wait indefinitely.
 func (s *Scheduler) Stop() error {
 	return s.StopWithTimeout(DefaultStopTimeout)
 }

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -12,7 +12,12 @@ import (
 )
 
 const (
-	// Metric type constants
+	// MetricTypeGauge is the value stored in Metric.Type for gauges, the one
+	// metric type whose value may be set or lowered rather than only
+	// incremented. SetGauge, adjustGauge and getGaugeValue all compare
+	// Metric.Type against it and silently do nothing for a name registered as
+	// some other type. The remaining types ("counter", "histogram") appear as
+	// literals.
 	MetricTypeGauge = "gauge"
 )
 
@@ -270,7 +275,12 @@ func (mc *Collector) Handler() http.HandlerFunc {
 	}
 }
 
-// DefaultMetrics initializes common metrics
+// InitDefaultMetrics registers the metrics ofelia exports out of the box —
+// job execution, service state, HTTP, Docker API, container monitoring, retry,
+// cron and workflow — then seeds ofelia_up to 1 and ofelia_jobs_running to 0.
+// Call it once, directly after NewCollector: registration replaces any metric
+// already held under the same name, so a second call discards every counter,
+// gauge and histogram value collected so far.
 func (mc *Collector) InitDefaultMetrics() {
 	// Job metrics
 	mc.RegisterCounter("ofelia_jobs_total", "Total number of jobs executed")

--- a/middlewares/common.go
+++ b/middlewares/common.go
@@ -5,6 +5,15 @@ package middlewares
 
 import "reflect"
 
+// IsEmpty reports whether i — which must be a non-nil pointer — points at the
+// zero value of its type. The middleware constructors (NewSlack, NewMail,
+// NewSave, NewOverlap) use it to tell "the operator configured this" from "the
+// config struct was never filled in" and return a nil middleware for the
+// latter.
+//
+// The comparison is reflect.DeepEqual against a freshly allocated zero value,
+// so unexported fields are taken into account and a field explicitly set to
+// its zero value still counts as empty. Panics if i is nil or not a pointer.
 func IsEmpty(i any) bool {
 	t := reflect.TypeOf(i).Elem()
 	e := reflect.New(t).Interface()

--- a/middlewares/sanitize.go
+++ b/middlewares/sanitize.go
@@ -130,7 +130,11 @@ func (ps *PathSanitizer) ValidateSaveFolder(folder string) error {
 	return nil
 }
 
-// Default sanitizer instance
+// DefaultSanitizer is the package-level PathSanitizer backing the
+// SanitizePath, SanitizeFilename and SanitizeJobName helpers. Its rules are
+// fixed at init and never mutated afterwards, so it is safe for concurrent
+// use; replacing it is not, and callers wanting different rules should build
+// their own with NewPathSanitizer instead.
 var DefaultSanitizer = NewPathSanitizer()
 
 // SanitizePath is a convenience function using the default sanitizer

--- a/middlewares/webhook_config.go
+++ b/middlewares/webhook_config.go
@@ -12,6 +12,11 @@ import (
 // TriggerType defines when a webhook notification should be sent
 type TriggerType string
 
+// The accepted values of a webhook's `trigger` setting, matched by
+// (*WebhookConfig).ShouldNotify against the outcome of each execution. An
+// empty value is also accepted by Validate and is replaced with the default
+// (TriggerError) by ApplyDefaults; any value ShouldNotify does not recognize
+// falls back to error-only behavior.
 const (
 	TriggerAlways  TriggerType = "always"  // Send on every execution
 	TriggerError   TriggerType = "error"   // Send only on errors

--- a/web/auth_secure.go
+++ b/web/auth_secure.go
@@ -26,6 +26,12 @@ const (
 	httpsProto = "https"
 )
 
+// TokenData is the server-side record behind an issued auth token: the user it
+// was minted for and the instant it stops being accepted. Tokens themselves are
+// opaque random strings carrying no claims, so this record — held only in a
+// SecureTokenManager's in-memory map — is the sole authority on who a token
+// belongs to. It is therefore lost on restart, and revoking a token takes
+// effect immediately rather than at expiry.
 type TokenData struct {
 	Username  string    `json:"username"`
 	ExpiresAt time.Time `json:"expiresAt"`
@@ -51,6 +57,15 @@ type RateLimiter struct {
 	burst      int // burst size
 }
 
+// NewRateLimiter returns a limiter that refills each key's bucket at
+// ratePerMinute tokens per minute and lets burst of them be spent at once.
+// Keys are opaque to the limiter; the login path uses the client IP.
+//
+// ratePerMinute must be greater than zero — GetLimiter divides by it, so a
+// zero rate panics on the first request rather than at construction. Buckets
+// are created on demand and never expire by themselves, so a caller that can
+// vary its key grows the map unboundedly unless CleanupOldLimiters is called
+// periodically.
 func NewRateLimiter(ratePerMinute, burst int) *RateLimiter {
 	return &RateLimiter{
 		limiters:   make(map[string]*rate.Limiter),
@@ -60,6 +75,10 @@ func NewRateLimiter(ratePerMinute, burst int) *RateLimiter {
 	}
 }
 
+// GetLimiter returns the bucket for key, creating it on first use, and stamps
+// the access time that CleanupOldLimiters later uses to evict idle keys. Safe
+// for concurrent use; it takes the write lock on every call because of that
+// bookkeeping, so it is not a cheap read path.
 func (rl *RateLimiter) GetLimiter(key string) *rate.Limiter {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
@@ -74,6 +93,9 @@ func (rl *RateLimiter) GetLimiter(key string) *rate.Limiter {
 	return limiter
 }
 
+// Allow consumes one token from key's bucket and reports whether the attempt
+// may proceed. It never blocks: a false result means "reject now" (the login
+// handler answers 429), not "wait and retry".
 func (rl *RateLimiter) Allow(key string) bool {
 	limiter := rl.GetLimiter(key)
 	return limiter.Allow()
@@ -105,6 +127,17 @@ type SecureTokenManager struct {
 	closeOnce   sync.Once
 }
 
+// NewSecureTokenManager returns a manager that issues and tracks auth tokens
+// (valid for expiryHours) and one-time CSRF tokens (valid for one hour). Both
+// kinds are random values kept in memory and validated by lookup: they do not
+// survive a restart and are not shared between instances. secretKey is stored
+// on the manager but is not currently used to sign or derive anything, so
+// supplying one does not make tokens portable; an empty secretKey is replaced
+// by 32 random bytes, and the only error returned is a failure to read that
+// randomness.
+//
+// It starts a goroutine that sweeps expired tokens hourly, so every manager
+// must eventually be closed with Close.
 func NewSecureTokenManager(secretKey string, expiryHours int) (*SecureTokenManager, error) {
 	if secretKey == "" {
 		// Generate a cryptographically secure random key
@@ -264,6 +297,21 @@ type SecureLoginHandler struct {
 	trustedProxies []*net.IPNet
 }
 
+// NewSecureLoginHandler returns the handler backing POST /api/login. Per
+// request it rate limits on the client IP through rl, requires a valid
+// one-time CSRF token in X-CSRF-Token, compares the submitted username against
+// config.Username in constant time and the password against
+// config.PasswordHash with bcrypt, and on success issues an auth token both in
+// the JSON body and as an HttpOnly, SameSite=Strict cookie.
+//
+// trustedProxies are the peers whose X-Forwarded-For and X-Real-IP headers are
+// believed when deriving that client IP; headers from any other peer are
+// ignored. Loopback is always trusted, so passing none still trusts a proxy on
+// the same host.
+//
+// It does not consult config.Enabled and does no authorization beyond the
+// credential check — deciding whether to mount it, and what an authenticated
+// user may then do, is the caller's job.
 func NewSecureLoginHandler(
 	config *SecureAuthConfig, tm *SecureTokenManager, rl *RateLimiter, trustedProxies ...*net.IPNet,
 ) *SecureLoginHandler {

--- a/web/health.go
+++ b/web/health.go
@@ -19,6 +19,12 @@ import (
 // HealthStatus represents the overall health status
 type HealthStatus string
 
+// The statuses a single check, and the aggregate health report, can carry.
+// GetHealth folds the individual checks into the worst status present, so one
+// unhealthy check makes the whole report unhealthy. Only the readiness
+// endpoint acts on the value, and only for Unhealthy: /ready answers 503 for
+// it and 200 for the other two, so a degraded ofelia stays in rotation.
+// /health and /healthz always answer 200 and put the status in the body.
 const (
 	HealthStatusHealthy   HealthStatus = "healthy"
 	HealthStatusDegraded  HealthStatus = "degraded"

--- a/web/server.go
+++ b/web/server.go
@@ -26,6 +26,13 @@ import (
 	"github.com/netresearch/ofelia/static"
 )
 
+// Server is the HTTP front end of a running scheduler: the JSON API under
+// /api, the embedded single-page UI, and — once RegisterHealthEndpoints has
+// been called — the health and readiness probes. It owns the middleware chain
+// (rate limiting, security headers, optional token auth) and the bookkeeping
+// that decides which jobs the API is allowed to mutate.
+//
+// Build one with NewServer or NewServerWithAuth; the zero value is not usable.
 type Server struct {
 	addr           string
 	scheduler      *core.Scheduler
@@ -118,6 +125,14 @@ func (s *Server) HTTPServer() *http.Server { return s.srv }
 // GetHTTPServer returns the underlying http.Server for graceful shutdown support
 func (s *Server) GetHTTPServer() *http.Server { return s.srv }
 
+// NewServer builds an unauthenticated Server on addr for scheduler s. cfg is
+// the parsed configuration served by /api/config and reflected over to tell
+// config-owned jobs from API-created ones; provider is the Docker client the
+// handlers use.
+//
+// This is NewServerWithAuth with no auth config: every route, including the
+// job create/update/delete endpoints, is reachable without credentials, so
+// only bind it where that is acceptable. Returns nil if construction failed.
 func NewServer(addr string, s *core.Scheduler, cfg any, provider core.DockerProvider) *Server {
 	return NewServerWithAuth(addr, s, cfg, provider, nil)
 }
@@ -155,6 +170,18 @@ func setupAuth(server *Server, authCfg *SecureAuthConfig) error {
 	return nil
 }
 
+// NewServerWithAuth builds a Server on addr and assembles its handler chain:
+// the API routes and embedded UI, wrapped in a 100-request-per-minute per-IP
+// rate limiter and the security headers, and — only when authCfg is non-nil
+// and Enabled — token authentication plus the /api/login, /api/logout,
+// /api/auth/status and /api/csrf-token endpoints. Authentication covers the
+// /api/ routes only: the static UI, the login/CSRF/auth-status endpoints and
+// the health probes stay reachable without a token. A nil or disabled authCfg
+// leaves everything open; there is no partial mode.
+//
+// Returns nil, after logging the reason, when the token manager cannot be
+// created or the embedded UI assets cannot be opened — callers must check for
+// nil rather than assume a usable server. Nothing is listening until Start.
 func NewServerWithAuth(addr string, s *core.Scheduler, cfg any, provider core.DockerProvider, authCfg *SecureAuthConfig) *Server {
 	server := &Server{
 		addr:       addr,
@@ -222,8 +249,16 @@ func NewServerWithAuth(addr string, s *core.Scheduler, cfg any, provider core.Do
 	return server
 }
 
+// Start serves in a background goroutine and returns immediately, always with
+// a nil error. ListenAndServe's error is discarded, so a failure to bind addr
+// shows up as refused connections rather than as a return value here — check
+// reachability if you need to know the listener came up. Stop with Shutdown.
 func (s *Server) Start() error { go func() { _ = s.srv.ListenAndServe() }(); return nil }
 
+// Shutdown stops the background goroutines of the rate limiter and the token
+// manager, then gracefully shuts the HTTP server down, letting in-flight
+// requests finish until ctx expires. A Server that has been shut down cannot
+// be started again.
 func (s *Server) Shutdown(ctx context.Context) error {
 	if s.rl != nil {
 		s.rl.close()
@@ -237,6 +272,16 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return nil
 }
 
+// RegisterHealthEndpoints rebuilds the whole route table so that hc's /health,
+// /healthz, /ready and /live endpoints sit next to the API and UI routes, and
+// installs the result on the running http.Server. The probes stay exempt from
+// authentication but still pass through the security headers and the rate
+// limiter, which is replaced by a fresh one here, discarding the request
+// counters accumulated so far.
+//
+// Call it before Start: it assigns http.Server.Handler, which is racy once the
+// server is serving. It does nothing if the Server was not constructed
+// successfully.
 func (s *Server) RegisterHealthEndpoints(hc *HealthChecker) {
 	if s.srv == nil || s.srv.Handler == nil {
 		return


### PR DESCRIPTION
Completes the documentation work started in #753, which documented the packages but exempted exported symbols.

## The count was wrong, and that matters

Lifting the exemption appeared to surface **50** findings. It was **123**. golangci-lint caps output at `max-issues-per-linter: 50` by default, and I had been reading the capped number — two runs showing different files but the same total 50 is what gave it away.

That cap is itself a hole in the gate: once a linter exceeds it, further findings are silently dropped, so a regression can hide behind unrelated noise. Both `max-issues-per-linter` and `max-same-issues` are now `0`.

## What is documented

All 123: **114** exported symbols with no comment at all, and **9** whose comment did not begin with the symbol name as Go requires.

The comments state what a symbol does and what a caller needs to know — nil and zero-value behaviour, blocking versus async, goroutine-safety, units, error semantics — rather than restating the name. For example, on the auth token record:

> `TokenData` is the server-side record behind an issued auth token […] Tokens themselves are opaque random strings carrying no claims, so this record — held only in a `SecureTokenManager`'s in-memory map — is the sole authority on who a token belongs to. It is therefore lost on restart, and revoking a token takes effect immediately rather than at expiry.

Enum constants are documented as a block with short per-value comments rather than repeated boilerplate.

## No code changed — verified mechanically

Rather than eyeballing a 621-line diff, every touched file was re-printed with all comments stripped (`go/parser` + `go/printer`, `f.Comments = nil`) and compared against `HEAD`:

```
29 files checked, 0 with real code changes (blank lines ignored)
```

The only non-comment lines in the diff are `gofmt` realignments caused by adding trailing comments to `const` blocks.

## Verification

| Check | Result |
|---|---|
| `golangci-lint run` | **0 issues** |
| one doc comment removed | exactly **1** finding — the rule bites |
| `go build`, `go vet` (default, `integration`, `e2e`) | clean |
| `go test -race ./...` | 14/14 |
| `gofmt -l .` | empty |

Three British spellings that came in with the new comments (`cancelling`, `behaviour`) were corrected to the US spellings `misspell` enforces.