### PR TITLE
ci: verify each published release against its own documentation

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2025-2026 Netresearch DTT GmbH
+#
+# Re-verifies a published release the way a user following SECURITY.md would:
+# every signature, the checksum manifest, build provenance, and the container
+# image. Running the documented commands is the only thing that keeps them
+# true — every one of them was wrong until #755, and nothing caught it.
+
+name: Verify Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to verify (e.g. v0.28.0)."
+        type: string
+        required: true
+
+permissions: {}
+
+concurrency:
+  group: verify-release-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  # The container tag drops the leading "v" while the release tag keeps it, so
+  # ghcr.io/netresearch/ofelia:v0.28.0 does not exist and :0.28.0 does. GitHub
+  # expressions cannot strip a prefix, hence this job.
+  refs:
+    name: Resolve refs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+      image: ${{ steps.resolve.outputs.image }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Resolve tag and image reference
+        id: resolve
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          TAG="${RELEASE_TAG:-$INPUT_TAG}"
+          if [ -z "$TAG" ]; then
+            echo "::error::no release tag to verify"
+            exit 1
+          fi
+          # The tag reaches $GITHUB_OUTPUT and, downstream, an image reference.
+          # Constrain it to what a tag may contain so nothing else can ride
+          # along, however the release was created.
+          case "$TAG" in
+            *[!A-Za-z0-9._-]*)
+              echo "::error::tag '$TAG' contains characters a release tag should not"
+              exit 1
+              ;;
+          esac
+          {
+            echo "tag=$TAG"
+            echo "image=ghcr.io/netresearch/ofelia:${TAG#v}"
+          } >> "$GITHUB_OUTPUT"
+
+  verify:
+    name: Verify
+    needs: refs
+    uses: netresearch/.github/.github/workflows/verify-release.yml@main
+    with:
+      tag: ${{ needs.refs.outputs.tag }}
+      container-image: ${{ needs.refs.outputs.image }}
+    permissions:
+      contents: read
+      attestations: read
+      id-token: write

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -102,12 +102,16 @@ gh attestation verify <artifact> \
 
 ### Verify Container Image
 
+The image tag has no `v` prefix, while the release tag does — release `v0.28.0`
+publishes `ghcr.io/netresearch/ofelia:0.28.0`. Pasting the release tag here
+fails with a manifest-not-found error rather than a signature error.
+
 ```bash
-cosign verify ghcr.io/netresearch/ofelia:<TAG> \
+cosign verify ghcr.io/netresearch/ofelia:0.28.0 \
   --certificate-identity-regexp "^https://github\.com/netresearch/\.github/\.github/workflows/release-go-app\.yml@" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 
-gh attestation verify oci://ghcr.io/netresearch/ofelia:<TAG> \
+gh attestation verify oci://ghcr.io/netresearch/ofelia:0.28.0 \
   --repo netresearch/ofelia \
   --signer-workflow netresearch/.github/.github/workflows/release-go-app.yml
 ```


### PR DESCRIPTION
Wires up [netresearch/.github#315](https://github.com/netresearch/.github/pull/315), which re-verifies a published release by running the commands `SECURITY.md` hands to users: every signature, the checksum manifest, build provenance, and the container image.

The reason this matters here specifically: **every one of those documented commands was wrong until #755** — wrong file extensions, a signer workflow that does not exist, a verifier aimed at assets no release ships. Nobody noticed, because nothing ran them. This makes the documentation self-checking.

Fires on release publication, and can be dispatched for any tag.

## A documentation defect found while wiring it up

The container tag drops the leading `v` that the release tag keeps: release `v0.28.0` publishes `ghcr.io/netresearch/ofelia:0.28.0`. `SECURITY.md` wrote both container commands with a `<TAG>` placeholder, so a reader substituting the tag from the release page got a *manifest not found* error — which reads like a missing image rather than a documentation bug, and is the kind of thing people give up on rather than report.

Verified against the published image:

| Reference | `cosign verify` | `gh attestation verify` |
|---|---|---|
| `:0.28.0` | OK | OK |
| `:v0.28.0` | fails | fails |

Both examples now use a concrete tag and state that the prefix is dropped.

## Caller shape

The prefix is stripped in a small `refs` job because GitHub expressions have no way to do it. That job also constrains the tag to the characters a tag may contain before it reaches `$GITHUB_OUTPUT` and the image reference — the release tag is set by whoever creates the release, and it should not be able to carry anything else into either.
