### PR TITLE
fix(ci): make the linters and secret scanning actually able to fail

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,4 +1,11 @@
 # Gitleaks configuration file
+#
+# A config file REPLACES gitleaks' built-in ruleset unless it extends it. Without
+# the [extend] block below this file defined an allowlist and no rules at all, so
+# the scan matched nothing and reported "no leaks found" for every input.
+[extend]
+useDefault = true
+
 [allowlist]
 description = "Allowlist for test files and legitimate test constants"
 

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,13 +1,22 @@
-# Ignore test constants and non-sensitive values - these are not actual secrets
-# but rather test constants used in unit tests
+# Findings accepted in history. Gitleaks scans every commit, so a value that
+# was committed once stays reportable even after the file is corrected — the
+# only way to remove it from history is a rewrite, which is not worth it for
+# documentation examples.
+#
+# Each entry below was reviewed individually. If any of these had been a live
+# credential the answer would be rotation, not an ignore entry.
 
-# File-level ignores (specific files that contain test secrets)
-web/missing_coverage_test.go
-web/jwt_auth_test.go  
-web/auth_test.go
+# Placeholder token in the ntfy webhook docs and preset example. Replaced in
+# the working tree with tk_REPLACE_WITH_YOUR_NTFY_TOKEN; the original shape was
+# indistinguishable from a real ntfy access token, which is why it tripped the
+# scanner once the ruleset was repaired.
+df6d07e2545e1cb6acbedb6d69a122d01d1237a6:docs/webhooks.md:generic-api-key:171
+df6d07e2545e1cb6acbedb6d69a122d01d1237a6:docs/webhooks.md:generic-api-key:180
 
-# Pattern-based ignores for test constants
-test-secret-for-testing
-test-secret-key
-test-secret-key-that-is-long-enough-for-jwt
-testSecretKey
+# Truncated JWT header (the standard {"alg":"HS256","typ":"JWT"} prefix
+# followed by "...") used as an Authorization-header example.
+06d254ff97a013c9d307ef55b911e05e85dc0a7a:docs/API.md:generic-api-key:25
+06d254ff97a013c9d307ef55b911e05e85dc0a7a:docs/API.md:generic-api-key:45
+
+# curl example in the security docs showing the shape of an auth header.
+053a2527b5004a61e1bae7a32e616e822eb444ba:docs/SECURITY.md:curl-auth-header:392

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,20 +1,37 @@
-# Findings accepted in history. Gitleaks scans every commit, so a value that
-# was committed once stays reportable even after the file is corrected — the
-# only way to remove it from history is a rewrite, which is not worth it for
-# documentation examples.
-#
-# Each entry below was reviewed individually. If any of these had been a live
-# credential the answer would be rotation, not an ignore entry.
+# Ignore test constants and non-sensitive values - these are not actual secrets
+# but rather test constants used in unit tests
 
-# Placeholder token in the ntfy webhook docs and preset example. Replaced in
-# the working tree with tk_REPLACE_WITH_YOUR_NTFY_TOKEN; the original shape was
-# indistinguishable from a real ntfy access token, which is why it tripped the
-# scanner once the ruleset was repaired.
+# File-level ignores (specific files that contain test secrets)
+web/missing_coverage_test.go
+web/jwt_auth_test.go  
+web/auth_test.go
+
+# Pattern-based ignores for test constants
+test-secret-for-testing
+test-secret-key
+test-secret-key-that-is-long-enough-for-jwt
+testSecretKey
+
+# --- Findings accepted in history -------------------------------------------
+# Gitleaks scans every commit, not just the working tree, so a value committed
+# once stays reportable after the file is corrected. Each entry below was
+# reviewed individually; had any been a live credential the answer would be
+# rotation, not an ignore entry.
+#
+# NOTE: the entries above this block are bare paths and substrings. That is not
+# the .gitleaksignore format — it matches finding fingerprints
+# (commit:file:rule:line) — so they match nothing. The equivalent suppression
+# that does work lives in .gitleaks.toml's [allowlist] paths/regexes. Left in
+# place rather than deleted, but they are decorative.
+
+# Placeholder token in the ntfy webhook docs and preset example, 2025-12.
+# Replaced in the working tree with tk_REPLACE_WITH_YOUR_NTFY_TOKEN; the
+# original shape was indistinguishable from a real ntfy access token.
 df6d07e2545e1cb6acbedb6d69a122d01d1237a6:docs/webhooks.md:generic-api-key:171
 df6d07e2545e1cb6acbedb6d69a122d01d1237a6:docs/webhooks.md:generic-api-key:180
 
-# Truncated JWT header (the standard {"alg":"HS256","typ":"JWT"} prefix
-# followed by "...") used as an Authorization-header example.
+# Truncated JWT header ({"alg":"HS256","typ":"JWT"} followed by "...") shown as
+# an Authorization-header example.
 06d254ff97a013c9d307ef55b911e05e85dc0a7a:docs/API.md:generic-api-key:25
 06d254ff97a013c9d307ef55b911e05e85dc0a7a:docs/API.md:generic-api-key:45
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -80,6 +80,15 @@ linters:
       ignore-sig-regexps:
         - errors\.New\(
         - \*github\.com/netresearch/ofelia/core\.Context\)\.Next\(
+    staticcheck:
+      # Explicit selection instead of the blanket `text: "QF"` exclusion this
+      # replaces: that regex matched every QF#### check by message text, and
+      # also silently swallowed an ST1018 finding about invisible Unicode in a
+      # mail template. QF1008 (redundant embedded-field selector) is the one
+      # check excluded on purpose — it is pure style and fires widely here.
+      checks:
+        - all
+        - -QF1008
   exclusions:
     generated: lax
     presets:
@@ -132,15 +141,6 @@ linters:
       - linters:
           - tagliatelle
         path: middlewares/slack\.go
-      - linters:
-          - staticcheck
-        text: "QF"
-      - linters:
-          - staticcheck
-        text: "ST1005:"
-      - linters:
-          - staticcheck
-        text: "ST1018:"
       # Docker SDK deprecated types - will update when SDK breaks
       - linters:
           - staticcheck
@@ -253,3 +253,4 @@ formatters:
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
+  uniq-by-line: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,14 @@
 version: "2"
 run:
   tests: true
+  # Without these, every linter skips the files behind //go:build integration
+  # and //go:build e2e — the whole e2e suite and the Docker integration
+  # adapters were outside static analysis entirely. "unix" is not listed: it is
+  # a GOOS-derived release tag, already satisfied where those files compile,
+  # and forcing it would drag unix-only syscalls into the Windows build.
+  build-tags:
+    - integration
+    - e2e
 linters:
   default: none
   enable:

--- a/cli/config_global_merge.go
+++ b/cli/config_global_merge.go
@@ -82,10 +82,8 @@ func mergeSlackGlobals(dst, src *middlewares.SlackConfig) bool {
 // piece testable and below the linter's cyclomatic complexity threshold.
 // See file header for the precedence policy.
 func mergeMailGlobals(dst, src *middlewares.MailConfig) bool {
-	changed := false
-	if mergeMailSMTPGlobals(dst, src) {
-		changed = true
-	}
+	changed := mergeMailSMTPGlobals(dst, src)
+
 	if mergeMailEnvelopeGlobals(dst, src) {
 		changed = true
 	}
@@ -245,10 +243,8 @@ func (c *Config) applyAllowListedGlobals(parsed *Config) bool {
 	if parsed == nil {
 		return false
 	}
-	changed := false
-	if mergeSlackGlobals(&c.Global.SlackConfig, &parsed.Global.SlackConfig) {
-		changed = true
-	}
+	changed := mergeSlackGlobals(&c.Global.SlackConfig, &parsed.Global.SlackConfig)
+
 	if mergeMailGlobals(&c.Global.MailConfig, &parsed.Global.MailConfig) {
 		changed = true
 	}

--- a/cli/docker_config_handler.go
+++ b/cli/docker_config_handler.go
@@ -281,7 +281,7 @@ func pingWithRetry(ctx context.Context, provider core.DockerProvider, count int,
 		select {
 		case <-time.After(backoff):
 		case <-ctx.Done():
-			return fmt.Errorf("Docker startup retry canceled: %w", ctx.Err())
+			return fmt.Errorf("docker startup retry canceled: %w", ctx.Err())
 		}
 	}
 	return lastErr

--- a/cli/errors.go
+++ b/cli/errors.go
@@ -19,7 +19,7 @@ var (
 	ErrUsernameTooShort    = errors.New("username must be at least 3 characters")
 	ErrJobNameEmpty        = errors.New("job name cannot be empty")
 	ErrJobNameInvalid      = errors.New("job name must be alphanumeric with hyphens or underscores only")
-	ErrDockerImageEmpty    = errors.New("Docker image cannot be empty")
+	ErrDockerImageEmpty    = errors.New("docker image cannot be empty")
 	ErrCommandEmpty        = errors.New("command cannot be empty")
 	ErrScheduleEmpty       = errors.New("schedule cannot be empty")
 )

--- a/cli/init.go
+++ b/cli/init.go
@@ -365,7 +365,7 @@ func (c *InitCommand) promptRunJob() (*runJobConfig, error) {
 		Label: "Docker image (e.g., alpine:latest, postgres:16)",
 		Validate: func(input string) error {
 			if input == "" {
-				return fmt.Errorf("Docker image cannot be empty")
+				return fmt.Errorf("docker image cannot be empty")
 			}
 			return nil
 		},

--- a/config/sanitizer.go
+++ b/config/sanitizer.go
@@ -200,12 +200,12 @@ func (s *Sanitizer) ValidateDockerImage(image string) error {
 
 	// Check for suspicious patterns
 	if strings.Contains(image, "..") || strings.Contains(image, "//") {
-		return fmt.Errorf("Docker image name contains suspicious patterns")
+		return fmt.Errorf("docker image name contains suspicious patterns")
 	}
 
 	// Validate length
 	if len(image) > 255 {
-		return fmt.Errorf("Docker image name exceeds maximum length")
+		return fmt.Errorf("docker image name exceeds maximum length")
 	}
 
 	return nil

--- a/core/adapters/docker/image.go
+++ b/core/adapters/docker/image.go
@@ -198,6 +198,9 @@ func EncodeAuthConfig(auth domain.AuthConfig) (string, error) {
 		RegistryToken: auth.RegistryToken,
 	}
 
+	// The Docker API expects the credentials as base64-encoded JSON in the
+	// X-Registry-Auth header, so the password field has to be marshaled here.
+	// #nosec G117 -- registry auth payload required by the Docker API
 	encoded, err := json.Marshal(authConfig)
 	if err != nil {
 		return "", fmt.Errorf("encoding auth config: %w", err)

--- a/core/docker_benchmark_test.go
+++ b/core/docker_benchmark_test.go
@@ -18,7 +18,7 @@ import (
 
 func newBenchClient(b *testing.B) *client.Client {
 	b.Helper()
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	cli, err := client.New(client.FromEnv)
 	if err != nil {
 		b.Skipf("Docker not available: %v", err)
 	}

--- a/core/integration_test_main.go
+++ b/core/integration_test_main.go
@@ -2,6 +2,7 @@
 
 // Copyright (c) 2025-2026 Netresearch DTT GmbH
 // SPDX-License-Identifier: MIT
+
 package core
 
 import (

--- a/core/scheduler.go
+++ b/core/scheduler.go
@@ -188,7 +188,7 @@ func newSchedulerInternal(
 
 	cronInstance = cron.New(cronOpts...)
 
-	var clock Clock = GetDefaultClock()
+	clock := GetDefaultClock()
 	if cronClock != nil {
 		clock = cronClock.FakeClock
 	}

--- a/docs/API.md
+++ b/docs/API.md
@@ -22,7 +22,7 @@ Content-Type: application/json
 **Response:**
 ```json
 {
-  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "token": "<jwt-token>",
   "expires": "2024-01-01T00:00:00Z"
 }
 ```
@@ -30,7 +30,7 @@ Content-Type: application/json
 #### Using the Token
 Include the JWT token in the Authorization header:
 ```http
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+Authorization: Bearer <jwt-token>
 ```
 
 #### Refresh Token
@@ -42,7 +42,7 @@ Authorization: Bearer <current-token>
 **Response:**
 ```json
 {
-  "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "token": "<jwt-token>",
   "expires": "2024-01-01T00:00:00Z"
 }
 ```

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -402,14 +402,22 @@ go tool pprof cpu.prof
 ```
 
 ### Jobs Overlapping
-```bash
+```ini
 # Add no-overlap to job config
 [job-exec "long-task"]
 schedule = @hourly
 container = worker
 command = /scripts/task.sh
 no-overlap = true               # ← Add this
-max-runtime = 50m               # ← And timeout
+```
+
+`max-runtime` is not available on `job-exec`; it applies to `job-run`,
+`job-service-run` and `[global]`. To bound an exec job, set the global
+default:
+
+```ini
+[global]
+max-runtime = 50m
 ```
 
 ## Performance Tips

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -59,7 +59,7 @@ paths:
                 properties:
                   token:
                     type: string
-                    example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+                    example: "<jwt-token>"
                   expires_in:
                     type: number
                     example: 3600

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -397,7 +397,7 @@ For private topics or self-hosted ntfy with access tokens:
 [webhook "ntfy-private"]
 preset = ntfy-token
 id = my-private-topic
-secret = tk_AgQdq7mVBoFD37zQVN29RhuMzNIz2
+secret = tk_REPLACE_WITH_YOUR_NTFY_TOKEN
 trigger = always
 ```
 
@@ -406,7 +406,7 @@ For self-hosted ntfy with custom URL and authentication:
 [webhook "ntfy-self-hosted"]
 preset = ntfy-token
 url = https://ntfy.example.com/my-topic
-secret = tk_AgQdq7mVBoFD37zQVN29RhuMzNIz2
+secret = tk_REPLACE_WITH_YOUR_NTFY_TOKEN
 trigger = always
 ```
 

--- a/e2e/config_validation_test.go
+++ b/e2e/config_validation_test.go
@@ -1,5 +1,5 @@
-//go:build e2e
-// +build e2e
+//go:build e2e && unix
+// +build e2e,unix
 
 // Copyright (c) 2025-2026 Netresearch DTT GmbH
 // SPDX-License-Identifier: MIT

--- a/e2e/docker_job_test.go
+++ b/e2e/docker_job_test.go
@@ -1,5 +1,5 @@
-//go:build e2e
-// +build e2e
+//go:build e2e && unix
+// +build e2e,unix
 
 // Copyright (c) 2025-2026 Netresearch DTT GmbH
 // SPDX-License-Identifier: MIT

--- a/e2e/graceful_shutdown_test.go
+++ b/e2e/graceful_shutdown_test.go
@@ -1,5 +1,5 @@
-//go:build e2e
-// +build e2e
+//go:build e2e && unix
+// +build e2e,unix
 
 // Copyright (c) 2025-2026 Netresearch DTT GmbH
 // SPDX-License-Identifier: MIT

--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -1,5 +1,5 @@
-//go:build e2e
-// +build e2e
+//go:build e2e && unix
+// +build e2e,unix
 
 // Copyright (c) 2025-2026 Netresearch DTT GmbH
 // SPDX-License-Identifier: MIT

--- a/e2e/local_job_test.go
+++ b/e2e/local_job_test.go
@@ -1,5 +1,5 @@
-//go:build e2e
-// +build e2e
+//go:build e2e && unix
+// +build e2e,unix
 
 // Copyright (c) 2025-2026 Netresearch DTT GmbH
 // SPDX-License-Identifier: MIT

--- a/e2e/scheduler_lifecycle_test.go
+++ b/e2e/scheduler_lifecycle_test.go
@@ -1,5 +1,5 @@
-//go:build e2e
-// +build e2e
+//go:build e2e && unix
+// +build e2e,unix
 
 // Copyright (c) 2025-2026 Netresearch DTT GmbH
 // SPDX-License-Identifier: MIT

--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -241,22 +241,22 @@ func (mc *Collector) Export() string {
 
 	for _, metric := range mc.metrics {
 		// Add HELP and TYPE comments
-		output.WriteString(fmt.Sprintf("# HELP %s %s\n", metric.Name, metric.Help))
-		output.WriteString(fmt.Sprintf("# TYPE %s %s\n", metric.Name, metric.Type))
+		fmt.Fprintf(&output, "# HELP %s %s\n", metric.Name, metric.Help)
+		fmt.Fprintf(&output, "# TYPE %s %s\n", metric.Name, metric.Type)
 
 		switch metric.Type {
 		case "counter", MetricTypeGauge:
-			output.WriteString(fmt.Sprintf("%s %f\n", metric.Name, metric.Value))
+			fmt.Fprintf(&output, "%s %f\n", metric.Name, metric.Value)
 
 		case "histogram":
 			if metric.Histogram != nil {
 				// Export histogram buckets
 				for bucket, count := range metric.Histogram.Bucket {
-					output.WriteString(fmt.Sprintf("%s_bucket{le=\"%g\"} %d\n", metric.Name, bucket, count))
+					fmt.Fprintf(&output, "%s_bucket{le=\"%g\"} %d\n", metric.Name, bucket, count)
 				}
-				output.WriteString(fmt.Sprintf("%s_bucket{le=\"+Inf\"} %d\n", metric.Name, metric.Histogram.Count))
-				output.WriteString(fmt.Sprintf("%s_count %d\n", metric.Name, metric.Histogram.Count))
-				output.WriteString(fmt.Sprintf("%s_sum %f\n", metric.Name, metric.Histogram.Sum))
+				fmt.Fprintf(&output, "%s_bucket{le=\"+Inf\"} %d\n", metric.Name, metric.Histogram.Count)
+				fmt.Fprintf(&output, "%s_count %d\n", metric.Name, metric.Histogram.Count)
+				fmt.Fprintf(&output, "%s_sum %f\n", metric.Name, metric.Histogram.Sum)
 			}
 		}
 

--- a/middlewares/mail.go
+++ b/middlewares/mail.go
@@ -194,7 +194,7 @@ func (m *Mail) Run(ctx *core.Context) error {
 	err := ctx.Next()
 	ctx.Stop(err)
 
-	if !(ctx.Execution.Failed || !boolVal(m.MailOnlyOnError)) {
+	if !ctx.Execution.Failed && boolVal(m.MailOnlyOnError) {
 		return err
 	}
 	// Check deduplication - suppress duplicate error notifications
@@ -310,9 +310,9 @@ func init() {
 
 	template.Must(mailBodyTemplate.Parse(`
 		<p>
-			Job ​<b>{{.Job.GetName}}</b>,
-			Execution <b>{{status .Execution}}</b> in ​<b>{{.Execution.Duration}}</b>​,
-			command: ​<pre>{{.Job.GetCommand}}</pre>​
+			Job <b>{{.Job.GetName}}</b>,
+			Execution <b>{{status .Execution}}</b> in <b>{{.Execution.Duration}}</b>,
+			command: <pre>{{.Job.GetCommand}}</pre>
 		</p>
   `))
 

--- a/middlewares/presets/ntfy-token.yaml
+++ b/middlewares/presets/ntfy-token.yaml
@@ -18,7 +18,7 @@ variables:
     description: "ntfy access token (required for private topics)"
     required: true
     sensitive: true
-    example: "tk_AgQdq7mVBoFD37zQVN29RhuMzNIz2"
+    example: "tk_REPLACE_WITH_YOUR_NTFY_TOKEN"
 
 body: |
   {

--- a/web/auth_secure.go
+++ b/web/auth_secure.go
@@ -387,7 +387,11 @@ func (h *SecureLoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Set secure cookie
+	// Secure is conditional rather than a constant true: the UI is commonly
+	// served over plain HTTP on a private network, where a hard true would
+	// make the cookie silently unusable. HttpOnly and SameSite=Strict are
+	// unconditional.
+	// #nosec G124 -- Secure is set from the request scheme; see comment above
 	http.SetCookie(w, &http.Cookie{
 		Name:     "auth_token",
 		Value:    token,

--- a/web/server.go
+++ b/web/server.go
@@ -1013,6 +1013,9 @@ func (s *Server) logoutHandler(w http.ResponseWriter, r *http.Request) {
 		s.tokenManager.RevokeToken(token)
 	}
 
+	// Mirrors the attributes used when the cookie was issued so the browser
+	// actually replaces it; see the issuing site in auth_secure.go.
+	// #nosec G124 -- Secure is set from the request scheme, MaxAge -1 clears the cookie
 	http.SetCookie(w, &http.Cookie{
 		Name:     "auth_token",
 		Value:    "",


### PR DESCRIPTION
An audit of this repo's quality gates found several that were configured but inert — the same pattern as the documentation rule that sat `disabled: true` for years. This sharpens the repo-local ones and fixes what they immediately surfaced.

## Secret scanning found nothing because it had no rules

A gitleaks config file **replaces** the built-in ruleset unless it extends it. `.gitleaks.toml` declared only an `[allowlist]` — so there were zero detection rules and every scan reported "no leaks found" regardless of input.

Proven by A/B on the same file:

| | Result |
|---|---|
| config as committed | `no leaks found` |
| identical config + `[extend] useDefault = true` | **`leaks found: 1`** |

Turning it on immediately flagged four doc examples. The JWT ones are truncated placeholders. `docs/webhooks.md` and `middlewares/presets/ntfy-token.yaml` carried `tk_AgQdq7mVBoFD37zQVN29RhuMzNIz2` — indistinguishable in shape from a real ntfy access token. All are now unmistakable placeholders.

> ⚠️ **If that value was ever a real token it has been in public git history since 2025-12 and needs rotating.** Replacing the file does not undo that. Only someone with access to the ntfy instance can say.

## The blanket staticcheck exclusions were hiding a real defect

`text: "QF"` is an unanchored regex over the message, so it dropped every `QF####` check. Alongside it, `text: "ST1018:"` was suppressing a finding about invisible Unicode — and it was right: the HTML mail body template contained **five U+200B zero-width spaces**, shipped in every notification mail this daemon sends. Zero-width characters are a well-known spam-filter signal.

```
Job ⟦ZWSP⟧<b>{{.Job.GetName}}</b>,
Execution <b>{{status .Execution}}</b> in ⟦ZWSP⟧<b>{{.Execution.Duration}}</b>⟦ZWSP⟧,
```

Removed. staticcheck now selects checks explicitly (`all` minus `QF1008`, the one pure-style check that fires widely here) instead of filtering by message text.

## Also

- `uniq-by-line: false` — the default drops a second linter's finding whenever another linter already reported on that line.
- Five error strings lowercased: ST1005 wants it, and this codebase already writes `docker unavailable` / `creating docker client` everywhere else. These five were the outliers.
- Eleven mechanical staticcheck findings fixed (`WriteString(fmt.Sprintf(…))` → `fmt.Fprintf`, De Morgan, inferrable types).

## gosec annotations

netresearch/.github#312 makes gosec blocking. Its three findings here are false positives and are annotated with reasons rather than worked around:

- both auth cookies **do** set `HttpOnly` and `SameSite=Strict`, and derive `Secure` from the request scheme on purpose — a hard `true` would silently break the common plain-HTTP-on-a-private-network deployment;
- the third marshals a password because the Docker API requires exactly that payload in `X-Registry-Auth`.

## Verification

`golangci-lint` 0 issues · `gosec` exit 0 · `gitleaks` clean · build and vet clean under the default, `integration` and `e2e` tags · `go test -race ./...` 14/14.