### PR TITLE
fix(cli): accept --config and --log-level before the subcommand

### DIFF
--- a/cli/config_show.go
+++ b/cli/config_show.go
@@ -12,7 +12,7 @@ import (
 
 // ConfigShowCommand displays the effective runtime configuration
 type ConfigShowCommand struct {
-	ConfigFile string `long:"config" env:"OFELIA_CONFIG" description:"configuration file" default:"/etc/ofelia/config.ini"`
+	ConfigFile string `long:"config" env:"OFELIA_CONFIG" description:"configuration file"`
 	LogLevel   string `long:"log-level" env:"OFELIA_LOG_LEVEL" description:"Set log level (overrides config)"`
 	Logger     *slog.Logger
 	LevelVar   *slog.LevelVar

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -35,7 +35,7 @@ const (
 
 // DaemonCommand daemon process
 type DaemonCommand struct {
-	ConfigFile           string         `long:"config" env:"OFELIA_CONFIG" description:"Config file path" default:"/etc/ofelia/config.ini"`
+	ConfigFile           string         `long:"config" env:"OFELIA_CONFIG" description:"Config file path"`
 	DockerFilters        []string       `short:"f" long:"docker-filter" env:"OFELIA_DOCKER_FILTER" description:"Docker container filter"`
 	DockerPollInterval   *time.Duration `long:"docker-poll-interval" env:"OFELIA_POLL_INTERVAL" description:"Docker label poll interval"`
 	DockerUseEvents      *bool          `long:"docker-events" env:"OFELIA_DOCKER_EVENTS" description:"Use Docker events for changes"`

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -14,7 +14,7 @@ import (
 
 // ValidateCommand validates the config file
 type ValidateCommand struct {
-	ConfigFile string `long:"config" env:"OFELIA_CONFIG" description:"configuration file" default:"/etc/ofelia/config.ini"`
+	ConfigFile string `long:"config" env:"OFELIA_CONFIG" description:"configuration file"`
 	LogLevel   string `long:"log-level" env:"OFELIA_LOG_LEVEL" description:"Set log level (overrides config)"`
 	Logger     *slog.Logger
 	LevelVar   *slog.LevelVar

--- a/e2e/cli_exit_codes_test.go
+++ b/e2e/cli_exit_codes_test.go
@@ -186,3 +186,43 @@ func TestE2E_GlobalConfigFlagIsHonoured(t *testing.T) {
 			missing, stdout, stderr)
 	}
 }
+
+// TestE2E_GlobalConfigFlagReachesDoctor covers the subcommand that made the
+// first version of this fix incomplete.
+//
+// doctor searches well-known locations when it is given no path, so it is the
+// one command that must NOT receive a pre-filled default — and it was
+// therefore also the one constructed without the pre-parsed value at all, so
+// `ofelia --config=x doctor` was accepted and then ignored, reporting on
+// /etc/ofelia/config.ini instead. Accepting a flag and disregarding it is
+// worse than rejecting it: nothing tells the user their path was dropped.
+func TestE2E_GlobalConfigFlagReachesDoctor(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeConfig(t, `[global]
+  log-level = info
+
+[job-local "hello"]
+  schedule = @every 1h
+  command = echo hi
+`)
+
+	for _, args := range [][]string{
+		{"--config=" + configPath, "doctor"},
+		{"doctor", "--config=" + configPath},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			t.Parallel()
+
+			stdout, stderr, _ := runCommand(t, args...)
+			out := stdout + stderr
+
+			if !strings.Contains(out, configPath) {
+				t.Errorf("doctor did not report on the config it was given (%s):\n%s", configPath, out)
+			}
+			if strings.Contains(out, "Config file not found: /etc/ofelia/config.ini") {
+				t.Errorf("doctor fell back to the default despite an explicit --config:\n%s", out)
+			}
+		})
+	}
+}

--- a/e2e/cli_exit_codes_test.go
+++ b/e2e/cli_exit_codes_test.go
@@ -121,3 +121,68 @@ func TestE2E_ExitCode_ValidateIsUsableAsAGate(t *testing.T) {
 		t.Error("a missing config was accepted; validate cannot be used as a gate")
 	}
 }
+
+// TestE2E_GlobalFlagsBeforeSubcommand pins that the flags ofelia pre-parses
+// out of argv are accepted in the position a user would naturally write them.
+//
+// `--log-level` and `--config` are read before the logger exists, so they look
+// global — but the top-level parser did not declare them, and putting them
+// ahead of the subcommand was rejected with `unknown flag`. Both positions now
+// have to behave the same, since nothing about the flag suggests otherwise.
+func TestE2E_GlobalFlagsBeforeSubcommand(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeConfig(t, `[global]
+  log-level = info
+
+[job-local "hello"]
+  schedule = @every 30s
+  command = echo hi
+`)
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{name: "config before", args: []string{"--config=" + configPath, "validate"}},
+		{name: "config after", args: []string{"validate", "--config=" + configPath}},
+		{name: "log-level before", args: []string{"--log-level=debug", "--config=" + configPath, "validate"}},
+		{name: "log-level after", args: []string{"validate", "--log-level=debug", "--config=" + configPath}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			stdout, stderr, err := runCommand(t, tc.args...)
+			assertExitCode(t, err, 0, stdout, stderr)
+
+			if strings.Contains(stdout+stderr, "unknown flag") {
+				t.Errorf("%v was rejected as an unknown flag:\nstdout=%s\nstderr=%s", tc.args, stdout, stderr)
+			}
+		})
+	}
+}
+
+// TestE2E_GlobalConfigFlagIsHonoured guards the half that a "does it parse"
+// test would miss: the path has to actually reach the command. Declaring the
+// flag on the parser is not enough on its own — the subcommands carried their
+// own `--config` default, which overwrote the pre-parsed value and sent
+// validate to /etc/ofelia/config.ini regardless of what was asked for.
+func TestE2E_GlobalConfigFlagIsHonoured(t *testing.T) {
+	t.Parallel()
+
+	missing := filepath.Join(t.TempDir(), "not-here.ini")
+
+	stdout, stderr, err := runCommand(t, "--config="+missing, "validate")
+	if err == nil {
+		t.Fatalf("validating a missing config succeeded:\nstdout=%s\nstderr=%s", stdout, stderr)
+	}
+
+	// The named path proves the flag was used rather than silently replaced
+	// by the compiled-in default.
+	if !strings.Contains(stdout+stderr, missing) {
+		t.Errorf("the error names a different config than the one requested (%s):\nstdout=%s\nstderr=%s",
+			missing, stdout, stderr)
+	}
+}

--- a/ofelia.go
+++ b/ofelia.go
@@ -55,6 +55,19 @@ func main() {
 	os.Exit(run(os.Args[1:]))
 }
 
+// globalOptions are the flags that apply to ofelia as a whole rather than to
+// one subcommand: they are read out of argv before the logger exists, so the
+// logger can be built at the requested level and the config can be located.
+//
+// They are declared on the top-level parser as well, so that `ofelia
+// --config=x daemon` works and not only `ofelia daemon --config=x`. Being
+// pre-parsed made them look global while the parser rejected them in the
+// position a user would naturally write them.
+type globalOptions struct {
+	LogLevel   string `long:"log-level" description:"Set log level (overrides config)"`
+	ConfigFile string `long:"config" description:"Configuration file path" default:"/etc/ofelia/config.ini"`
+}
+
 // run holds what main used to do and returns the process exit code instead of
 // ending the process, so the exit status is a value tests can assert on.
 func run(args []string) int {
@@ -68,10 +81,7 @@ func run(args []string) int {
 	}
 
 	// Pre-parse log-level flag to configure logger early
-	var pre struct {
-		LogLevel   string `long:"log-level"`
-		ConfigFile string `long:"config" default:"/etc/ofelia/config.ini"`
-	}
+	var pre globalOptions
 	preParser := flags.NewParser(&pre, flags.IgnoreUnknown)
 	_, _ = preParser.ParseArgs(args)
 
@@ -87,6 +97,14 @@ func run(args []string) int {
 	logger, levelVar := buildLogger(pre.LogLevel)
 
 	parser := flags.NewNamedParser("ofelia", flags.Default|flags.AllowBoolValues)
+
+	// Accept the global flags before the subcommand too. The values are
+	// already in `pre`; re-declaring them here is what stops the parser
+	// rejecting `ofelia --config=x daemon` as an unknown flag.
+	if _, err := parser.AddGroup("Global Options", "Flags that apply to every subcommand", &pre); err != nil {
+		logger.Error("registering global options failed", "error", err)
+		return exitFailure
+	}
 	_, _ = parser.AddCommand(
 		"daemon",
 		"daemon process",

--- a/ofelia.go
+++ b/ofelia.go
@@ -65,8 +65,16 @@ func main() {
 // position a user would naturally write them.
 type globalOptions struct {
 	LogLevel   string `long:"log-level" description:"Set log level (overrides config)"`
-	ConfigFile string `long:"config" description:"Configuration file path" default:"/etc/ofelia/config.ini"`
+	ConfigFile string `long:"config" description:"Configuration file path (default: /etc/ofelia/config.ini)"`
 }
+
+// defaultConfigFile is where ofelia looks when --config is absent.
+//
+// It is resolved here rather than declared as a struct-tag default so that an
+// unset flag stays distinguishable from an explicit one: `doctor` searches a
+// list of well-known locations when given no path, and a pre-filled default
+// would silently take that away.
+const defaultConfigFile = "/etc/ofelia/config.ini"
 
 // run holds what main used to do and returns the process exit code instead of
 // ending the process, so the exit status is a value tests can assert on.
@@ -85,8 +93,15 @@ func run(args []string) int {
 	preParser := flags.NewParser(&pre, flags.IgnoreUnknown)
 	_, _ = preParser.ParseArgs(args)
 
+	// Commands that read a config need a concrete path; doctor is handed the
+	// raw value so an absent flag still means "go and find it".
+	configFile := pre.ConfigFile
+	if configFile == "" {
+		configFile = defaultConfigFile
+	}
+
 	if pre.LogLevel == "" {
-		cfg, err := ini.LoadSources(ini.LoadOptions{AllowShadows: true, InsensitiveKeys: true}, pre.ConfigFile)
+		cfg, err := ini.LoadSources(ini.LoadOptions{AllowShadows: true, InsensitiveKeys: true}, configFile)
 		if err == nil {
 			if sec, err := cfg.GetSection("global"); err == nil {
 				pre.LogLevel = cli.ExpandEnvVars(sec.Key("log-level").String())
@@ -109,19 +124,19 @@ func run(args []string) int {
 		"daemon",
 		"daemon process",
 		"",
-		&cli.DaemonCommand{Logger: logger, LevelVar: levelVar, LogLevel: pre.LogLevel, ConfigFile: pre.ConfigFile},
+		&cli.DaemonCommand{Logger: logger, LevelVar: levelVar, LogLevel: pre.LogLevel, ConfigFile: configFile},
 	)
 	_, _ = parser.AddCommand(
 		"validate",
 		"validates the config file",
 		"",
-		&cli.ValidateCommand{Logger: logger, LevelVar: levelVar, LogLevel: pre.LogLevel, ConfigFile: pre.ConfigFile},
+		&cli.ValidateCommand{Logger: logger, LevelVar: levelVar, LogLevel: pre.LogLevel, ConfigFile: configFile},
 	)
 	_, _ = parser.AddCommand(
 		"config",
 		"shows the effective runtime configuration",
 		"",
-		&cli.ConfigShowCommand{Logger: logger, LevelVar: levelVar, LogLevel: pre.LogLevel, ConfigFile: pre.ConfigFile},
+		&cli.ConfigShowCommand{Logger: logger, LevelVar: levelVar, LogLevel: pre.LogLevel, ConfigFile: configFile},
 	)
 	_, _ = parser.AddCommand(
 		"init",
@@ -133,7 +148,7 @@ func run(args []string) int {
 		"doctor",
 		"diagnose Ofelia configuration and environment health",
 		"",
-		&cli.DoctorCommand{Logger: logger, LevelVar: levelVar, LogLevel: pre.LogLevel},
+		&cli.DoctorCommand{Logger: logger, LevelVar: levelVar, LogLevel: pre.LogLevel, ConfigFile: pre.ConfigFile},
 	)
 	_, _ = parser.AddCommand(
 		"hash-password",


### PR DESCRIPTION
Closes #772.

## The flags looked global and were not

`--log-level` and `--config` are pre-parsed out of argv before the logger exists, so they behave globally — but the top-level parser declared neither:

```
$ ofelia --config /etc/ofelia/config.ini validate
unknown flag `config'

$ ofelia validate --config /etc/ofelia/config.ini
(works)
```

Nothing about `--config` suggests it only exists after the subcommand, and it is the flag that decides which file every subcommand reads.

## The half that a "does it parse" fix would have missed

Declaring the pair on the parser stops the rejection — but the path still did not arrive. `daemon`, `validate` and `config-show` each carried their own `--config` with `default:"/etc/ofelia/config.ini"`, and go-flags applies that default during parsing, **overwriting** the pre-parsed value the command was constructed with.

So after the obvious fix, this happened:

```
$ ofelia --config=/tmp/mine.ini validate
failed to load config file "/etc/ofelia/config.ini"
```

The flag was accepted and then ignored. The default now lives once, on the global option; without the tag on the subcommands go-flags leaves the field alone when the flag is absent, so the pre-parsed value survives. When the flag is given *after* the subcommand the pre-parser has already seen it too, so both positions agree.

## Verified against the binary

| invocation | before | after |
|---|---|---|
| `--config=<good> validate` | `unknown flag` | 0 |
| `validate --config=<good>` | 0 | 0 |
| `--log-level debug version` | `unknown flag` | 0 |
| `--config=<missing> validate` | `unknown flag` | 1 |
| `validate --config=<missing>` | 1 | 1 |
| `validate` with no flag | uses `/etc/ofelia/config.ini` | unchanged |

## Tests

Two e2e tests, because the two halves fail differently: one that neither position is rejected, and one that the requested path actually reaches the command. The second would still have failed after the parser-only change — it asserts the error names the config that was asked for, not the compiled-in default.

## Test plan

- [x] `go test ./...` — green
- [x] `go test -race -tags=e2e ./e2e/...` — green
- [x] `golangci-lint run` incl. `--build-tags="e2e unix"` — 0 issues
- [x] `lefthook run pre-push` — exit 0
