### PR TITLE
docs(security): fix release-verification instructions that cannot work

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -357,19 +357,21 @@ All releases include:
 Users can verify releases:
 
 ```bash
-# Verify binary provenance
-slsa-verifier verify-artifact ofelia-linux-amd64 \
-  --provenance-path ofelia-linux-amd64.intoto.jsonl \
-  --source-uri github.com/netresearch/ofelia
-
-# Verify checksums signature
+# Verify a binary against its bundled signature
 cosign verify-blob \
-  --certificate checksums.txt.pem \
-  --signature checksums.txt.sig \
-  --certificate-identity "https://github.com/netresearch/ofelia/.github/workflows/release-slsa.yml@refs/tags/vX.Y.Z" \
+  --bundle ofelia-linux-amd64.sigstore.json \
+  --certificate-identity-regexp "^https://github\.com/netresearch/\.github/\.github/workflows/release-go-app\.yml@" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-  checksums.txt
+  ofelia-linux-amd64
+
+# Verify build provenance
+gh attestation verify ofelia-linux-amd64 \
+  --repo netresearch/ofelia \
+  --signer-workflow netresearch/.github/.github/workflows/release-go-app.yml
 ```
+
+The signing identity is the reusable workflow in `netresearch/.github`, not
+this repository — see [SECURITY.md](SECURITY.md) for the full procedure.
 
 ## Questions or Issues?
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,29 +64,52 @@ This project implements several security measures:
 
 ## Verifying Releases
 
-### Verify Binary Provenance
+Releases are built by a reusable workflow in `netresearch/.github`, so the
+signing identity is that workflow rather than this repository. Verification
+fails without the `--certificate-identity-regexp` / `--signer-workflow` flags
+below.
 
-```bash
-slsa-verifier verify-artifact ofelia-linux-amd64 \
-  --provenance-path ofelia-linux-amd64.intoto.jsonl \
-  --source-uri github.com/netresearch/ofelia
-```
+### Verify a Binary
 
-### Verify Checksums Signature
+Every asset ships a bundled signature next to it (`<asset>.sigstore.json`):
 
 ```bash
 cosign verify-blob \
-  --certificate checksums.txt.pem \
-  --signature checksums.txt.sig \
-  --certificate-identity "https://github.com/netresearch/ofelia/.github/workflows/release-slsa.yml@refs/tags/<TAG>" \
+  --bundle ofelia-linux-amd64.sigstore.json \
+  --certificate-identity-regexp "^https://github\.com/netresearch/\.github/\.github/workflows/release-go-app\.yml@" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  ofelia-linux-amd64
+```
+
+### Verify Checksums
+
+```bash
+cosign verify-blob \
+  --bundle checksums.txt.sigstore.json \
+  --certificate-identity-regexp "^https://github\.com/netresearch/\.github/\.github/workflows/release-go-app\.yml@" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   checksums.txt
+sha256sum -c checksums.txt --ignore-missing
+```
+
+### Verify Build Provenance
+
+```bash
+gh attestation verify <artifact> \
+  --repo netresearch/ofelia \
+  --signer-workflow netresearch/.github/.github/workflows/release-go-app.yml
 ```
 
 ### Verify Container Image
 
 ```bash
-cosign verify ghcr.io/netresearch/ofelia:<TAG>
+cosign verify ghcr.io/netresearch/ofelia:<TAG> \
+  --certificate-identity-regexp "^https://github\.com/netresearch/\.github/\.github/workflows/release-go-app\.yml@" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+
+gh attestation verify oci://ghcr.io/netresearch/ofelia:<TAG> \
+  --repo netresearch/ofelia \
+  --signer-workflow netresearch/.github/.github/workflows/release-go-app.yml
 ```
 
 ## OpenSSF Scorecard Notes


### PR DESCRIPTION
`SECURITY.md` and `CONTRIBUTING.md` describe a release pipeline this project no longer has. **Every parameter is wrong**, so an operator following the documented procedure verifies nothing — and signature verification is the only control they have before handing this daemon the Docker socket.

## What is broken

| Documented | Reality |
|---|---|
| `--certificate checksums.txt.pem --signature checksums.txt.sig` | Releases ship a bundle, `checksums.txt.sigstore.json`. Neither `.pem` nor `.sig` exists. |
| signer `netresearch/ofelia/.github/workflows/release-slsa.yml` | That workflow does not exist. Releases are signed by the reusable `netresearch/.github/.github/workflows/release-go-app.yml`, so the identity never matches. |
| `slsa-verifier ... --provenance-path ofelia-linux-amd64.intoto.jsonl` | v0.28.0 ships **zero** `.intoto.jsonl` assets. |
| `cosign verify ghcr.io/netresearch/ofelia:<TAG>` | Keyless cosign requires `--certificate-identity-regexp` and `--certificate-oidc-issuer`; without them it fails. |

Asset inventory of v0.28.0, for reference:

```
.sigstore.json ×7   .spdx.json ×7   .spdx.json.sigstore.json ×7
.txt ×1   .txt.sigstore.json ×1   (+ .exe variants)   .intoto.jsonl ×0
```

## What this replaces it with

The procedure the pipeline actually produces, including the `--signer-workflow` flag that provenance verification needs because the signing identity is the reusable workflow rather than this repository — the single detail most likely to make a correct-looking command fail.

## Verified by execution, not by reading

Every command in the new text was run against the **published** v0.28.0 assets before committing, with cosign v2.6.3:

```
cosign verify-blob --bundle ofelia-linux-amd64.sigstore.json  … → Verified OK
cosign verify-blob --bundle checksums.txt.sigstore.json       … → Verified OK
sha256sum -c checksums.txt --ignore-missing                      → ofelia-linux-amd64: OK
gh attestation verify … --signer-workflow …                      → exit 0
```

## Follow-up worth considering

Nothing in CI verifies a release after it is published, which is why this drift went unnoticed across several releases. A job triggered `on: release: [published]` that runs exactly these commands against the uploaded assets would turn this class of drift into a build failure instead of a silent one. Raised separately rather than bundled here.