### PR TITLE
fix(docker): guard nil Config, and raise coverage to 90% for Best Practices Gold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,54 @@ coverage:
     patch:
       default:
         target: 80%
+
+# Components split the coverage report along the architecture boundaries in
+# ARCHITECTURE.md, so a drop is attributable to a layer rather than to the
+# repository as a whole. Statuses stay informational: the gate that can fail a
+# PR is the patch target above, not per-component drift.
+#
+# `core` excludes the adapter and persistence subtrees because those are
+# reported as components of their own; without the negations their files would
+# be counted in two components at once.
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        informational: true
+  individual_components:
+    - component_id: core
+      name: core (scheduler, jobs, domain)
+      paths:
+        - core/**
+        - "!core/adapters/**"
+        - "!core/persist/**"
+    - component_id: adapters
+      name: adapters (docker, mock)
+      paths:
+        - core/adapters/**
+    - component_id: persist
+      name: persistence
+      paths:
+        - core/persist/**
+    - component_id: web
+      name: web UI and HTTP API
+      paths:
+        - web/**
+        - static/**
+    - component_id: cli
+      name: CLI and daemon
+      paths:
+        - cli/**
+        - "*.go"
+    - component_id: config
+      name: config parsing and validation
+      paths:
+        - config/**
+    - component_id: middlewares
+      name: middlewares (notifications)
+      paths:
+        - middlewares/**
+    - component_id: metrics
+      name: metrics
+      paths:
+        - metrics/**

--- a/core/adapters/docker/adapters_stub_test.go
+++ b/core/adapters/docker/adapters_stub_test.go
@@ -1,0 +1,459 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package docker
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/netresearch/ofelia/core/domain"
+	"github.com/netresearch/ofelia/core/ports"
+)
+
+// The system, image and network adapters translate between the domain types
+// and the Docker SDK the same way the container adapter does, and their
+// success branches were unreachable without a daemon for the same reason.
+// These tests answer as a daemon would (see stubSDK in
+// container_wrappers_test.go) so the translation is asserted directly.
+
+func TestSystemServiceAdapter_Ping_MapsFields(t *testing.T) {
+	t.Parallel()
+
+	adapter := &SystemServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/_ping": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Api-Version", "1.43")
+			w.Header().Set("Ostype", "linux")
+			w.Header().Set("Docker-Experimental", "false")
+			w.Header().Set("Builder-Version", "2")
+			w.WriteHeader(http.StatusOK)
+		},
+	})}
+
+	got, err := adapter.Ping(context.Background())
+	if err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if got.APIVersion != "1.43" {
+		t.Errorf("APIVersion = %q, want 1.43", got.APIVersion)
+	}
+	if got.OSType != "linux" {
+		t.Errorf("OSType = %q, want linux", got.OSType)
+	}
+}
+
+func TestSystemServiceAdapter_Version_MapsFields(t *testing.T) {
+	t.Parallel()
+
+	adapter := &SystemServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/version": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, map[string]any{
+				"Version":       "27.1.1",
+				"ApiVersion":    "1.46",
+				"MinAPIVersion": "1.24",
+				"Os":            "linux",
+				"Arch":          "amd64",
+				"Platform":      map[string]any{"Name": "Docker Engine - Community"},
+				"Components": []map[string]any{
+					{
+						"Name":    "Engine",
+						"Version": "27.1.1",
+						"Details": map[string]string{
+							"GitCommit":     "abc1234",
+							"GoVersion":     "go1.22.5",
+							"KernelVersion": "6.8.0",
+							"BuildTime":     "2026-01-01T00:00:00.000000000+00:00",
+						},
+					},
+				},
+			})
+		},
+	})}
+
+	got, err := adapter.Version(context.Background())
+	if err != nil {
+		t.Fatalf("Version: %v", err)
+	}
+	if got.Version != "27.1.1" || got.APIVersion != "1.46" {
+		t.Errorf("Version/APIVersion = %q/%q, want 27.1.1/1.46", got.Version, got.APIVersion)
+	}
+	if got.Platform.Name != "Docker Engine - Community" {
+		t.Errorf("Platform.Name = %q", got.Platform.Name)
+	}
+	// GitCommit and friends are lifted out of the Engine component's Details
+	// map rather than read from a top-level field, which is the one piece of
+	// logic in Version worth pinning.
+	if got.GitCommit != "abc1234" {
+		t.Errorf("GitCommit = %q, want abc1234 (lifted from the Engine component)", got.GitCommit)
+	}
+	if got.GoVersion != "go1.22.5" {
+		t.Errorf("GoVersion = %q, want go1.22.5", got.GoVersion)
+	}
+	if len(got.Components) != 1 || got.Components[0].Name != "Engine" {
+		t.Errorf("Components = %+v, want one Engine entry", got.Components)
+	}
+}
+
+func TestSystemServiceAdapter_Info_MapsFields(t *testing.T) {
+	t.Parallel()
+
+	adapter := &SystemServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/info": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, map[string]any{
+				"ID":                "sys-id",
+				"Name":              "test-daemon",
+				"ServerVersion":     "27.1.1",
+				"OperatingSystem":   "Debian",
+				"OSType":            "linux",
+				"Architecture":      "x86_64",
+				"NCPU":              8,
+				"MemTotal":          16000000000,
+				"Containers":        3,
+				"ContainersRunning": 1,
+				"ContainersPaused":  0,
+				"ContainersStopped": 2,
+				"Images":            5,
+				"Driver":            "overlay2",
+			})
+		},
+	})}
+
+	got, err := adapter.Info(context.Background())
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if got.Name != "test-daemon" {
+		t.Errorf("Name = %q, want test-daemon", got.Name)
+	}
+	if got.Containers != 3 || got.ContainersRunning != 1 || got.ContainersStopped != 2 {
+		t.Errorf("container counts = %d/%d/%d, want 3/1/2",
+			got.Containers, got.ContainersRunning, got.ContainersStopped)
+	}
+	if got.NCPU != 8 {
+		t.Errorf("NCPU = %d, want 8", got.NCPU)
+	}
+}
+
+func TestImageServiceAdapter_List_ConvertsSummaries(t *testing.T) {
+	t.Parallel()
+
+	adapter := &ImageServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/images/json": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, []map[string]any{
+				{"Id": "sha256:aaa", "RepoTags": []string{"alpine:3.20"}, "Size": 1234},
+				{"Id": "sha256:bbb", "RepoTags": []string{"busybox:latest"}, "Size": 5678},
+			})
+		},
+	})}
+
+	got, err := adapter.List(context.Background(), domain.ImageListOptions{All: true})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("List returned %d images, want 2", len(got))
+	}
+	if got[0].ID != "sha256:aaa" || got[1].ID != "sha256:bbb" {
+		t.Errorf("List returned ids %q, %q; want sha256:aaa, sha256:bbb", got[0].ID, got[1].ID)
+	}
+}
+
+// TestImageServiceAdapter_Exists covers both branches of the not-found
+// translation: Exists must report absence as (false, nil) and never as an
+// error, because callers use it to decide whether to pull.
+func TestImageServiceAdapter_Exists(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		status  int
+		want    bool
+		wantErr bool
+	}{
+		{name: "present", status: http.StatusOK, want: true},
+		{name: "absent", status: http.StatusNotFound, want: false},
+		{name: "daemon error", status: http.StatusInternalServerError, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			adapter := &ImageServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+				"/images/": func(w http.ResponseWriter, _ *http.Request) {
+					if tc.status != http.StatusOK {
+						w.WriteHeader(tc.status)
+						writeJSON(t, w, map[string]any{"message": "nope"})
+						return
+					}
+					writeJSON(t, w, map[string]any{"Id": "sha256:aaa", "RepoTags": []string{"alpine:3.20"}})
+				},
+			})}
+
+			got, err := adapter.Exists(context.Background(), "alpine:3.20")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected an error for a failing daemon, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Exists: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("Exists = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestImageServiceAdapter_Tag_SendsRepoAndTag(t *testing.T) {
+	t.Parallel()
+
+	var gotQuery, gotPath string
+	adapter := &ImageServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/tag": func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotQuery = r.URL.RawQuery
+			w.WriteHeader(http.StatusCreated)
+		},
+	})}
+
+	if err := adapter.Tag(context.Background(), "alpine:3.20", "myrepo/alpine:pinned"); err != nil {
+		t.Fatalf("Tag: %v", err)
+	}
+	if gotPath == "" {
+		t.Fatal("Tag never reached the daemon")
+	}
+	// The SDK splits the target into repo and tag query parameters; assert the
+	// tag survived rather than the exact encoding of the repo path.
+	if want := "tag=pinned"; !strings.Contains(gotQuery, want) {
+		t.Errorf("tag request query = %q, want it to contain %q", gotQuery, want)
+	}
+}
+
+func TestNetworkServiceAdapter_List_ConvertsNetworks(t *testing.T) {
+	t.Parallel()
+
+	adapter := &NetworkServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/networks": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, []map[string]any{
+				{"Id": "net-1", "Name": "bridge", "Driver": "bridge", "Scope": "local"},
+				{"Id": "net-2", "Name": "host", "Driver": "host", "Scope": "local"},
+			})
+		},
+	})}
+
+	got, err := adapter.List(context.Background(), domain.NetworkListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("List returned %d networks, want 2", len(got))
+	}
+	if got[0].Name != "bridge" || got[1].Name != "host" {
+		t.Errorf("List returned %q, %q; want bridge, host", got[0].Name, got[1].Name)
+	}
+}
+
+func TestNetworkServiceAdapter_Create_ReturnsID(t *testing.T) {
+	t.Parallel()
+
+	adapter := &NetworkServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/networks/create": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, map[string]any{"Id": "new-net-id", "Warning": ""})
+		},
+	})}
+
+	id, err := adapter.Create(context.Background(), "ofelia-net", ports.NetworkCreateOptions{Driver: "bridge"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if id != "new-net-id" {
+		t.Errorf("Create returned %q, want new-net-id", id)
+	}
+}
+
+func TestNetworkServiceAdapter_ConnectDisconnectRemove(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		route  string
+		invoke func(*NetworkServiceAdapter) error
+	}{
+		{
+			name:  "Connect",
+			route: "/connect",
+			invoke: func(a *NetworkServiceAdapter) error {
+				return a.Connect(context.Background(), "net", "container", nil)
+			},
+		},
+		{
+			name:  "Disconnect",
+			route: "/disconnect",
+			invoke: func(a *NetworkServiceAdapter) error {
+				return a.Disconnect(context.Background(), "net", "container", true)
+			},
+		},
+		{
+			name:  "Remove",
+			route: "/networks",
+			invoke: func(a *NetworkServiceAdapter) error {
+				return a.Remove(context.Background(), "net")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			reached := false
+			adapter := &NetworkServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+				tc.route: func(w http.ResponseWriter, _ *http.Request) {
+					reached = true
+					w.WriteHeader(http.StatusOK)
+				},
+			})}
+
+			if err := tc.invoke(adapter); err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			if !reached {
+				t.Errorf("%s never reached the daemon", tc.name)
+			}
+		})
+	}
+}
+
+// TestSystemServiceAdapter_DiskUsage_ConvertsInventory covers the conversion
+// loops, which are the substance of DiskUsage: the daemon reports images,
+// containers and volumes in one payload and each list has to arrive on the
+// matching domain field rather than being silently dropped.
+func TestSystemServiceAdapter_DiskUsage_ConvertsInventory(t *testing.T) {
+	t.Parallel()
+
+	adapter := &SystemServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/system/df": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, map[string]any{
+				"LayersSize": 4096,
+				"Images": []map[string]any{
+					{"Id": "sha256:img1", "RepoTags": []string{"alpine:3.20"}, "Size": 4096, "Containers": 1},
+				},
+				"Containers": []map[string]any{
+					{"Id": "cnt1", "Names": []string{"/one"}, "Image": "alpine:3.20"},
+				},
+				"Volumes": []map[string]any{
+					{"Name": "vol1", "Driver": "local", "Mountpoint": "/var/lib/docker/volumes/vol1"},
+				},
+			})
+		},
+	})}
+
+	got, err := adapter.DiskUsage(context.Background())
+	if err != nil {
+		t.Fatalf("DiskUsage: %v", err)
+	}
+	if len(got.Images) != 1 || got.Images[0].ID != "sha256:img1" {
+		t.Errorf("Images = %+v, want one entry with id sha256:img1", got.Images)
+	}
+	if len(got.Containers) != 1 || got.Containers[0].ID != "cnt1" {
+		t.Errorf("Containers = %+v, want one entry with id cnt1", got.Containers)
+	}
+}
+
+// TestImageServiceAdapter_Inspect_ReturnsImage and the Remove case below cover
+// the two image operations a job actually performs around a pull.
+func TestImageServiceAdapter_Inspect_ReturnsImage(t *testing.T) {
+	t.Parallel()
+
+	adapter := &ImageServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/images/": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, map[string]any{
+				"Id":       "sha256:inspected",
+				"RepoTags": []string{"alpine:3.20"},
+				"Size":     4096,
+			})
+		},
+	})}
+
+	got, err := adapter.Inspect(context.Background(), "alpine:3.20")
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if got.ID != "sha256:inspected" {
+		t.Errorf("Inspect returned id %q, want sha256:inspected", got.ID)
+	}
+}
+
+func TestImageServiceAdapter_Remove_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	adapter := &ImageServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/images/": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, []map[string]any{{"Deleted": "sha256:gone"}})
+		},
+	})}
+
+	if err := adapter.Remove(context.Background(), "sha256:gone", true, true); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+}
+
+func TestNetworkServiceAdapter_Inspect_ReturnsNetwork(t *testing.T) {
+	t.Parallel()
+
+	adapter := &NetworkServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/networks/": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, map[string]any{
+				"Id":     "net-inspected",
+				"Name":   "ofelia-net",
+				"Driver": "bridge",
+				"Scope":  "local",
+			})
+		},
+	})}
+
+	got, err := adapter.Inspect(context.Background(), "net-inspected")
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if got.Name != "ofelia-net" {
+		t.Errorf("Inspect returned name %q, want ofelia-net", got.Name)
+	}
+}
+
+// TestImageServiceAdapter_Inspect_NilConfig pins the guard added alongside
+// these tests: the SDK's image-inspect response carries Config as a pointer,
+// and a daemon that omits it used to panic here rather than return an image.
+// Writing the success-path test above is what surfaced it.
+func TestImageServiceAdapter_Inspect_NilConfig(t *testing.T) {
+	t.Parallel()
+
+	defer failOnPanic(t, "Inspect on a response without Config")()
+
+	adapter := &ImageServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/images/": func(w http.ResponseWriter, _ *http.Request) {
+			// No "Config" key at all — the shape a proxy or a
+			// Docker-compatible API may return.
+			writeJSON(t, w, map[string]any{
+				"Id":       "sha256:noconfig",
+				"RepoTags": []string{"alpine:3.20"},
+			})
+		},
+	})}
+
+	got, err := adapter.Inspect(context.Background(), "alpine:3.20")
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if got.ID != "sha256:noconfig" {
+		t.Errorf("Inspect returned id %q, want sha256:noconfig", got.ID)
+	}
+	if got.Labels != nil {
+		t.Errorf("Labels = %v, want nil when the daemon sent no Config", got.Labels)
+	}
+}

--- a/core/adapters/docker/adapters_stub_test.go
+++ b/core/adapters/docker/adapters_stub_test.go
@@ -6,7 +6,6 @@ package docker
 import (
 	"context"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/netresearch/ofelia/core/domain"
@@ -212,11 +211,10 @@ func TestImageServiceAdapter_Exists(t *testing.T) {
 func TestImageServiceAdapter_Tag_SendsRepoAndTag(t *testing.T) {
 	t.Parallel()
 
-	var gotQuery, gotPath string
+	var rec requestRecorder
 	adapter := &ImageServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
 		"/tag": func(w http.ResponseWriter, r *http.Request) {
-			gotPath = r.URL.Path
-			gotQuery = r.URL.RawQuery
+			rec.record(r)
 			w.WriteHeader(http.StatusCreated)
 		},
 	})}
@@ -224,13 +222,13 @@ func TestImageServiceAdapter_Tag_SendsRepoAndTag(t *testing.T) {
 	if err := adapter.Tag(context.Background(), "alpine:3.20", "myrepo/alpine:pinned"); err != nil {
 		t.Fatalf("Tag: %v", err)
 	}
-	if gotPath == "" {
+	if rec.count() == 0 {
 		t.Fatal("Tag never reached the daemon")
 	}
 	// The SDK splits the target into repo and tag query parameters; assert the
 	// tag survived rather than the exact encoding of the repo path.
-	if want := "tag=pinned"; !strings.Contains(gotQuery, want) {
-		t.Errorf("tag request query = %q, want it to contain %q", gotQuery, want)
+	if got := rec.param("tag"); got != "pinned" {
+		t.Errorf("tag request `tag` query param = %q, want pinned", got)
 	}
 }
 
@@ -311,10 +309,10 @@ func TestNetworkServiceAdapter_ConnectDisconnectRemove(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			reached := false
+			var rec requestRecorder
 			adapter := &NetworkServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
-				tc.route: func(w http.ResponseWriter, _ *http.Request) {
-					reached = true
+				tc.route: func(w http.ResponseWriter, r *http.Request) {
+					rec.record(r)
 					w.WriteHeader(http.StatusOK)
 				},
 			})}
@@ -322,7 +320,7 @@ func TestNetworkServiceAdapter_ConnectDisconnectRemove(t *testing.T) {
 			if err := tc.invoke(adapter); err != nil {
 				t.Fatalf("%s: %v", tc.name, err)
 			}
-			if !reached {
+			if rec.count() == 0 {
 				t.Errorf("%s never reached the daemon", tc.name)
 			}
 		})

--- a/core/adapters/docker/container_wrappers_test.go
+++ b/core/adapters/docker/container_wrappers_test.go
@@ -1,0 +1,421 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package docker
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/moby/moby/client"
+
+	"github.com/netresearch/ofelia/core/domain"
+)
+
+// The adapters in container.go are thin translations between the domain types
+// and the Docker SDK. Their error branches are well covered by the nil-input
+// and empty-ID tests; their success branches were not, because reaching them
+// needs a daemon to answer. A stub daemon supplies the answers, so the
+// translation each wrapper performs — request shape out, domain type back — is
+// asserted without Docker being installed.
+//
+// This complements rather than replaces the mock provider used by core: these
+// tests pin the SDK boundary, which the mock by definition cannot.
+
+// stubSDK starts an httptest server whose handler is assembled from per-route
+// responders and returns an SDK client pointed at it. Routes are matched on a
+// path substring, which is enough to distinguish the Docker endpoints and
+// keeps the tests readable.
+//
+// Fragments are tried longest-first, deliberately: several Docker endpoints are
+// prefixes of others ("/networks" contains "/networks/create"), and ranging a
+// map would pick between them in Go's randomized order, so the same test would
+// hit different handlers on different runs.
+//
+// An unmatched request fails the test instead of returning 404, so a changed
+// request path surfaces as a clear failure rather than a generic SDK error.
+func stubSDK(t *testing.T, routes map[string]http.HandlerFunc) *client.Client {
+	t.Helper()
+
+	fragments := make([]string, 0, len(routes))
+	for fragment := range routes {
+		fragments = append(fragments, fragment)
+	}
+	sort.Slice(fragments, func(i, j int) bool { return len(fragments[i]) > len(fragments[j]) })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, fragment := range fragments {
+			if strings.Contains(r.URL.Path, fragment) {
+				routes[fragment](w, r)
+				return
+			}
+		}
+		t.Errorf("stub daemon received an unrouted request: %s %s", r.Method, r.URL.Path)
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	return newSDKClientForStubServer(t, srv)
+}
+
+// stubDaemon wires a container adapter to a stub daemon.
+func stubDaemon(t *testing.T, routes map[string]http.HandlerFunc) *ContainerServiceAdapter {
+	t.Helper()
+	return &ContainerServiceAdapter{client: stubSDK(t, routes)}
+}
+
+// writeJSON is the success path every non-streaming stub route needs.
+func writeJSON(t *testing.T, w http.ResponseWriter, payload any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		t.Errorf("stub daemon failed to encode response: %v", err)
+	}
+}
+
+func TestContainerServiceAdapter_Create_ReturnsID(t *testing.T) {
+	t.Parallel()
+
+	adapter := stubDaemon(t, map[string]http.HandlerFunc{
+		"/containers/create": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, map[string]any{"Id": "created-abc123", "Warnings": []string{}})
+		},
+	})
+
+	id, err := adapter.Create(context.Background(), &domain.ContainerConfig{
+		Image: "alpine:3.20",
+		Name:  "ofelia-test",
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if id != "created-abc123" {
+		t.Errorf("Create returned id %q, want created-abc123", id)
+	}
+}
+
+// TestContainerServiceAdapter_Create_SendsName pins that the container name
+// travels as the documented `name` query parameter rather than inside the
+// body, which is where the SDK expects it and where a refactor could drop it
+// without any local error.
+func TestContainerServiceAdapter_Create_SendsName(t *testing.T) {
+	t.Parallel()
+
+	var gotName string
+	adapter := stubDaemon(t, map[string]http.HandlerFunc{
+		"/containers/create": func(w http.ResponseWriter, r *http.Request) {
+			gotName = r.URL.Query().Get("name")
+			writeJSON(t, w, map[string]any{"Id": "id", "Warnings": []string{}})
+		},
+	})
+
+	if _, err := adapter.Create(context.Background(), &domain.ContainerConfig{
+		Image: "alpine:3.20",
+		Name:  "named-container",
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if gotName != "named-container" {
+		t.Errorf("daemon `name` query param = %q, want named-container", gotName)
+	}
+}
+
+func TestContainerServiceAdapter_Start_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	adapter := stubDaemon(t, map[string]http.HandlerFunc{
+		"/start": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+	})
+
+	if err := adapter.Start(context.Background(), "abc123"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+}
+
+// TestContainerServiceAdapter_List_ConvertsContainers covers the conversion
+// loop, which is the part of List that carries logic rather than delegation:
+// every daemon entry must arrive as a domain.Container in the same order.
+func TestContainerServiceAdapter_List_ConvertsContainers(t *testing.T) {
+	t.Parallel()
+
+	adapter := stubDaemon(t, map[string]http.HandlerFunc{
+		"/containers/json": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, []map[string]any{
+				{"Id": "one", "Names": []string{"/first"}, "Image": "alpine"},
+				{"Id": "two", "Names": []string{"/second"}, "Image": "busybox"},
+			})
+		},
+	})
+
+	got, err := adapter.List(context.Background(), domain.ListOptions{All: true})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("List returned %d containers, want 2", len(got))
+	}
+	if got[0].ID != "one" || got[1].ID != "two" {
+		t.Errorf("List returned ids %q, %q; want one, two (order must be preserved)", got[0].ID, got[1].ID)
+	}
+}
+
+// TestContainerServiceAdapter_List_EmptyIsNotNil pins that an empty daemon
+// response yields an empty slice rather than nil, so callers can range over
+// the result unconditionally.
+func TestContainerServiceAdapter_List_EmptyIsNotNil(t *testing.T) {
+	t.Parallel()
+
+	adapter := stubDaemon(t, map[string]http.HandlerFunc{
+		"/containers/json": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, []map[string]any{})
+		},
+	})
+
+	got, err := adapter.List(context.Background(), domain.ListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if got == nil {
+		t.Fatal("List returned nil for an empty result; want an empty slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("List returned %d containers for an empty daemon response", len(got))
+	}
+}
+
+func TestContainerServiceAdapter_Wait_ReturnsExitStatus(t *testing.T) {
+	t.Parallel()
+
+	adapter := stubDaemon(t, map[string]http.HandlerFunc{
+		"/wait": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, map[string]any{"StatusCode": 137})
+		},
+	})
+
+	respCh, errCh := adapter.Wait(context.Background(), "abc123")
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("Wait reported error: %v", err)
+		}
+	case resp := <-respCh:
+		if resp.StatusCode != 137 {
+			t.Errorf("Wait returned status %d, want 137", resp.StatusCode)
+		}
+	}
+}
+
+// TestContainerServiceAdapter_Wait_PropagatesDaemonError covers the branch
+// that maps a daemon-side wait error onto the error channel, which is what
+// callers use to distinguish "container failed" from "wait failed".
+func TestContainerServiceAdapter_Wait_PropagatesDaemonError(t *testing.T) {
+	t.Parallel()
+
+	adapter := stubDaemon(t, map[string]http.HandlerFunc{
+		"/wait": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			writeJSON(t, w, map[string]any{"message": "no such container"})
+		},
+	})
+
+	respCh, errCh := adapter.Wait(context.Background(), "missing")
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("Wait on a missing container returned nil error")
+		}
+	case resp := <-respCh:
+		t.Fatalf("Wait on a missing container returned a status (%d) instead of an error", resp.StatusCode)
+	}
+}
+
+func TestContainerServiceAdapter_Logs_ReturnsStream(t *testing.T) {
+	t.Parallel()
+
+	adapter := stubDaemon(t, map[string]http.HandlerFunc{
+		"/logs": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write([]byte("hello from the container"))
+		},
+	})
+
+	rc, err := adapter.Logs(context.Background(), "abc123", domain.LogOptions{ShowStdout: true})
+	if err != nil {
+		t.Fatalf("Logs: %v", err)
+	}
+	defer rc.Close()
+
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("reading log stream: %v", err)
+	}
+	if string(body) != "hello from the container" {
+		t.Errorf("log stream = %q, want %q", body, "hello from the container")
+	}
+}
+
+// TestContainerServiceAdapter_CopyLogs_DemuxesNonTTY covers the stdcopy branch:
+// a non-TTY container multiplexes stdout and stderr into one stream with an
+// 8-byte header per frame, and CopyLogs must split them back apart. Writing
+// both frames to the same writer would pass a naive test, so stdout and stderr
+// are asserted separately.
+func TestContainerServiceAdapter_CopyLogs_DemuxesNonTTY(t *testing.T) {
+	t.Parallel()
+
+	adapter := stubDaemon(t, map[string]http.HandlerFunc{
+		// Inspect must report a container without a HostConfig so CopyLogs
+		// takes the demultiplexing path rather than the raw TTY copy.
+		"/json": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, map[string]any{
+				"Id":    "abc123",
+				"Name":  "/demux",
+				"State": map[string]any{"Running": false},
+				"Config": map[string]any{
+					"Image": "alpine",
+				},
+			})
+		},
+		"/logs": func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(stdcopyFrame(1, "to stdout"))
+			_, _ = w.Write(stdcopyFrame(2, "to stderr"))
+		},
+	})
+
+	var out, errOut strings.Builder
+	if err := adapter.CopyLogs(context.Background(), "abc123", &out, &errOut, domain.LogOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+	}); err != nil {
+		t.Fatalf("CopyLogs: %v", err)
+	}
+
+	if out.String() != "to stdout" {
+		t.Errorf("stdout = %q, want %q", out.String(), "to stdout")
+	}
+	if errOut.String() != "to stderr" {
+		t.Errorf("stderr = %q, want %q", errOut.String(), "to stderr")
+	}
+}
+
+// stdcopyFrame builds one frame of Docker's multiplexed stream format:
+// a stream byte (1 = stdout, 2 = stderr), three reserved zero bytes, a
+// big-endian uint32 payload length, then the payload.
+func stdcopyFrame(stream byte, payload string) []byte {
+	header := make([]byte, 8, 8+len(payload))
+	header[0] = stream
+	binary.BigEndian.PutUint32(header[4:], uint32(len(payload)))
+	return append(header, payload...)
+}
+
+// TestContainerServiceAdapter_SignalWrappers covers Kill, Pause, Unpause and
+// Rename together: each is the same shape (delegate, convert the error), so a
+// table keeps the duplication that SonarCloud measures on new code down while
+// still asserting each one reaches its own endpoint.
+func TestContainerServiceAdapter_SignalWrappers(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		route    string
+		invoke   func(*ContainerServiceAdapter) error
+		wantPath string
+	}{
+		{
+			name:     "Kill",
+			route:    "/kill",
+			invoke:   func(a *ContainerServiceAdapter) error { return a.Kill(context.Background(), "abc", "SIGTERM") },
+			wantPath: "/kill",
+		},
+		{
+			name:     "Pause",
+			route:    "/pause",
+			invoke:   func(a *ContainerServiceAdapter) error { return a.Pause(context.Background(), "abc") },
+			wantPath: "/pause",
+		},
+		{
+			name:     "Unpause",
+			route:    "/unpause",
+			invoke:   func(a *ContainerServiceAdapter) error { return a.Unpause(context.Background(), "abc") },
+			wantPath: "/unpause",
+		},
+		{
+			name:     "Rename",
+			route:    "/rename",
+			invoke:   func(a *ContainerServiceAdapter) error { return a.Rename(context.Background(), "abc", "new") },
+			wantPath: "/rename",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotPath string
+			adapter := stubDaemon(t, map[string]http.HandlerFunc{
+				tc.route: func(w http.ResponseWriter, r *http.Request) {
+					gotPath = r.URL.Path
+					w.WriteHeader(http.StatusNoContent)
+				},
+			})
+
+			if err := tc.invoke(adapter); err != nil {
+				t.Fatalf("%s: %v", tc.name, err)
+			}
+			if !strings.Contains(gotPath, tc.wantPath) {
+				t.Errorf("%s hit %q, want a path containing %q", tc.name, gotPath, tc.wantPath)
+			}
+		})
+	}
+}
+
+// TestContainerServiceAdapter_Kill_SendsSignal pins the signal as a query
+// parameter — the one piece of Kill that is not pure delegation, and the piece
+// a caller relies on to stop a job with anything other than the default.
+func TestContainerServiceAdapter_Kill_SendsSignal(t *testing.T) {
+	t.Parallel()
+
+	var gotSignal string
+	adapter := stubDaemon(t, map[string]http.HandlerFunc{
+		"/kill": func(w http.ResponseWriter, r *http.Request) {
+			gotSignal = r.URL.Query().Get("signal")
+			w.WriteHeader(http.StatusNoContent)
+		},
+	})
+
+	if err := adapter.Kill(context.Background(), "abc", "SIGUSR1"); err != nil {
+		t.Fatalf("Kill: %v", err)
+	}
+	if gotSignal != "SIGUSR1" {
+		t.Errorf("daemon `signal` query param = %q, want SIGUSR1", gotSignal)
+	}
+}
+
+// TestContainerServiceAdapter_Rename_SendsName mirrors the Kill assertion for
+// the rename target.
+func TestContainerServiceAdapter_Rename_SendsName(t *testing.T) {
+	t.Parallel()
+
+	var gotName string
+	adapter := stubDaemon(t, map[string]http.HandlerFunc{
+		"/rename": func(w http.ResponseWriter, r *http.Request) {
+			gotName = r.URL.Query().Get("name")
+			w.WriteHeader(http.StatusNoContent)
+		},
+	})
+
+	if err := adapter.Rename(context.Background(), "abc", "renamed"); err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	if gotName != "renamed" {
+		t.Errorf("daemon `name` query param = %q, want renamed", gotName)
+	}
+}

--- a/core/adapters/docker/container_wrappers_test.go
+++ b/core/adapters/docker/container_wrappers_test.go
@@ -10,8 +10,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/moby/moby/client"
@@ -39,8 +41,8 @@ import (
 // map would pick between them in Go's randomized order, so the same test would
 // hit different handlers on different runs.
 //
-// An unmatched request fails the test instead of returning 404, so a changed
-// request path surfaces as a clear failure rather than a generic SDK error.
+// An unmatched request fails the test and answers 404, so a changed request
+// path surfaces as a named failure rather than only as a generic SDK error.
 func stubSDK(t *testing.T, routes map[string]http.HandlerFunc) *client.Client {
 	t.Helper()
 
@@ -62,6 +64,51 @@ func stubSDK(t *testing.T, routes map[string]http.HandlerFunc) *client.Client {
 	}))
 	t.Cleanup(srv.Close)
 	return newSDKClientForStubServer(t, srv)
+}
+
+// requestRecorder carries observations from a stub route back to the test.
+//
+// The handler runs on the server's goroutine and the assertions run on the
+// test's, so the two need synchronization that does not depend on net/http's
+// internals happening to order them: the handlers here assign before writing
+// the response, which today gives the client's return a happens-before edge,
+// but nothing in the memory model guarantees that and a later edit that moves
+// an assignment after the write would make it a genuine race.
+type requestRecorder struct {
+	mu     sync.Mutex
+	path   string
+	query  url.Values
+	visits int
+}
+
+// record captures the request under the lock. Call it from a stub route.
+func (rr *requestRecorder) record(r *http.Request) {
+	rr.mu.Lock()
+	defer rr.mu.Unlock()
+	rr.path = r.URL.Path
+	rr.query = r.URL.Query()
+	rr.visits++
+}
+
+// param returns a captured query parameter.
+func (rr *requestRecorder) param(name string) string {
+	rr.mu.Lock()
+	defer rr.mu.Unlock()
+	return rr.query.Get(name)
+}
+
+// requestPath returns the captured request path.
+func (rr *requestRecorder) requestPath() string {
+	rr.mu.Lock()
+	defer rr.mu.Unlock()
+	return rr.path
+}
+
+// count returns how many requests the route has served.
+func (rr *requestRecorder) count() int {
+	rr.mu.Lock()
+	defer rr.mu.Unlock()
+	return rr.visits
 }
 
 // stubDaemon wires a container adapter to a stub daemon.
@@ -107,10 +154,10 @@ func TestContainerServiceAdapter_Create_ReturnsID(t *testing.T) {
 func TestContainerServiceAdapter_Create_SendsName(t *testing.T) {
 	t.Parallel()
 
-	var gotName string
+	var rec requestRecorder
 	adapter := stubDaemon(t, map[string]http.HandlerFunc{
 		"/containers/create": func(w http.ResponseWriter, r *http.Request) {
-			gotName = r.URL.Query().Get("name")
+			rec.record(r)
 			writeJSON(t, w, map[string]any{"Id": "id", "Warnings": []string{}})
 		},
 	})
@@ -121,8 +168,8 @@ func TestContainerServiceAdapter_Create_SendsName(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
-	if gotName != "named-container" {
-		t.Errorf("daemon `name` query param = %q, want named-container", gotName)
+	if got := rec.param("name"); got != "named-container" {
+		t.Errorf("daemon `name` query param = %q, want named-container", got)
 	}
 }
 
@@ -359,10 +406,10 @@ func TestContainerServiceAdapter_SignalWrappers(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			var gotPath string
+			var rec requestRecorder
 			adapter := stubDaemon(t, map[string]http.HandlerFunc{
 				tc.route: func(w http.ResponseWriter, r *http.Request) {
-					gotPath = r.URL.Path
+					rec.record(r)
 					w.WriteHeader(http.StatusNoContent)
 				},
 			})
@@ -370,8 +417,8 @@ func TestContainerServiceAdapter_SignalWrappers(t *testing.T) {
 			if err := tc.invoke(adapter); err != nil {
 				t.Fatalf("%s: %v", tc.name, err)
 			}
-			if !strings.Contains(gotPath, tc.wantPath) {
-				t.Errorf("%s hit %q, want a path containing %q", tc.name, gotPath, tc.wantPath)
+			if got := rec.requestPath(); !strings.Contains(got, tc.wantPath) {
+				t.Errorf("%s hit %q, want a path containing %q", tc.name, got, tc.wantPath)
 			}
 		})
 	}
@@ -383,10 +430,10 @@ func TestContainerServiceAdapter_SignalWrappers(t *testing.T) {
 func TestContainerServiceAdapter_Kill_SendsSignal(t *testing.T) {
 	t.Parallel()
 
-	var gotSignal string
+	var rec requestRecorder
 	adapter := stubDaemon(t, map[string]http.HandlerFunc{
 		"/kill": func(w http.ResponseWriter, r *http.Request) {
-			gotSignal = r.URL.Query().Get("signal")
+			rec.record(r)
 			w.WriteHeader(http.StatusNoContent)
 		},
 	})
@@ -394,8 +441,8 @@ func TestContainerServiceAdapter_Kill_SendsSignal(t *testing.T) {
 	if err := adapter.Kill(context.Background(), "abc", "SIGUSR1"); err != nil {
 		t.Fatalf("Kill: %v", err)
 	}
-	if gotSignal != "SIGUSR1" {
-		t.Errorf("daemon `signal` query param = %q, want SIGUSR1", gotSignal)
+	if got := rec.param("signal"); got != "SIGUSR1" {
+		t.Errorf("daemon `signal` query param = %q, want SIGUSR1", got)
 	}
 }
 
@@ -404,10 +451,10 @@ func TestContainerServiceAdapter_Kill_SendsSignal(t *testing.T) {
 func TestContainerServiceAdapter_Rename_SendsName(t *testing.T) {
 	t.Parallel()
 
-	var gotName string
+	var rec requestRecorder
 	adapter := stubDaemon(t, map[string]http.HandlerFunc{
 		"/rename": func(w http.ResponseWriter, r *http.Request) {
-			gotName = r.URL.Query().Get("name")
+			rec.record(r)
 			w.WriteHeader(http.StatusNoContent)
 		},
 	})
@@ -415,7 +462,7 @@ func TestContainerServiceAdapter_Rename_SendsName(t *testing.T) {
 	if err := adapter.Rename(context.Background(), "abc", "renamed"); err != nil {
 		t.Fatalf("Rename: %v", err)
 	}
-	if gotName != "renamed" {
-		t.Errorf("daemon `name` query param = %q, want renamed", gotName)
+	if got := rec.param("name"); got != "renamed" {
+		t.Errorf("daemon `name` query param = %q, want renamed", got)
 	}
 }

--- a/core/adapters/docker/convert.go
+++ b/core/adapters/docker/convert.go
@@ -103,7 +103,15 @@ func convertFromContainerJSON(c *containertypes.InspectResponse) *domain.Contain
 		Name:    c.Name,
 		Image:   c.Image,
 		Created: parseTime(c.Created),
-		Labels:  c.Config.Labels,
+	}
+
+	// Config is a pointer in the SDK response, so a daemon that omits it — a
+	// socket proxy, or a Docker-compatible API that fills in less than Docker
+	// does — made this a nil dereference that took the whole scheduler down.
+	// The State and Health fields below were already guarded this way; Config
+	// was the one that was not. Same class as ErrNilContainerConfig (#632).
+	if c.Config != nil {
+		container.Labels = c.Config.Labels
 	}
 
 	// Convert state

--- a/core/adapters/docker/convert_nil_test.go
+++ b/core/adapters/docker/convert_nil_test.go
@@ -402,3 +402,26 @@ func TestConvertToMount_ValidInput(t *testing.T) {
 		t.Errorf("ReadOnly = false, want true")
 	}
 }
+
+// TestConvertFromContainerJSON_NilConfig pins the guard on the container side
+// of the same defect: Config is a pointer in the SDK inspect response, and
+// reading Labels from it unconditionally panicked when a daemon left it out.
+func TestConvertFromContainerJSON_NilConfig(t *testing.T) {
+	t.Parallel()
+
+	defer failOnPanic(t, "convertFromContainerJSON without Config")()
+
+	got := convertFromContainerJSON(&containertypes.InspectResponse{
+		ID:   "abc123",
+		Name: "/no-config",
+	})
+	if got == nil {
+		t.Fatal("convertFromContainerJSON returned nil for a valid response")
+	}
+	if got.ID != "abc123" {
+		t.Errorf("ID = %q, want abc123", got.ID)
+	}
+	if got.Labels != nil {
+		t.Errorf("Labels = %v, want nil when the response carries no Config", got.Labels)
+	}
+}

--- a/core/adapters/docker/image.go
+++ b/core/adapters/docker/image.go
@@ -136,15 +136,22 @@ func (s *ImageServiceAdapter) Inspect(ctx context.Context, imageID string) (*dom
 		return nil, convertError(err)
 	}
 
-	return &domain.Image{
+	image := &domain.Image{
 		ID:          img.ID,
 		RepoTags:    img.RepoTags,
 		RepoDigests: img.RepoDigests,
 		Comment:     img.Comment,
 		Created:     parseTime(img.Created),
 		Size:        img.Size,
-		Labels:      img.Config.Labels,
-	}, nil
+	}
+
+	// Config is a pointer in the SDK response; an image inspect without it
+	// panicked here. See the matching guard in convertFromContainerJSON.
+	if img.Config != nil {
+		image.Labels = img.Config.Labels
+	}
+
+	return image, nil
 }
 
 // Remove removes an image.

--- a/core/adapters/docker/service_stub_test.go
+++ b/core/adapters/docker/service_stub_test.go
@@ -1,0 +1,238 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package docker
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/netresearch/ofelia/core/domain"
+)
+
+// The swarm adapter's polling loops (WaitForTask, WaitForServiceTasks) were
+// only reachable with a swarm-enabled daemon, so their termination conditions
+// — task reached a terminal state, timeout expired — went unexercised. A stub
+// daemon lets both be driven deterministically.
+
+// swarmTask builds one entry of a /tasks response in the shape the SDK decodes.
+func swarmTask(id, state string) map[string]any {
+	return map[string]any{
+		"ID":     id,
+		"Status": map[string]any{"State": state},
+	}
+}
+
+func TestSwarmServiceAdapter_Create_ReturnsID(t *testing.T) {
+	t.Parallel()
+
+	adapter := &SwarmServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/services/create": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, map[string]any{"ID": "svc-123", "Warnings": []string{}})
+		},
+	})}
+
+	id, err := adapter.Create(context.Background(), domain.ServiceSpec{Name: "ofelia-job"},
+		domain.ServiceCreateOptions{})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if id != "svc-123" {
+		t.Errorf("Create returned %q, want svc-123", id)
+	}
+}
+
+func TestSwarmServiceAdapter_List_ConvertsServices(t *testing.T) {
+	t.Parallel()
+
+	adapter := &SwarmServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/services": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, []map[string]any{
+				{"ID": "svc-1", "Spec": map[string]any{"Name": "first"}},
+				{"ID": "svc-2", "Spec": map[string]any{"Name": "second"}},
+			})
+		},
+	})}
+
+	got, err := adapter.List(context.Background(), domain.ServiceListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("List returned %d services, want 2", len(got))
+	}
+	if got[0].ID != "svc-1" || got[1].ID != "svc-2" {
+		t.Errorf("List returned %q, %q; want svc-1, svc-2", got[0].ID, got[1].ID)
+	}
+}
+
+func TestSwarmServiceAdapter_ListTasks_ConvertsTasks(t *testing.T) {
+	t.Parallel()
+
+	adapter := &SwarmServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/tasks": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, []map[string]any{
+				swarmTask("task-1", string(domain.TaskStateRunning)),
+				swarmTask("task-2", string(domain.TaskStateComplete)),
+			})
+		},
+	})}
+
+	got, err := adapter.ListTasks(context.Background(), domain.TaskListOptions{})
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("ListTasks returned %d tasks, want 2", len(got))
+	}
+	if got[0].ID != "task-1" || got[1].ID != "task-2" {
+		t.Errorf("ListTasks returned %q, %q; want task-1, task-2", got[0].ID, got[1].ID)
+	}
+}
+
+func TestSwarmServiceAdapter_Inspect_ReturnsService(t *testing.T) {
+	t.Parallel()
+
+	adapter := &SwarmServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/services/": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, map[string]any{
+				"ID":   "svc-123",
+				"Spec": map[string]any{"Name": "inspected"},
+			})
+		},
+	})}
+
+	got, err := adapter.Inspect(context.Background(), "svc-123")
+	if err != nil {
+		t.Fatalf("Inspect: %v", err)
+	}
+	if got.ID != "svc-123" {
+		t.Errorf("Inspect returned id %q, want svc-123", got.ID)
+	}
+}
+
+func TestSwarmServiceAdapter_Remove_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	adapter := &SwarmServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/services/": func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		},
+	})}
+
+	if err := adapter.Remove(context.Background(), "svc-123"); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+}
+
+// TestSwarmServiceAdapter_WaitForTask_ReturnsOnTerminalState drives the polling
+// loop to its success exit: the first poll reports a running task, the second a
+// completed one, and only then does WaitForTask return.
+func TestSwarmServiceAdapter_WaitForTask_ReturnsOnTerminalState(t *testing.T) {
+	t.Parallel()
+
+	poll := 0
+	adapter := &SwarmServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/tasks": func(w http.ResponseWriter, _ *http.Request) {
+			poll++
+			state := string(domain.TaskStateRunning)
+			if poll > 1 {
+				state = string(domain.TaskStateComplete)
+			}
+			writeJSON(t, w, []map[string]any{swarmTask("task-1", state)})
+		},
+	})}
+
+	got, err := adapter.WaitForTask(context.Background(), "task-1", 10*time.Second)
+	if err != nil {
+		t.Fatalf("WaitForTask: %v", err)
+	}
+	if got.ID != "task-1" {
+		t.Errorf("WaitForTask returned task %q, want task-1", got.ID)
+	}
+	if poll < 2 {
+		t.Errorf("WaitForTask returned after %d polls; it should keep polling while the task runs", poll)
+	}
+}
+
+// TestSwarmServiceAdapter_WaitForTask_TimesOut pins the other exit: a task that
+// never terminates must surface domain.ErrTimeout rather than blocking, which
+// is what stops a wedged swarm job from hanging the scheduler.
+func TestSwarmServiceAdapter_WaitForTask_TimesOut(t *testing.T) {
+	t.Parallel()
+
+	adapter := &SwarmServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/tasks": func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, []map[string]any{swarmTask("task-1", string(domain.TaskStateRunning))})
+		},
+	})}
+
+	_, err := adapter.WaitForTask(context.Background(), "task-1", 1200*time.Millisecond)
+	if !errors.Is(err, domain.ErrTimeout) {
+		t.Fatalf("WaitForTask error = %v, want domain.ErrTimeout", err)
+	}
+}
+
+// TestSwarmServiceAdapter_WaitForServiceTasks_WaitsForAll pins that the wait
+// ends only once EVERY task is terminal — a service whose second replica is
+// still running must not be reported as finished.
+func TestSwarmServiceAdapter_WaitForServiceTasks_WaitsForAll(t *testing.T) {
+	t.Parallel()
+
+	poll := 0
+	adapter := &SwarmServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
+		"/tasks": func(w http.ResponseWriter, _ *http.Request) {
+			poll++
+			second := string(domain.TaskStateRunning)
+			if poll > 1 {
+				second = string(domain.TaskStateFailed)
+			}
+			writeJSON(t, w, []map[string]any{
+				swarmTask("task-1", string(domain.TaskStateComplete)),
+				swarmTask("task-2", second),
+			})
+		},
+	})}
+
+	got, err := adapter.WaitForServiceTasks(context.Background(), "svc-1", 10*time.Second)
+	if err != nil {
+		t.Fatalf("WaitForServiceTasks: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("WaitForServiceTasks returned %d tasks, want 2", len(got))
+	}
+	if poll < 2 {
+		t.Error("WaitForServiceTasks returned while one task was still running")
+	}
+}
+
+// TestAllTasksTerminal covers the helper directly, including the empty slice,
+// which the polling loops never reach because they skip empty results.
+func TestAllTasksTerminal(t *testing.T) {
+	t.Parallel()
+
+	terminal := domain.Task{Status: domain.TaskStatus{State: domain.TaskStateComplete}}
+	running := domain.Task{Status: domain.TaskStatus{State: domain.TaskStateRunning}}
+
+	cases := []struct {
+		name  string
+		tasks []domain.Task
+		want  bool
+	}{
+		{name: "empty is vacuously true", tasks: nil, want: true},
+		{name: "all terminal", tasks: []domain.Task{terminal, terminal}, want: true},
+		{name: "one still running", tasks: []domain.Task{terminal, running}, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := allTasksTerminal(tc.tasks); got != tc.want {
+				t.Errorf("allTasksTerminal = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/core/adapters/docker/service_stub_test.go
+++ b/core/adapters/docker/service_stub_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -134,12 +135,11 @@ func TestSwarmServiceAdapter_Remove_Succeeds(t *testing.T) {
 func TestSwarmServiceAdapter_WaitForTask_ReturnsOnTerminalState(t *testing.T) {
 	t.Parallel()
 
-	poll := 0
+	var polls atomic.Int32
 	adapter := &SwarmServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
 		"/tasks": func(w http.ResponseWriter, _ *http.Request) {
-			poll++
 			state := string(domain.TaskStateRunning)
-			if poll > 1 {
+			if polls.Add(1) > 1 {
 				state = string(domain.TaskStateComplete)
 			}
 			writeJSON(t, w, []map[string]any{swarmTask("task-1", state)})
@@ -153,8 +153,8 @@ func TestSwarmServiceAdapter_WaitForTask_ReturnsOnTerminalState(t *testing.T) {
 	if got.ID != "task-1" {
 		t.Errorf("WaitForTask returned task %q, want task-1", got.ID)
 	}
-	if poll < 2 {
-		t.Errorf("WaitForTask returned after %d polls; it should keep polling while the task runs", poll)
+	if n := polls.Load(); n < 2 {
+		t.Errorf("WaitForTask returned after %d polls; it should keep polling while the task runs", n)
 	}
 }
 
@@ -182,12 +182,11 @@ func TestSwarmServiceAdapter_WaitForTask_TimesOut(t *testing.T) {
 func TestSwarmServiceAdapter_WaitForServiceTasks_WaitsForAll(t *testing.T) {
 	t.Parallel()
 
-	poll := 0
+	var polls atomic.Int32
 	adapter := &SwarmServiceAdapter{client: stubSDK(t, map[string]http.HandlerFunc{
 		"/tasks": func(w http.ResponseWriter, _ *http.Request) {
-			poll++
 			second := string(domain.TaskStateRunning)
-			if poll > 1 {
+			if polls.Add(1) > 1 {
 				second = string(domain.TaskStateFailed)
 			}
 			writeJSON(t, w, []map[string]any{
@@ -204,7 +203,7 @@ func TestSwarmServiceAdapter_WaitForServiceTasks_WaitsForAll(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("WaitForServiceTasks returned %d tasks, want 2", len(got))
 	}
-	if poll < 2 {
+	if polls.Load() < 2 {
 		t.Error("WaitForServiceTasks returned while one task was still running")
 	}
 }

--- a/ofelia_main_test.go
+++ b/ofelia_main_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// main() is reachable from a test because every one of its exits is a plain
+// return: the flag-error path was deliberately changed to return instead of
+// calling os.Exit(1) (see the comment at its final return). Exercising it here
+// covers the command wiring — a command dropped from the parser, or a
+// constructor that starts panicking, fails these tests instead of only showing
+// up when a user runs the binary.
+//
+// These tests never pass a real command such as `daemon`, which would start a
+// scheduler. Only paths that parse and return are used.
+
+// runMain invokes main() with the given argv while redirecting stdout, so the
+// parser's help output does not drown the test log. It restores both os.Args
+// and os.Stdout before returning and reports what main() printed.
+func runMain(t *testing.T, argv ...string) string {
+	t.Helper()
+
+	origArgs, origStdout := os.Args, os.Stdout
+	t.Cleanup(func() {
+		os.Args = origArgs
+		os.Stdout = origStdout
+	})
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("creating stdout pipe: %v", err)
+	}
+
+	// A pipe's buffer is finite and the help text is long, so drain it
+	// concurrently; writing more than the buffer holds would otherwise block
+	// main() forever.
+	captured := make(chan string, 1)
+	go func() {
+		var sb strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, readErr := r.Read(buf)
+			if n > 0 {
+				sb.Write(buf[:n])
+			}
+			if readErr != nil {
+				break
+			}
+		}
+		captured <- sb.String()
+	}()
+
+	os.Args = append([]string{"ofelia"}, argv...)
+	os.Stdout = w
+
+	main()
+
+	_ = w.Close()
+	out := <-captured
+	_ = r.Close()
+	return out
+}
+
+// TestMain_VersionFlag covers the short-circuit before the parser is built:
+// --version must print and return without constructing any command.
+//
+//nolint:paralleltest // mutates os.Args and os.Stdout, which are process-global
+func TestMain_VersionFlag(t *testing.T) {
+	// No t.Parallel(): os.Args and os.Stdout are process-global.
+	out := runMain(t, "--version")
+	if strings.TrimSpace(out) == "" {
+		t.Error("--version printed nothing")
+	}
+}
+
+// TestMain_Help covers the full command-registration path and the
+// flags.WroteHelp branch: every AddCommand call runs before the parser reports
+// that it wrote help.
+//
+//nolint:paralleltest // mutates os.Args and os.Stdout, which are process-global
+func TestMain_Help(t *testing.T) {
+	out := runMain(t, "--help")
+
+	// Each registered command should appear in the help output. This is what
+	// turns the test from "main did not panic" into a check that the command
+	// set is intact.
+	for _, cmd := range []string{"daemon", "validate", "config", "init", "doctor", "hash-password", "version"} {
+		if !strings.Contains(out, cmd) {
+			t.Errorf("help output does not mention the %q command", cmd)
+		}
+	}
+}
+
+// TestMain_UnknownCommand covers the flags.Error branch, which prints help plus
+// the version string and returns rather than exiting the process.
+//
+//nolint:paralleltest // mutates os.Args and os.Stdout, which are process-global
+func TestMain_UnknownCommand(t *testing.T) {
+	out := runMain(t, "definitely-not-a-command")
+	if !strings.Contains(out, "daemon") {
+		t.Errorf("an unknown command should print the help listing; got %q", out)
+	}
+}
+
+// TestMain_NoArguments covers the same error branch reached with no command at
+// all, which is what a bare `ofelia` invocation does.
+//
+//nolint:paralleltest // mutates os.Args and os.Stdout, which are process-global
+func TestMain_NoArguments(t *testing.T) {
+	out := runMain(t)
+	if strings.TrimSpace(out) == "" {
+		t.Error("a bare invocation printed nothing; expected the help listing")
+	}
+}
+
+// TestMain_LogLevelFlagIsPreParsed pins that --log-level is consumed by the
+// pre-parser before the real parser runs, so an early log level applies to
+// everything the commands log. It reaches the same help path, but with the
+// pre-parse branch populated.
+//
+//nolint:paralleltest // mutates os.Args and os.Stdout, which are process-global
+func TestMain_LogLevelFlagIsPreParsed(t *testing.T) {
+	out := runMain(t, "--log-level", "debug", "--help")
+	if !strings.Contains(out, "daemon") {
+		t.Errorf("expected help output with a log level set; got %q", out)
+	}
+}
+
+// TestMain_ConfigFlagMissingFileIsTolerated pins that a --config path which
+// does not exist does not stop startup: the INI load is best-effort and only
+// supplies a log level.
+//
+//nolint:paralleltest // mutates os.Args and os.Stdout, which are process-global
+func TestMain_ConfigFlagMissingFileIsTolerated(t *testing.T) {
+	missing := t.TempDir() + "/no-such-config.ini"
+	out := runMain(t, "--config", missing, "--help")
+	if !strings.Contains(out, "daemon") {
+		t.Errorf("a missing --config file should be tolerated; got %q", out)
+	}
+}


### PR DESCRIPTION
Follow-ups to the security and quality reports on the repository's dashboards. Each item below was verified before acting; the ones that turned out to be false positives are dismissed at the source with a justification rather than worked around in code.

## A crash, found by writing the coverage tests

`convert.go` and `image.go` both read `Labels` straight off the SDK's `Config` field. `Config` is a **pointer** in `container.InspectResponse` and `image.InspectResponse`, so a daemon that omits it — a socket proxy, or a Docker-compatible API that fills in less than Docker does — is a nil dereference on a path that does not recover: the scheduler goes down.

The surrounding code already treats this as a real shape (`State` and `State.Health` are guarded a few lines below the container dereference). `Config` was the field that was missed, and it is the same defect `ErrNilContainerConfig` was added for in #632/#626, in the two places that fix did not reach.

Both regression tests were confirmed to fail against the unpatched code.

## Coverage: 87.64% → 90.08%

OpenSSF Best Practices Gold asks for ≥90% statement coverage. The gap sat where a daemon or a process boundary made code awkward to reach:

| | before | after |
|---|---|---|
| `core/adapters/docker` | 66.7% | 78.3% |
| root (`ofelia.go`) | 22.0% | 95.1% |
| repository | 87.64% | **90.08%** |

A stub daemon answers as Docker would, so each adapter's translation is asserted directly — container lifecycle, the stdcopy demultiplexing `CopyLogs` performs, system/image/network calls, and the swarm polling loops including both exits (terminal task, and the timeout that stops a wedged job hanging the scheduler). `main()` is driven over `--version`, `--help`, an unknown command and a bare invocation, so a command dropped from the parser fails a test instead of only surfacing when a user runs the binary.

**Branch coverage (the second Gold criterion) is not addressed here** and cannot be from this repository: Go's toolchain measures statements, not branches, and there is no established FLOSS branch-coverage tool for Go. That criterion needs a justified N/A on bestpractices.dev, which is a change to the badge questionnaire rather than to this repo.

## Codecov components

The Components page was empty — `codecov.yml` declared no `component_management`, so a coverage drop said nothing about where it happened. Components now follow the boundaries in ARCHITECTURE.md; `core` negates the adapter and persistence subtrees so those files are not counted twice. Validated against `https://codecov.io/validate`.

## Dismissed at the source (no code change — the code is correct)

- **13× CodeQL `go/log-injection`** in `web/server.go`. Every one passes `req.Name` as a *structured* slog attribute, and `ofelia.go:39` installs the stdlib `slog.NewTextHandler`, which escapes newlines in attribute values **and** in the message — verified empirically with a payload containing a full forged log line. The `action` concatenated into two of those messages is a compile-time literal from `server.go:618,622`. Sanitizing the values would add code that demonstrably prevents nothing.
- **2× Scorecard `PinnedDependencies`** on `zizmor.yml:18` and `verify-release.yml:90`. Both point at `netresearch/.github` reusables — first-party, misclassified as third-party. Org policy keeps them on `@main` so upstream security fixes propagate; third-party actions stay hash-pinned.
- **1× zizmor `dangerous-triggers`** on the `workflow_run` in `verify-release.yml`. Nothing is checked out, `permissions: {}` at workflow level with minimal per-job scopes, and the upstream Release workflow fires only on maintainer tag pushes — not fork PRs. The one external value (`head_branch`) is env-passed and validated against a character allowlist before use.

Open code-scanning alerts on `main`: **16 → 0**.

## Reported, not actioned

- **Trivy "results may be out of date"** is a stale configuration, not a broken scan. The filesystem scan lived in `ci.yml` and was removed on 2026-04-19 by the template sync (`50803c4`); the shared `go-check.yml` uses govulncheck + gosec instead. Trivy still runs as `container-scan` on every release (last: `v0.28.1`, 2026-07-28). Clearing the banner means deleting 1016 analyses across 437 refs — GitHub releases only the newest per ref, so the API path is ~1016 chained irreversible deletes. The one-click alternative is Security → Code scanning → Tool status.
- **GO-2026-5932** (`x/crypto/openpgp` unmaintained) is not reachable: 0 occurrences in the build graph, and `govulncheck` reports 0 vulnerabilities in code. `x/crypto` is required for **bcrypt** (`cli`, web auth). There is no fixed version — `introduced: 0` with no fix event — so no upgrade can clear it.
- **Missing release provenance** is a detection gap, not missing provenance. `actions/attest-build-provenance` runs in the release; `ofelia-linux-amd64` of v0.28.1 has an in-toto attestation retrievable by digest. Scorecard reads release *assets* and looks for `.intoto.jsonl`. Fixing it belongs in `netresearch/.github`, as does the JUnit upload that would populate Codecov Test Analytics.

## Test plan

- [x] `go test ./...` — full suite green, 0 failures
- [x] Coverage measured at 90.0784% (7699/8547 statements)
- [x] `golangci-lint run` over the whole repo — 0 issues
- [x] `lefthook run pre-push` — exit 0
- [x] Both nil-Config regression tests confirmed red against the unpatched code
- [x] `codecov.yml` accepted by Codecov's validator
