### PR TITLE
ci: send test results to Codecov Test Analytics

### DIFF
--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -5,7 +5,9 @@ template: go-app
 intentional-drift:
 - path: .github/workflows/ci.yml
   reason: "enable-integration-tests: true and enable-e2e-tests: true \u2014 repo has\
-    \ integration tests (12 files, -tags=integration) and e2e tests (10 tests under\
-    \ ./e2e/..., -tags=e2e) that run in CI."
+    \ integration tests (12 files, -tags=integration) and e2e tests (11 tests under\
+    \ ./e2e/..., -tags=e2e, one of them browser-driven) that run in CI. Plus\
+    \ enable-test-results: true, which routes the unit tests through gotestsum so\
+    \ Codecov Test Analytics has data (netresearch/.github#333)."
 - path: .github/dependabot.yml
   reason: "Opt-in devcontainers ecosystem. The trimmed go-app template (netresearch/.github#166) declares only gomod/github-actions/docker; this repo has a .devcontainer so it self-manages dependabot.yml to keep devcontainers updates. Core blocks are kept in step with the template manually."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       enable-fuzz: true
       enable-license-check: true
       enable-codecov: true
+      enable-test-results: true
       enable-integration-tests: true
       enable-e2e-tests: true
       e2e-test-packages: ./e2e/...


### PR DESCRIPTION
Follow-up to [netresearch/.github#333](https://github.com/netresearch/.github/pull/333), which is merged.

## Why

Codecov's Test Analytics page for this repo is empty — `go-check` uploads `coverage.out` and nothing else, so there is no flaky-test detection, no per-test durations, and no failure history. That is what `app.codecov.io/gh/netresearch/ofelia/tests/new` shows as unconfigured.

## What changes

One input. With `enable-test-results: true` the shared workflow runs the unit tests through gotestsum — which drives `go test -json` and writes a JUnit report next to the coverage profile — and uploads it via `codecov/codecov-action` with `report_type: test_results`.

Nothing about which tests run changes: the flags, packages and coverage threshold are the same, and the coverage upload is untouched.

`template.yaml`'s drift reason is updated to name the new input, and the e2e count it records is corrected to 11 (one of them browser-driven, added in #767).

## Verification

The input exists on the shared workflow's `main` (`go-check.yml:88`), so the call resolves. Locally, the invocation the shared workflow now uses produces both artifacts from a single run — a valid JUnit report and the coverage profile the threshold step and the Codecov upload consume.

The proof that matters is on this PR's own CI: the Build & Test job should report the upload, and the Test Analytics page should stop being empty once it lands.
