### PR TITLE
docs: remove config keys the daemon never had, and gate against reintroduction

### DIFF
--- a/cli/config_docs_ini_test.go
+++ b/cli/config_docs_ini_test.go
@@ -1,0 +1,276 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	ini "gopkg.in/ini.v1"
+)
+
+const (
+	// docsINIFence opens a documented INI snippet.
+	docsINIFence = "```ini"
+	// docsINISkipMarker in the fence info string exempts a snippet from
+	// parsing. Reserved for snippets that are deliberately not valid config:
+	// placeholder section names, "wrong vs. correct" typo examples.
+	docsINISkipMarker = "no-validate"
+)
+
+// docsINIBlock is one fenced INI snippet lifted out of a Markdown file.
+type docsINIBlock struct {
+	file string // repo-relative path
+	line int    // 1-based line of the opening fence
+	body string
+}
+
+// TestDocumentedINIParses feeds every ```ini block in every Markdown file of
+// the repository through the real INI loader and section decoder, so a
+// documented configuration cannot be invalid and cannot silently stop being
+// valid when a key is renamed.
+//
+// A snippet fails when it does not parse, when it uses a section the daemon
+// never looks at, or when it uses a key no struct field claims. The last case is
+// the drift this guards: renaming a mapstructure tag without touching the docs
+// leaves the old key in the snippet, where the parser ignores it.
+func TestDocumentedINIParses(t *testing.T) {
+	t.Parallel()
+
+	blocks := collectDocsINIBlocks(t)
+	if len(blocks) == 0 {
+		t.Fatal("no ```ini blocks found in any *.md file - extraction is broken")
+	}
+
+	webhookKeys := webhookINIKeys(t)
+
+	for _, b := range blocks {
+		name := b.file + ":" + strconv.Itoa(b.line)
+		t.Run(name, func(t *testing.T) {
+			cfg, err := ini.LoadSources(
+				ini.LoadOptions{AllowShadows: true, InsensitiveKeys: true},
+				[]byte(b.body),
+			)
+			if err != nil {
+				t.Fatalf("%s: INI does not load: %v", name, err)
+			}
+
+			c := NewConfig(discardLogger())
+			res, err := parseIni(cfg, c)
+			if err != nil {
+				t.Fatalf("%s: parse failed: %v", name, err)
+			}
+
+			checkSections(t, b, cfg, webhookKeys)
+			checkUnknownKeys(t, b, res)
+		})
+	}
+}
+
+// checkSections rejects section names the daemon never looks at and, for the
+// sections whose keys are read by explicit lookups rather than by mapstructure
+// ([webhook "name"]), rejects unknown keys too. Both are silent at runtime.
+//
+// Keys above the first section header come from a snippet quoting a few lines
+// without their [section]. They are checked against the union of every
+// recognized key, which still catches a rename or a typo.
+func checkSections(t *testing.T, b docsINIBlock, cfg *ini.File, webhookKeys map[string]bool) {
+	t.Helper()
+	for _, section := range cfg.Sections() {
+		name := strings.TrimSpace(section.Name())
+		switch {
+		case name == ini.DefaultSection:
+			all := allKnownINIKeys(webhookKeys)
+			for _, k := range section.KeyStrings() {
+				if !all[strings.ToLower(k)] {
+					reportUnknownKey(t, b, "headerless", k)
+				}
+			}
+		case name == "global", name == "docker":
+		case strings.HasPrefix(name, jobExec), strings.HasPrefix(name, jobServiceRun),
+			strings.HasPrefix(name, jobRun), strings.HasPrefix(name, jobLocal),
+			strings.HasPrefix(name, jobCompose):
+		case strings.HasPrefix(name, webhookSection):
+			for _, k := range section.KeyStrings() {
+				if !webhookKeys[strings.ToLower(k)] {
+					reportUnknownKey(t, b, name, k)
+				}
+			}
+		default:
+			t.Errorf("%s:%d: unknown section [%s]", b.file, b.line, name)
+		}
+	}
+}
+
+// checkUnknownKeys reports every key mapstructure left unused, i.e. every
+// documented key with no matching struct field.
+func checkUnknownKeys(t *testing.T, b docsINIBlock, res *parseResult) {
+	t.Helper()
+	if res == nil {
+		return
+	}
+	for _, k := range res.unknownGlobal {
+		reportUnknownKey(t, b, "global", k)
+	}
+	for _, k := range res.unknownDocker {
+		reportUnknownKey(t, b, "docker", k)
+	}
+	for _, j := range res.unknownJobs {
+		for _, k := range j.UnknownKeys {
+			reportUnknownKey(t, b, j.JobType+" \""+j.JobName+"\"", k)
+		}
+	}
+}
+
+// reportUnknownKey fails the block. Every documented key the parser does not
+// recognize is a documentation bug: the daemon ignores it without a warning,
+// so an operator who pastes the snippet gets none of the promised behavior.
+// There is no allow-list — a key that cannot be honored must not be documented.
+func reportUnknownKey(t *testing.T, b docsINIBlock, section, key string) {
+	t.Helper()
+	t.Errorf("%s:%d: [%s] uses unknown key %q - not a key the parser recognizes",
+		b.file, b.line, section, key)
+}
+
+// allKnownINIKeys is every key any section recognizes, used to check snippets
+// quoted without their section header. All of it is derived from the structs the
+// parser decodes into, so a renamed mapstructure tag drops out of the set.
+func allKnownINIKeys(webhookKeys map[string]bool) map[string]bool {
+	all := make(map[string]bool, len(webhookKeys))
+	for k := range webhookKeys {
+		all[k] = true
+	}
+	add := func(keys []string) {
+		for _, k := range keys {
+			all[strings.ToLower(k)] = true
+		}
+	}
+	add(globalKnownKeys())
+	add(dockerKnownKeys())
+	for _, jobType := range []string{jobExec, jobRun, jobServiceRun, jobLocal, jobCompose} {
+		add(getKnownKeysForJobType(jobType))
+	}
+	return all
+}
+
+// collectDocsINIBlocks extracts the ```ini fenced blocks from every Markdown
+// file in the repository, skipping blocks whose fence info string carries
+// docsINISkipMarker. The file list is derived by walking the tree from the
+// repo root (located via go.mod), so a newly added document is covered without
+// touching this test. Only vendored/generated trees are excluded — they are
+// not this repo's documentation.
+func collectDocsINIBlocks(t *testing.T) []docsINIBlock {
+	t.Helper()
+	repoRoot := filepath.Dir(findRepoFile(t, "go.mod"))
+
+	var paths []string
+	err := filepath.WalkDir(repoRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			// .git is not documentation; vendor/ and node_modules/ hold
+			// third-party files this repo does not author.
+			switch d.Name() {
+			case ".git", "vendor", "node_modules":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// CHANGELOG.md is a historical record: its snippets illustrate the
+		// syntax of the release they were written for, often as deliberately
+		// incomplete fragments. Validating history against the CURRENT parser
+		// would demand rewriting old release notes after every rename, so it
+		// is the one Markdown file exempted from this gate.
+		if path == filepath.Join(repoRoot, "CHANGELOG.md") {
+			return nil
+		}
+		if strings.EqualFold(filepath.Ext(path), ".md") {
+			paths = append(paths, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk repo for *.md: %v", err)
+	}
+	sort.Strings(paths)
+
+	blocks := make([]docsINIBlock, 0, len(paths))
+	for _, path := range paths {
+		data, err := os.ReadFile(path) // #nosec G304 -- test reads repo file by computed path
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		rel, err := filepath.Rel(repoRoot, path)
+		if err != nil {
+			t.Fatalf("rel %s: %v", path, err)
+		}
+		blocks = append(blocks, extractINIBlocks(filepath.ToSlash(rel), string(data))...)
+	}
+	return blocks
+}
+
+// extractINIBlocks scans Markdown for ```ini fences. Nested fences are not a
+// concern: INI has no fenced-code syntax of its own.
+func extractINIBlocks(rel, content string) []docsINIBlock {
+	var blocks []docsINIBlock
+	lines := strings.Split(content, "\n")
+	for i := 0; i < len(lines); i++ {
+		info, ok := iniFenceInfo(lines[i])
+		if !ok {
+			continue
+		}
+		start := i + 1 // 1-based line of the opening fence
+		var body []string
+		for i++; i < len(lines) && !strings.HasPrefix(strings.TrimSpace(lines[i]), "```"); i++ {
+			body = append(body, lines[i])
+		}
+		if strings.Contains(info, docsINISkipMarker) {
+			continue
+		}
+		blocks = append(blocks, docsINIBlock{file: rel, line: start, body: strings.Join(body, "\n")})
+	}
+	return blocks
+}
+
+// iniFenceInfo reports whether line opens an INI code fence and returns the rest
+// of the info string, where the skip marker may live.
+func iniFenceInfo(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, docsINIFence) {
+		return "", false
+	}
+	rest := trimmed[len(docsINIFence):]
+	if rest != "" && !strings.HasPrefix(rest, " ") {
+		return "", false // e.g. ```inifoo
+	}
+	return strings.TrimSpace(rest), true
+}
+
+// webhookINIKeys reads the key names parseWebhookConfig actually looks up,
+// straight out of config_webhook.go. Deriving them from the source keeps this
+// test from carrying a second, drifting copy of the webhook key list — the
+// [webhook] section is decoded by explicit GetKey calls, not by mapstructure, so
+// parseResult has nothing to report for it.
+func webhookINIKeys(t *testing.T) map[string]bool {
+	t.Helper()
+	src, err := os.ReadFile(findRepoFile(t, "cli", "config_webhook.go")) // #nosec G304 -- repo file
+	if err != nil {
+		t.Fatalf("read config_webhook.go: %v", err)
+	}
+	re := regexp.MustCompile(`section\.GetKey\("([^"]+)"\)`)
+	keys := make(map[string]bool)
+	for _, m := range re.FindAllStringSubmatch(string(src), -1) {
+		keys[strings.ToLower(m[1])] = true
+	}
+	if len(keys) == 0 {
+		t.Fatal("no section.GetKey calls found in config_webhook.go - extraction is broken")
+	}
+	return keys
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -319,7 +319,7 @@ command = pg_dump ${DB_NAME:-mydb}
 
 ### Basic Structure
 
-```ini
+```ini no-validate
 [global]
 # Global configuration options
 
@@ -334,9 +334,10 @@ command = pg_dump ${DB_NAME:-mydb}
 ```ini
 [global]
 # Docker Configuration
-docker-host = unix:///var/run/docker.sock
-docker-poll-interval = 30s
-docker-events = true
+# The Docker daemon address comes from the DOCKER_HOST environment variable
+# (default unix:///var/run/docker.sock) — there is no INI key for it.
+# Event/polling settings (events, docker-poll-interval, ...) belong in the
+# [docker] section — see "Docker label configurations" in the README.
 allow-host-jobs-from-labels = false
 default-user = nobody        # Default for exec/run/service; empty uses container default
 
@@ -437,7 +438,6 @@ environment = DB_NAME=mydb,BACKUP_RETENTION=7
 tty = false                 # Allocate TTY
 console-height = 24         # Initial pseudo-TTY rows (only honored when tty=true; #235)
 console-width  = 80         # Initial pseudo-TTY columns
-delay = 5s                  # Delay before execution
 
 # Middleware Configuration
 slack-webhook = https://hooks.slack.com/...
@@ -449,7 +449,7 @@ email-subject = Database Backup Report
 save-folder = /logs/backups
 save-only-on-error = false
 
-overlap = false             # Prevent overlapping runs
+no-overlap = true           # Prevent overlapping runs
 ```
 
 ### RunJob - Execute in New Container
@@ -471,27 +471,23 @@ hostname = processor-job
 
 # Container Configuration
 environment = ENV=production,LOG_LEVEL=info
-volumes = /data:/data:ro,/output:/output:rw
-devices = /dev/fuse:/dev/fuse
-capabilities-add = SYS_ADMIN
-capabilities-drop = NET_RAW
-dns = 8.8.8.8,8.8.4.4
-labels = job=processor,env=prod
+volume = /data:/data:ro
+volume = /output:/output:rw
 working-dir = /app
-memory = 512m
-memory-swap = 1g
-cpu-shares = 512
-cpu-quota = 50000
+max-runtime = 1h            # Abort the run after this long
 
 # Cleanup
 delete = true               # Delete container after execution
-delete-timeout = 30s        # Timeout for deletion
 stop-signal = SIGINT        # Signal sent at stop time (#234); empty = image's STOPSIGNAL or SIGTERM
 stop-timeout = 30s          # Grace period before SIGKILL in cleanupOnDeadline (#234); 0 = legacy 10s default
-
-# Restart Policy
-restart-on-failure = 3      # Max restart attempts
 ```
+
+Ofelia does not set resource limits, capabilities, devices, DNS servers or
+container labels on the containers it creates — there are no configuration keys
+for them, and a key it does not recognize is ignored without a warning. Apply
+those settings where the container is defined instead: in the image, in the
+Compose service that ofelia execs into, or as daemon-wide defaults. See
+[Security](SECURITY.md#resource-limits) for how to constrain a job's resources.
 
 ### LocalJob - Execute on Host
 
@@ -504,10 +500,12 @@ schedule = @daily
 command = /usr/local/bin/cleanup.sh
 
 # Optional
-user = maintenance          # System user
 dir = /var/maintenance      # Working directory
 environment = CLEANUP_DAYS=30,LOG_FILE=/var/log/cleanup.log
 
+# Local jobs run as the user the ofelia process runs as; there is no way to
+# switch user per job. Use a wrapper (su, sudo, setpriv) in the command if a
+# job must run as someone else.
 # Security Warning: LocalJobs run with host privileges
 # Not available from Docker labels unless explicitly allowed
 ```
@@ -539,15 +537,17 @@ Manages Docker Compose projects.
 [job-compose "stack-restart"]
 # Required
 schedule = 0 4 * * *        # 4 AM daily
-project = myapp             # Project name
 command = restart           # Compose command
 
 # Optional
-service = web               # Specific service
-timeout = 300s              # Operation timeout
-dir = /opt/compose/myapp    # Working directory with docker-compose.yml
-environment = COMPOSE_PROJECT_NAME=myapp
+file = /opt/compose/myapp/compose.yml   # Compose file; default compose.yml
+service = web               # Limit the command to one service
+exec = false                # true runs `compose exec` instead of `compose run`
 ```
+
+`file`, `service` and `exec` are the only compose-specific keys. The project
+name and the working directory follow from the compose file's location, as they
+do for the `docker compose` CLI.
 
 ## Docker Labels Configuration
 
@@ -684,7 +684,7 @@ services:
 | Log level | ❌ No | ✅ `OFELIA_LOG_LEVEL` | ✅ `log-level` |
 | Save folder | ❌ No | ❌ No | ✅ `save-folder` |
 | Save only on error | ❌ No | ❌ No | ✅ `save-only-on-error` |
-| Docker host | ❌ No | ❌ No | ✅ `docker-host` |
+| Docker host | ❌ No | ✅ `DOCKER_HOST` | ❌ No |
 | Web UI | ❌ No | ✅ `OFELIA_ENABLE_WEB` | ✅ `enable-web` |
 | Webhook definitions | ✅ `ofelia.webhook.NAME.*` | ❌ No | ✅ `[webhook "NAME"]` |
 | Webhook assignment | ✅ `ofelia.job-*.NAME.webhooks` | ❌ No | ✅ `webhooks` in job section |
@@ -711,7 +711,7 @@ Standard cron expressions with seconds (optional):
 
 ### Preset Schedules
 
-```ini
+```text
 @yearly     # Run once a year (0 0 1 1 *)
 @annually   # Same as @yearly
 @monthly    # Run once a month (0 0 1 * *)
@@ -766,7 +766,6 @@ OFELIA_JOB_RUN_CLEANUP_IMAGE=alpine:3.18
 ```bash
 ofelia daemon \
   --config=/etc/ofelia/config.ini \
-  --docker-host=unix:///var/run/docker.sock \
   --docker-poll-interval=30s \
   --docker-events \
   --enable-web \
@@ -925,7 +924,7 @@ container = worker
 command = long-task.sh
 
 # Prevent overlapping runs
-overlap = false
+no-overlap = true
 ```
 
 ## Job Dependencies
@@ -1169,29 +1168,28 @@ When enabled, strict validation provides:
 1. **Use environment variables for secrets**
    ```ini
    smtp-password = ${SMTP_PASSWORD}
-   jwt-secret = ${JWT_SECRET}
+   web-secret-key = ${WEB_SECRET_KEY}
    ```
 
 2. **Enable Docker events for real-time updates**
    ```ini
-   docker-events = true
+   [docker]
+   events = true
    ```
 
-3. **Set appropriate job timeouts**
+3. **Bound how long a job may run** (`job-run` and `job-service-run` only)
    ```ini
-   delete-timeout = 30s
+   max-runtime = 1h
    ```
 
 4. **Use overlap prevention for long-running jobs**
    ```ini
-   overlap = false
+   no-overlap = true
    ```
 
-5. **Configure appropriate resource limits**
-   ```ini
-   memory = 512m
-   cpu-shares = 512
-   ```
+5. **Constrain job resources where the container is defined** — ofelia has no
+   keys for memory or CPU limits; set them on the image, the Compose service or
+   the Docker daemon's defaults.
 
 6. **Use save-only-on-error for debugging**
    ```ini

--- a/docs/INTEGRATION_PATTERNS.md
+++ b/docs/INTEGRATION_PATTERNS.md
@@ -76,7 +76,6 @@ schedule = 0 1 * * 0  # Sunday 1 AM
 container = postgres
 command = vacuumdb --all --analyze --verbose
 user = postgres
-max-runtime = 2h
 no-overlap = true
 
 [job-exec "postgres-reindex"]
@@ -84,13 +83,12 @@ schedule = 0 1 1 * *  # First of month, 1 AM
 container = postgres
 command = reindexdb --all --verbose
 user = postgres
-max-runtime = 4h
 no-overlap = true
 ```
 
 **Best Practices**:
 - Set `no-overlap = true` for long-running maintenance
-- Use `max-runtime` to prevent runaway jobs
+- Cap the command itself (e.g. `timeout 2h ...`); `max-runtime` does not apply to exec jobs
 - Schedule during low-traffic periods
 - Monitor execution time trends via metrics
 
@@ -421,14 +419,12 @@ schedule = * * * * *  # Every minute
 container = worker
 command = /scripts/process-batch.sh --limit 100
 no-overlap = true
-max-runtime = 55s
 
 [job-exec "large-batch-processing"]
 schedule = 0 2 * * *  # Daily at 2 AM
 container = worker
 command = /scripts/process-all.sh --batch-size 1000
 no-overlap = true
-max-runtime = 4h
 ```
 
 ### Pattern: Concurrent Job Execution
@@ -567,7 +563,6 @@ schedule = 0 * * * *
 container = worker
 command = /scripts/process.sh
 no-overlap = true  # Prevent concurrent execution
-max-runtime = 50m  # Kill after 50 minutes
 ```
 
 ### Pattern: Gradual Rollout
@@ -595,7 +590,7 @@ command = /scripts/new-feature.sh --dry-run
 
 ### Scheduling
 ✅ Use `no-overlap = true` for long-running or resource-intensive jobs
-✅ Set appropriate `max-runtime` to prevent runaway jobs
+✅ Set `max-runtime` on run and service jobs to prevent runaway jobs
 ✅ Schedule maintenance during low-traffic periods
 ✅ Use cron expressions that distribute load (avoid XX:00 pileups)
 

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -411,13 +411,16 @@ command = /scripts/task.sh
 no-overlap = true               # ← Add this
 ```
 
-`max-runtime` is not available on `job-exec`; it applies to `job-run`,
-`job-service-run` and `[global]`. To bound an exec job, set the global
-default:
+`max-runtime` is not available on `job-exec`. It applies to `job-run` and
+`job-service-run`, and a `[global] max-runtime` seeds only those two — an exec
+job is never bounded by it, because the command runs inside a container ofelia
+did not create. To cap an exec job, put the limit in the command itself:
 
 ```ini
-[global]
-max-runtime = 50m
+[job-exec "worker-task"]
+schedule = @hourly
+container = worker
+command = timeout 50m /scripts/task.sh
 ```
 
 ## Performance Tips
@@ -432,7 +435,7 @@ OFELIA_POLL_INTERVAL=30s
 # 3. Use no-overlap for long-running jobs
 no-overlap = true
 
-# 4. Set appropriate max-runtime
+# 4. Bound run and service jobs
 max-runtime = 1h
 
 # 5. Limit history to reduce memory
@@ -452,7 +455,6 @@ container = postgres
 command = pg_dumpall -U postgres | gzip > /backups/$(date +\%Y\%m\%d).sql.gz
 user = postgres
 no-overlap = true
-max-runtime = 2h
 ```
 
 ### Log Rotation
@@ -650,7 +652,7 @@ mail-only-on-error = false
 - [ ] Set appropriate user for exec/run jobs
 - [ ] Use read-only volume mounts where possible
 - [ ] Enable audit logging (`save-only-on-error = false`)
-- [ ] Set `max-runtime` to prevent runaway jobs
+- [ ] Set `max-runtime` on run and service jobs to prevent runaway jobs
 - [ ] Use `no-overlap` for resource-intensive tasks
 - [ ] Validate all input in custom scripts
 - [ ] Keep Ofelia image updated

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -218,7 +218,7 @@ allow-host-jobs-from-labels = false
 delete = true
 
 # Overlap prevention for critical jobs
-overlap = false
+no-overlap = true
 ```
 
 ### A05:2021 - Security Misconfiguration
@@ -571,28 +571,36 @@ err := cmdValidator.ValidateCommandArgs(args)
 
 ### Container Isolation
 
-**Resource Limits**:
+#### Resource Limits
+
+Ofelia has no configuration keys for memory limits, CPU limits, capabilities or
+devices, and it ignores keys it does not recognize without warning — so these
+cannot be set on the job. Constrain the container itself instead.
+
+For `job-exec`, the container already exists and its limits are whatever created
+it, typically a Compose service:
+
+```yaml
+services:
+  processor:
+    image: myapp:latest
+    mem_limit: 512m
+    cpus: 0.5
+    cap_drop: [ALL]
+    cap_add: [NET_BIND_SERVICE]
+    security_opt: [no-new-privileges:true]
+```
+
+For `job-run`, ofelia creates the container from the image, so the limits have
+to come from the daemon: set `default-ulimits` and a default runtime in
+`/etc/docker/daemon.json`, or run those workloads on a daemon configured for
+them. What the job can express is how long it may run:
+
 ```ini
 [job-run "isolated-job"]
 image = myapp:latest
 command = process-data
-
-# Memory limits
-memory = 512m
-memory-swap = 1g
-
-# CPU limits
-cpu-shares = 512
-cpu-quota = 50000
-```
-
-**Capabilities**:
-```ini
-# Drop dangerous capabilities
-capabilities-drop = NET_RAW,SYS_ADMIN,SYS_MODULE
-
-# Add only required capabilities
-capabilities-add = NET_BIND_SERVICE
+max-runtime = 30m
 ```
 
 **User Restrictions**:
@@ -615,27 +623,29 @@ network = app_isolated
 network = none
 ```
 
-**DNS Restrictions**:
-```ini
-# Internal DNS only
-dns = 10.0.0.1,10.0.0.2
-```
+**DNS Restrictions**: there is no `dns` key. A container inherits its resolver
+from the network it joins, so restrict DNS by attaching the job to a network
+whose resolver you control, or set `dns` on the Docker daemon.
 
 ### Volume Security
 
 **Read-Only Mounts**:
 ```ini
 # Read-only data volume
-volumes = /data:/data:ro
+volume = /data:/data:ro
 
 # Writable output only
-volumes = /output:/output:rw
+volume = /output:/output:rw
 ```
 
-**Tmpfs for Sensitive Data**:
-```ini
-# Temporary in-memory storage
-tmpfs = /tmp:rw,noexec,nosuid,size=100m
+**Tmpfs for Sensitive Data**: there is no `tmpfs` key either. Declare the mount
+on the container definition:
+
+```yaml
+services:
+  processor:
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,size=100m
 ```
 
 ### Image Security

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -575,7 +575,9 @@ err := cmdValidator.ValidateCommandArgs(args)
 
 Ofelia has no configuration keys for memory limits, CPU limits, capabilities or
 devices, and it ignores keys it does not recognize without warning — so these
-cannot be set on the job. Constrain the container itself instead.
+cannot be set on the job. Constrain the container itself instead. This follows
+the boundary in [ADR-002](./adr/ADR-002-security-boundaries.md): the runtime
+enforces what a container may do, the scheduler decides when it runs.
 
 For `job-exec`, the container already exists and its limits are whatever created
 it, typically a Compose service:

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -89,9 +89,8 @@ ls -la /var/run/docker.sock
    ```
 
 3. **Docker socket path incorrect**:
-   ```ini
-   [global]
-   docker-host = unix:///var/run/docker.sock
+   ```bash
+   export DOCKER_HOST=unix:///var/run/docker.sock
    ```
 
 4. **Docker Desktop not started** (macOS/Windows):
@@ -155,9 +154,8 @@ docker exec ofelia id
    > Any local process can gain full Docker control, enabling privilege escalation
    > to root. Only use in isolated development environments, never in production.
 
-   ```ini
-   [global]
-   docker-host = tcp://localhost:2375
+   ```bash
+   export DOCKER_HOST=tcp://localhost:2375
    ```
 
    Enable TCP in Docker daemon:
@@ -344,7 +342,7 @@ See [#609](https://github.com/netresearch/ofelia/issues/609).
 - Any other scheme (e.g. `gopher://`, `tcp+ssh://`).
 
 **Solution**:
-Set `DOCKER_HOST` (or the `--docker-host` flag / `docker-host` config key)
+Set the `DOCKER_HOST` environment variable (or the `--docker-host` flag)
 to a value using one of the supported schemes above.
 
 ### TLS Handshake / Cert Path Errors (v0.24.1+)
@@ -640,7 +638,7 @@ grep -i "schedual" /etc/ofelia/config.ini
 **Solutions**:
 
 1. **Typo in field name**:
-   ```ini
+   ```ini no-validate
    # Wrong
    schedual = @daily
 
@@ -840,8 +838,8 @@ Fatal: Cannot start server: invalid JWT configuration
 2. **Configuration**:
    ```ini
    [global]
-   jwt-secret = ${JWT_SECRET}  # Minimum 32 characters
-   jwt-expiry-hours = 24
+   web-secret-key = ${JWT_SECRET}  # Minimum 32 characters
+   web-token-expiry = 24
    ```
 
 ### Invalid or Expired Token
@@ -878,7 +876,7 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/api/jobs
 3. **Increase token expiry**:
    ```ini
    [global]
-   jwt-expiry-hours = 168  # 1 week instead of 24 hours
+   web-token-expiry = 168  # 1 week instead of 24 hours
    ```
 
 ### Too Many Login Attempts
@@ -958,7 +956,7 @@ docker logs ofelia | grep "backup-db"
 4. **Overlap prevention blocking execution**:
    ```ini
    # Previous job still running
-   overlap = false  # Remove or set to true
+   no-overlap = true  # Remove or set to false
    ```
 
 ### Jobs Being Skipped
@@ -970,7 +968,7 @@ docker logs ofelia | grep "backup-db"
 
 **Root Cause**:
 
-When `overlap = false` (or `no-overlap: 'true'` in Docker labels), Ofelia prevents concurrent executions of the same job. If a previous execution appears to still be running (e.g., a hung process that never terminated), subsequent scheduled runs will be skipped.
+When `no-overlap = true` (or `no-overlap: 'true'` in Docker labels), Ofelia prevents concurrent executions of the same job. If a previous execution appears to still be running (e.g., a hung process that never terminated), subsequent scheduled runs will be skipped.
 
 Common causes of "stuck" jobs:
 - **Node.js**: Unhandled promise rejections don't exit by default
@@ -1025,7 +1023,7 @@ docker exec <container> ps aux | grep defunct
 4. **Temporarily disable overlap protection**:
    ```ini
    # For debugging - allows concurrent runs
-   overlap = true
+   no-overlap = false
    ```
 
 5. **Use shell wrapper with timeout**:
@@ -1078,10 +1076,10 @@ docker logs ofelia | grep "backup-db"
    # chmod +x /usr/local/bin/backup.sh
    ```
 
-3. **Container not ready**:
+3. **Container not ready**: there is no `delay` key — a job runs when its
+   schedule fires. Wait inside the command instead:
    ```ini
-   # Add delay before execution
-   delay = 10s
+   command = sh -c 'until pg_isready -q; do sleep 1; done; /usr/local/bin/backup.sh'
    ```
 
 4. **Script errors**:
@@ -1103,10 +1101,13 @@ Error: Container failed to respond
 
 **Solutions**:
 
-1. **Increase timeout**:
+1. **Raise the limit where it is set**: exec jobs have no `timeout` key, and
+   `max-runtime` applies only to `job-run` and `job-service-run`. A timeout on
+   an exec job therefore comes from the command or from the Docker daemon, not
+   from ofelia. Cap it explicitly if you want a known limit:
    ```ini
    [job-exec "long-task"]
-   timeout = 600s  # 10 minutes
+   command = timeout 600 /usr/local/bin/long-task.sh
    ```
 
 2. **Optimize task**:
@@ -1151,10 +1152,11 @@ docker inspect ofelia | grep Memory
              memory: 1G  # Increase from 512M
    ```
 
-2. **Optimize memory usage**:
+2. **Optimize memory usage**: ofelia has no cap on how many jobs run at once,
+   so spread the schedules apart rather than looking for a concurrency setting.
+   What it does offer is per-job overlap prevention and container cleanup:
    ```ini
-   # Limit concurrent jobs
-   max-concurrent-jobs = 3
+   no-overlap = true
 
    # Clean up after execution
    delete = true
@@ -1628,9 +1630,8 @@ Error: Rate limit exceeded
    ```
 
 3. **Wrong Docker host**:
-   ```ini
-   [global]
-   docker-host = unix:///var/run/docker.sock
+   ```bash
+   export DOCKER_HOST=unix:///var/run/docker.sock
    ```
 
 ### Scheduler Check Unhealthy
@@ -1805,11 +1806,9 @@ OOMKilled errors
    go tool pprof heap.out
    ```
 
-2. **Limit concurrent execution**:
-   ```ini
-   # Reduce parallel jobs
-   max-concurrent-jobs = 5
-   ```
+2. **Limit concurrent execution**: there is no setting for this. Stagger the
+   schedules of the heaviest jobs so they do not fire together, and set
+   `no-overlap = true` so a slow run does not stack on its own next tick.
 
 3. **Monitor and alert**:
    ```bash
@@ -1869,12 +1868,15 @@ df -h
 
 ### Profiling
 
-```bash
-# Enable profiling
+Enable profiling:
+
+```ini
 [global]
 enable-pprof = true
 pprof-address = :6060
+```
 
+```bash
 # Capture profiles
 curl http://localhost:6060/debug/pprof/goroutine > goroutine.out
 curl http://localhost:6060/debug/pprof/heap > heap.out

--- a/docs/packages/cli.md
+++ b/docs/packages/cli.md
@@ -72,7 +72,9 @@ func BuildFromFile(path string) (*Config, error) {
 ```ini
 [global]
 slack-webhook = https://hooks.slack.com/...
-docker-events = true
+
+[docker]
+events = true
 
 [job-exec "database-backup"]
 schedule = @midnight


### PR DESCRIPTION
The docs described 37 configuration keys that no struct field claims. Ofelia
ignores an unrecognized key without warning, so an operator who pasted these
snippets got none of the promised behavior.

Git history says they were never implemented and never removed: no commit ever
introduced any of them. They arrived in two documentation sweeps and describe
what the internal Docker model can express, not what the INI parser accepts.

## The part that matters

`SECURITY.md` presented `memory`, `memory-swap`, `cpu-shares`, `cpu-quota`,
`capabilities-add`, `capabilities-drop`, `dns` and `tmpfs` as container
hardening. Anyone who followed that guidance believed their jobs were
constrained while every line was discarded. That section now states ofelia has
no such keys and shows where the limits belong — on the Compose service for
exec jobs, on the daemon for run jobs.

## The rest

| Key | Reality |
|---|---|
| `max-runtime` on `job-exec` | exists on `job-run`/`job-service-run` only; `[global] max-runtime` seeds just those two |
| `timeout`, `delay` | exist nowhere |
| `max-concurrent-jobs` | ofelia does not cap parallelism at all |
| `user` on `job-local` | local jobs run as the ofelia process user |
| `project`, `dir`, `environment`, `timeout` on `job-compose` | it takes `file`, `service`, `exec` |
| `devices`, `labels`, `restart-on-failure`, `delete-timeout` on `job-run` | never existed |

Each is replaced by what does work rather than deleted silently.

## Gate

`TestDocumentedINIParses` parses every documented INI block with the real
parser. It carried these 37 occurrences as an allow-listed backlog; with the
docs fixed the list is empty, so the mechanism is removed and the gate is
unconditional.

One block in `TROUBLESHOOTING.md` hid INI config inside a bash fence and escaped
the check — it is split so the config half is validated. Two blocks keep an
explicit `no-validate` marker: a `[job-TYPE "NAME"]` placeholder schema, and a
snippet whose point is to show a misspelled key.

## Verification

golangci-lint 0 issues; the `cli` suite passes; reintroducing a single removed
key produces exactly one finding.

## Follow-up

Whether the hardening options should exist as real features is tracked in #758 — this PR only stops the docs promising them.
