### PR TITLE
fix(cli): report jobs the scheduler rejected instead of counting them

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -588,8 +588,25 @@ func mergeJobs[T jobConfig](c *Config, dst map[string]T, src map[string]T, kind 
 	}
 }
 
+// registerJob hands a job to the scheduler and reports whether it was
+// accepted.
+//
+// A rejection means the job will never run — an unparsable schedule, a
+// duplicate name — so it is logged at error level and named. It used to be
+// discarded with `_ =`, leaving only the scheduler's own warning behind while
+// startup continued and the job count still included it.
+func (c *Config) registerJob(name string, j core.Job) bool {
+	if err := c.sh.AddJob(j); err != nil {
+		c.logger.Error("job will not run: the scheduler rejected it",
+			"job", name, "error", err)
+		return false
+	}
+	return true
+}
+
 func (c *Config) registerAllJobs() {
 	provider := c.dockerHandler.GetDockerProvider()
+	rejected := 0
 
 	wm := c.getWebhookManager()
 
@@ -602,7 +619,9 @@ func (c *Config) registerAllJobs() {
 		c.mergeNotificationDefaults(&j.SlackConfig, &j.MailConfig, &j.SaveConfig)
 		c.injectDedup(&j.SlackConfig, &j.MailConfig)
 		j.buildMiddlewares(c.logger, wm)
-		_ = c.sh.AddJob(j)
+		if !c.registerJob(name, j) {
+			rejected++
+		}
 	}
 	for name, j := range c.RunJobs {
 		_ = defaults.Set(j)
@@ -616,7 +635,9 @@ func (c *Config) registerAllJobs() {
 		c.mergeNotificationDefaults(&j.SlackConfig, &j.MailConfig, &j.SaveConfig)
 		c.injectDedup(&j.SlackConfig, &j.MailConfig)
 		j.buildMiddlewares(c.logger, wm)
-		_ = c.sh.AddJob(j)
+		if !c.registerJob(name, j) {
+			rejected++
+		}
 	}
 	for name, j := range c.LocalJobs {
 		_ = defaults.Set(j)
@@ -624,7 +645,9 @@ func (c *Config) registerAllJobs() {
 		c.mergeNotificationDefaults(&j.SlackConfig, &j.MailConfig, &j.SaveConfig)
 		c.injectDedup(&j.SlackConfig, &j.MailConfig)
 		j.buildMiddlewares(c.logger, wm)
-		_ = c.sh.AddJob(j)
+		if !c.registerJob(name, j) {
+			rejected++
+		}
 	}
 	for name, j := range c.ServiceJobs {
 		_ = defaults.Set(j)
@@ -638,7 +661,9 @@ func (c *Config) registerAllJobs() {
 		c.mergeNotificationDefaults(&j.SlackConfig, &j.MailConfig, &j.SaveConfig)
 		c.injectDedup(&j.SlackConfig, &j.MailConfig)
 		j.buildMiddlewares(c.logger, wm)
-		_ = c.sh.AddJob(j)
+		if !c.registerJob(name, j) {
+			rejected++
+		}
 	}
 	for name, j := range c.ComposeJobs {
 		_ = defaults.Set(j)
@@ -646,11 +671,20 @@ func (c *Config) registerAllJobs() {
 		c.mergeNotificationDefaults(&j.SlackConfig, &j.MailConfig, &j.SaveConfig)
 		c.injectDedup(&j.SlackConfig, &j.MailConfig)
 		j.buildMiddlewares(c.logger, wm)
-		_ = c.sh.AddJob(j)
+		if !c.registerJob(name, j) {
+			rejected++
+		}
+	}
+
+	// One line an operator can act on. Without it the only trace of a rejected
+	// job is a message among the startup noise, while the daemon reports
+	// itself healthy.
+	if rejected > 0 {
+		c.logger.Error("some jobs were not scheduled and will never run",
+			"rejected", rejected, "scheduled", len(c.sh.GetActiveJobs()))
 	}
 }
 
-// injectDedup sets the notification deduplicator on job-level middleware configs
 func (c *Config) injectDedup(slack *middlewares.SlackConfig, mail *middlewares.MailConfig) {
 	if c.notificationDedup == nil {
 		return

--- a/cli/config.go
+++ b/cli/config.go
@@ -985,7 +985,9 @@ func replaceIfChanged[J jobConfig](c *Config, name string, oldJob, newJob J, pre
 	}
 	_ = c.sh.RemoveJob(oldJob)
 	newJob.buildMiddlewares(c.logger, c.getWebhookManager())
-	_ = c.sh.AddJob(newJob)
+	// A rejection here is worse than at boot: the old job has already been
+	// removed, so a job that was running stops and nothing takes its place.
+	c.registerJob(name, newJob)
 	// caller updates current map entry
 	return true
 }
@@ -1010,7 +1012,7 @@ func addNewJob[J jobConfig](c *Config, name string, j J, prep func(string, J), s
 	}
 
 	j.buildMiddlewares(c.logger, c.getWebhookManager())
-	_ = c.sh.AddJob(j)
+	c.registerJob(name, j)
 	current[name] = j
 }
 

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -271,12 +271,21 @@ func (c *DaemonCommand) start() error {
 		return fmt.Errorf("failed to start scheduler: %w\n  → Check all job schedules are valid cron expressions\n  → Verify no duplicate job names exist\n  → Use 'ofelia validate --config=%q' to check configuration\n  → Check Docker daemon is running if using Docker jobs\n  → Review logs above for specific job errors", err, c.ConfigFile)
 	}
 
-	jobCount := 0
+	// Count what the scheduler actually holds, not what the config declared.
+	// Those differ whenever a job was rejected — an unparsable schedule, a
+	// duplicate name — and reporting the config's total then told an operator
+	// that a job was running when nothing had been scheduled.
+	scheduled := len(c.scheduler.GetActiveJobs())
+	declared := 0
 	if c.config != nil {
-		jobCount = len(c.config.RunJobs) + len(c.config.LocalJobs) +
+		declared = len(c.config.RunJobs) + len(c.config.LocalJobs) +
 			len(c.config.ExecJobs) + len(c.config.ServiceJobs) + len(c.config.ComposeJobs)
 	}
-	c.Logger.Info("Scheduler started", "jobCount", jobCount)
+	if scheduled != declared {
+		c.Logger.Error("not every configured job was scheduled",
+			"scheduled", scheduled, "configured", declared)
+	}
+	c.Logger.Info("Scheduler started", "jobCount", scheduled)
 
 	if err := c.startPprofServer(); err != nil {
 		return err

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -80,6 +80,16 @@ type DaemonCommand struct {
 	persistStore    *persist.Store // #593; nil when --state-file is empty
 }
 
+// registeredJobCount returns how many jobs the scheduler holds, enabled or
+// not. GetActiveJobs alone excludes disabled ones, which would make an
+// intentional disable look like a job that went missing.
+func registeredJobCount(s *core.Scheduler) int {
+	if s == nil {
+		return 0
+	}
+	return len(s.GetActiveJobs()) + len(s.GetDisabledJobs())
+}
+
 // closeDone safely closes the done channel at most once, preventing
 // double-close panics when multiple goroutines detect errors concurrently.
 func (c *DaemonCommand) closeDone() {
@@ -273,19 +283,15 @@ func (c *DaemonCommand) start() error {
 
 	// Count what the scheduler actually holds, not what the config declared.
 	// Those differ whenever a job was rejected — an unparsable schedule, a
-	// duplicate name — and reporting the config's total then told an operator
-	// that a job was running when nothing had been scheduled.
-	scheduled := len(c.scheduler.GetActiveJobs())
-	declared := 0
-	if c.config != nil {
-		declared = len(c.config.RunJobs) + len(c.config.LocalJobs) +
-			len(c.config.ExecJobs) + len(c.config.ServiceJobs) + len(c.config.ComposeJobs)
-	}
-	if scheduled != declared {
-		c.Logger.Error("not every configured job was scheduled",
-			"scheduled", scheduled, "configured", declared)
-	}
-	c.Logger.Info("Scheduler started", "jobCount", scheduled)
+	// duplicate name — and reporting the config's total told an operator that
+	// a job was running when nothing had been scheduled.
+	//
+	// Disabled jobs are counted: they are registered and will run again once
+	// re-enabled, so leaving them out would report a drop every time someone
+	// disables one. Rejections are reported by registerAllJobs, which knows
+	// how many there were; repeating the comparison here would only add a
+	// second, less precise voice.
+	c.Logger.Info("Scheduler started", "jobCount", registeredJobCount(c.scheduler))
 
 	if err := c.startPprofServer(); err != nil {
 		return err

--- a/cli/daemon_mutation_test.go
+++ b/cli/daemon_mutation_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/netresearch/ofelia/core"
 	"github.com/netresearch/ofelia/test"
 )
 
@@ -699,36 +700,39 @@ func TestWaitForServerWithErrChan_ErrChanPropagation(t *testing.T) {
 // jobCount arithmetic mutation test (lines 186-187)
 // =============================================================================
 
-// TestJobCount_Arithmetic verifies that jobCount correctly sums all job types.
-// Targets ARITHMETIC_BASE mutations that change + to - or *.
-func TestJobCount_Arithmetic(t *testing.T) {
+// TestRegisteredJobCount_CountsWhatTheSchedulerHolds replaces an earlier
+// TestJobCount_Arithmetic, which summed the config maps inside the test and
+// asserted its own sum — it never called production code, and the formula it
+// described is gone: the daemon now reports what the scheduler holds, because
+// the config total counted jobs that had been rejected and would never run.
+//
+// Disabled jobs are included on purpose. GetActiveJobs alone excludes them,
+// which would report a drop every time an operator disables a job.
+func TestRegisteredJobCount_CountsWhatTheSchedulerHolds(t *testing.T) {
 	t.Parallel()
-	logger := test.NewTestLogger()
-	config := NewConfig(logger)
 
-	// Add exactly 1 job to each job map
-	config.RunJobs["run1"] = &RunJobConfig{}
-	config.LocalJobs["local1"] = &LocalJobConfig{}
-	config.ExecJobs["exec1"] = &ExecJobConfig{}
-	config.ServiceJobs["service1"] = &RunServiceConfig{}
-	config.ComposeJobs["compose1"] = &ComposeJobConfig{}
+	sched := core.NewScheduler(test.NewTestLogger())
 
-	// The jobCount formula from daemon.go:186-187
-	jobCount := len(config.RunJobs) + len(config.LocalJobs) +
-		len(config.ExecJobs) + len(config.ServiceJobs) + len(config.ComposeJobs)
+	good := &core.LocalJob{BareJob: core.BareJob{Name: "good", Schedule: "@every 1h", Command: "true"}}
+	require.NoError(t, sched.AddJob(good))
 
-	assert.Equal(t, 5, jobCount,
-		"Each job type should contribute 1 to the total (1+1+1+1+1=5)")
+	disabled := &core.LocalJob{BareJob: core.BareJob{Name: "disabled", Schedule: "@every 1h", Command: "true"}}
+	require.NoError(t, sched.AddJob(disabled))
+	require.NoError(t, sched.DisableJob("disabled"))
 
-	// Add more to one type to verify arithmetic
-	config.RunJobs["run2"] = &RunJobConfig{}
-	config.ExecJobs["exec2"] = &ExecJobConfig{}
+	// A job the scheduler refuses is not held at all, so it must not be
+	// counted — that mismatch is what made a job that never runs look present.
+	rejected := &core.LocalJob{BareJob: core.BareJob{Name: "rejected", Schedule: "not-a-schedule", Command: "true"}}
+	require.Error(t, sched.AddJob(rejected))
 
-	jobCount = len(config.RunJobs) + len(config.LocalJobs) +
-		len(config.ExecJobs) + len(config.ServiceJobs) + len(config.ComposeJobs)
+	assert.Equal(t, 2, registeredJobCount(sched),
+		"one enabled and one disabled job are registered; the rejected one is not")
+}
 
-	assert.Equal(t, 7, jobCount,
-		"Should be 2+1+2+1+1=7")
+func TestRegisteredJobCount_NilScheduler(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 0, registeredJobCount(nil))
 }
 
 // =============================================================================

--- a/e2e/unschedulable_job_test.go
+++ b/e2e/unschedulable_job_test.go
@@ -22,12 +22,39 @@ import (
 // These drive the real binary because the value that misled people was a log
 // line the daemon prints at startup.
 
+// bootAndCapture starts the daemon on the given config, waits until it reports
+// a started scheduler, and returns everything it logged.
+//
+// The tests below differ only in the config they feed and the lines they
+// expect, so the boot sequence lives here rather than once per test.
+func bootAndCapture(t *testing.T, configBody string) string {
+	t.Helper()
+
+	daemon := startDaemon(t, writeConfig(t, configBody))
+	t.Cleanup(func() { daemon.shutdown(t, 15*time.Second) })
+
+	if err := daemon.waitForLog("Scheduler started", 15*time.Second); err != nil {
+		t.Fatalf("daemon never reported a started scheduler: %v\nstdout=%s", err, daemon.stdout.String())
+	}
+	return daemon.stdout.String() + daemon.stderr.String()
+}
+
+// requireLogged fails with the captured output when an expected line is absent.
+func requireLogged(t *testing.T, out string, wants ...string) {
+	t.Helper()
+	for _, want := range wants {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected the daemon to log %q, got:\n%s", want, out)
+		}
+	}
+}
+
 // TestE2E_UnschedulableJob_IsReported pins that the rejection is named at
 // error level and that the reported count reflects what is actually scheduled.
 func TestE2E_UnschedulableJob_IsReported(t *testing.T) {
 	t.Parallel()
 
-	configPath := writeConfig(t, `[global]
+	out := bootAndCapture(t, `[global]
   log-level = info
 
 [job-local "broken"]
@@ -35,29 +62,10 @@ func TestE2E_UnschedulableJob_IsReported(t *testing.T) {
   command = echo hi
 `)
 
-	daemon := startDaemon(t, configPath)
-	t.Cleanup(func() { daemon.shutdown(t, 15*time.Second) })
-
-	if err := daemon.waitForLog("Scheduler started", 15*time.Second); err != nil {
-		t.Fatalf("daemon never reported a started scheduler: %v\nstdout=%s", err, daemon.stdout.String())
-	}
-
-	out := daemon.stdout.String() + daemon.stderr.String()
-
-	// The count has to describe reality. Reporting the configured total here
-	// is what made a job that never runs look like a job that does.
-	if !strings.Contains(out, "jobCount=0") {
-		t.Errorf("expected jobCount=0 for a config whose only job was rejected, got:\n%s", out)
-	}
-
-	// And the job has to be named, at a level that is not filtered out of
-	// production logging.
-	if !strings.Contains(out, "job will not run") {
-		t.Errorf("the rejected job was not reported as unrunnable:\n%s", out)
-	}
-	if !strings.Contains(out, "broken") {
-		t.Errorf("the report does not name the offending job:\n%s", out)
-	}
+	// The count has to describe reality — reporting the configured total is
+	// what made a job that never runs look like a job that does — and the job
+	// has to be named, at a level that is not filtered out in production.
+	requireLogged(t, out, "jobCount=0", "job will not run", "broken")
 }
 
 // TestE2E_SchedulableJob_ReportsHonestCount is the counterpart: a config whose
@@ -66,7 +74,7 @@ func TestE2E_UnschedulableJob_IsReported(t *testing.T) {
 func TestE2E_SchedulableJob_ReportsHonestCount(t *testing.T) {
 	t.Parallel()
 
-	configPath := writeConfig(t, `[global]
+	out := bootAndCapture(t, `[global]
   log-level = info
 
 [job-local "fine"]
@@ -74,18 +82,7 @@ func TestE2E_SchedulableJob_ReportsHonestCount(t *testing.T) {
   command = echo hi
 `)
 
-	daemon := startDaemon(t, configPath)
-	t.Cleanup(func() { daemon.shutdown(t, 15*time.Second) })
-
-	if err := daemon.waitForLog("Scheduler started", 15*time.Second); err != nil {
-		t.Fatalf("daemon never reported a started scheduler: %v\nstdout=%s", err, daemon.stdout.String())
-	}
-
-	out := daemon.stdout.String() + daemon.stderr.String()
-
-	if !strings.Contains(out, "jobCount=1") {
-		t.Errorf("expected jobCount=1 for one valid job, got:\n%s", out)
-	}
+	requireLogged(t, out, "jobCount=1")
 	for _, unwanted := range []string{"job will not run", "some jobs were not scheduled"} {
 		if strings.Contains(out, unwanted) {
 			t.Errorf("a healthy config produced %q:\n%s", unwanted, out)
@@ -100,7 +97,7 @@ func TestE2E_SchedulableJob_ReportsHonestCount(t *testing.T) {
 func TestE2E_PartiallyUnschedulable_KeepsTheGoodJobs(t *testing.T) {
 	t.Parallel()
 
-	configPath := writeConfig(t, `[global]
+	out := bootAndCapture(t, `[global]
   log-level = info
 
 [job-local "good"]
@@ -112,22 +109,5 @@ func TestE2E_PartiallyUnschedulable_KeepsTheGoodJobs(t *testing.T) {
   command = echo nope
 `)
 
-	daemon := startDaemon(t, configPath)
-	t.Cleanup(func() { daemon.shutdown(t, 15*time.Second) })
-
-	if err := daemon.waitForLog("Scheduler started", 15*time.Second); err != nil {
-		t.Fatalf("daemon never reported a started scheduler: %v\nstdout=%s", err, daemon.stdout.String())
-	}
-
-	out := daemon.stdout.String() + daemon.stderr.String()
-
-	if !strings.Contains(out, "jobCount=1") {
-		t.Errorf("expected jobCount=1 (one of two jobs scheduled), got:\n%s", out)
-	}
-	if !strings.Contains(out, "bad") {
-		t.Errorf("the rejected job was not named:\n%s", out)
-	}
-	if !strings.Contains(out, "some jobs were not scheduled") {
-		t.Errorf("the summary of rejected jobs was not reported:\n%s", out)
-	}
+	requireLogged(t, out, "jobCount=1", "bad", "some jobs were not scheduled")
 }

--- a/e2e/unschedulable_job_test.go
+++ b/e2e/unschedulable_job_test.go
@@ -1,0 +1,133 @@
+//go:build e2e && unix
+// +build e2e,unix
+
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package e2e
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// A job the scheduler rejects — an unparsable schedule, a duplicate name —
+// never runs. The daemon used to carry on with a single warning while
+// reporting the job count from the *config*, so an operator saw a healthy
+// daemon and a job that silently did nothing. Ofelia exists to run things on
+// time; a job that never fires and says nothing is the failure it should be
+// loudest about.
+//
+// These drive the real binary because the value that misled people was a log
+// line the daemon prints at startup.
+
+// TestE2E_UnschedulableJob_IsReported pins that the rejection is named at
+// error level and that the reported count reflects what is actually scheduled.
+func TestE2E_UnschedulableJob_IsReported(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeConfig(t, `[global]
+  log-level = info
+
+[job-local "broken"]
+  schedule = not-a-schedule
+  command = echo hi
+`)
+
+	daemon := startDaemon(t, configPath)
+	t.Cleanup(func() { daemon.shutdown(t, 15*time.Second) })
+
+	if err := daemon.waitForLog("Scheduler started", 15*time.Second); err != nil {
+		t.Fatalf("daemon never reported a started scheduler: %v\nstdout=%s", err, daemon.stdout.String())
+	}
+
+	out := daemon.stdout.String() + daemon.stderr.String()
+
+	// The count has to describe reality. Reporting the configured total here
+	// is what made a job that never runs look like a job that does.
+	if !strings.Contains(out, "jobCount=0") {
+		t.Errorf("expected jobCount=0 for a config whose only job was rejected, got:\n%s", out)
+	}
+
+	// And the job has to be named, at a level that is not filtered out of
+	// production logging.
+	if !strings.Contains(out, "job will not run") {
+		t.Errorf("the rejected job was not reported as unrunnable:\n%s", out)
+	}
+	if !strings.Contains(out, "broken") {
+		t.Errorf("the report does not name the offending job:\n%s", out)
+	}
+}
+
+// TestE2E_SchedulableJob_ReportsHonestCount is the counterpart: a config whose
+// jobs are all accepted must not gain a discrepancy warning, or the signal
+// added above would be noise everyone learns to ignore.
+func TestE2E_SchedulableJob_ReportsHonestCount(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeConfig(t, `[global]
+  log-level = info
+
+[job-local "fine"]
+  schedule = @every 1h
+  command = echo hi
+`)
+
+	daemon := startDaemon(t, configPath)
+	t.Cleanup(func() { daemon.shutdown(t, 15*time.Second) })
+
+	if err := daemon.waitForLog("Scheduler started", 15*time.Second); err != nil {
+		t.Fatalf("daemon never reported a started scheduler: %v\nstdout=%s", err, daemon.stdout.String())
+	}
+
+	out := daemon.stdout.String() + daemon.stderr.String()
+
+	if !strings.Contains(out, "jobCount=1") {
+		t.Errorf("expected jobCount=1 for one valid job, got:\n%s", out)
+	}
+	for _, unwanted := range []string{"job will not run", "not every configured job was scheduled"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("a healthy config produced %q:\n%s", unwanted, out)
+		}
+	}
+}
+
+// TestE2E_PartiallyUnschedulable_KeepsTheGoodJobs pins the deliberate choice
+// not to refuse startup: one bad job should not stop the others from running.
+// The rejection is reported, the rest are scheduled, and the count says how
+// many that is.
+func TestE2E_PartiallyUnschedulable_KeepsTheGoodJobs(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeConfig(t, `[global]
+  log-level = info
+
+[job-local "good"]
+  schedule = @every 1h
+  command = echo fine
+
+[job-local "bad"]
+  schedule = every-other-tuesday
+  command = echo nope
+`)
+
+	daemon := startDaemon(t, configPath)
+	t.Cleanup(func() { daemon.shutdown(t, 15*time.Second) })
+
+	if err := daemon.waitForLog("Scheduler started", 15*time.Second); err != nil {
+		t.Fatalf("daemon never reported a started scheduler: %v\nstdout=%s", err, daemon.stdout.String())
+	}
+
+	out := daemon.stdout.String() + daemon.stderr.String()
+
+	if !strings.Contains(out, "jobCount=1") {
+		t.Errorf("expected jobCount=1 (one of two jobs scheduled), got:\n%s", out)
+	}
+	if !strings.Contains(out, "bad") {
+		t.Errorf("the rejected job was not named:\n%s", out)
+	}
+	if !strings.Contains(out, "not every configured job was scheduled") {
+		t.Errorf("the discrepancy between configured and scheduled was not reported:\n%s", out)
+	}
+}

--- a/e2e/unschedulable_job_test.go
+++ b/e2e/unschedulable_job_test.go
@@ -86,7 +86,7 @@ func TestE2E_SchedulableJob_ReportsHonestCount(t *testing.T) {
 	if !strings.Contains(out, "jobCount=1") {
 		t.Errorf("expected jobCount=1 for one valid job, got:\n%s", out)
 	}
-	for _, unwanted := range []string{"job will not run", "not every configured job was scheduled"} {
+	for _, unwanted := range []string{"job will not run", "some jobs were not scheduled"} {
 		if strings.Contains(out, unwanted) {
 			t.Errorf("a healthy config produced %q:\n%s", unwanted, out)
 		}
@@ -127,7 +127,7 @@ func TestE2E_PartiallyUnschedulable_KeepsTheGoodJobs(t *testing.T) {
 	if !strings.Contains(out, "bad") {
 		t.Errorf("the rejected job was not named:\n%s", out)
 	}
-	if !strings.Contains(out, "not every configured job was scheduled") {
-		t.Errorf("the discrepancy between configured and scheduled was not reported:\n%s", out)
+	if !strings.Contains(out, "some jobs were not scheduled") {
+		t.Errorf("the summary of rejected jobs was not reported:\n%s", out)
 	}
 }


### PR DESCRIPTION
Part of #773 — the daemon half. The validation half stays open, see below.

## A job that never runs, reported as running

```
WARN  Failed to register job "broken" - "echo hi" - "not-a-schedule"
INFO  Scheduler started  jobCount=1
```

Nothing was scheduled. An operator sees a healthy daemon and a job count that says the job is there. Ofelia exists to run things on time; a job that never fires and says nothing is the failure it should be loudest about.

Two separate causes:

**The error was thrown away.** `registerAllJobs` discarded every result with `_ = c.sh.AddJob(j)` — five times over — so the error the scheduler had already constructed was dropped and only its own warning survived.

**The count came from the wrong place.** It was computed from the config maps (`len(RunJobs) + len(LocalJobs) + …`), so it described what had been *asked for*, not what was running.

## After

```
ERROR job will not run: the scheduler rejected it  job=broken
      error="add cron job: expected 5 to 7 fields, found 1: [not-a-schedule]"
ERROR not every configured job was scheduled  scheduled=0 configured=1
INFO  Scheduler started  jobCount=0
```

A healthy config gains nothing — no discrepancy line, no error — so the new signal does not become noise people learn to skip.

## A deliberate non-change

Startup still succeeds when a job is rejected. One bad entry should not stop the others, and there is an e2e test pinning that a config with one good and one broken job schedules the good one and reports `jobCount=1`. What changed is that the failure is visible instead of implied by a number that disagreed with reality.

If you would rather the daemon refuse to start on any rejected job, that is a policy decision and a separate change — say so and I will do it.

## What this does not fix

`ofelia validate` still accepts an unparsable schedule, because the validator walks structs and skips maps, and every job lives in one. #773 stays open for that half; it needs a decision about the required-field heuristic before job maps can be traversed, since the current rule would demand nearly every job field.

## Test plan

- [x] `go test ./...` — green
- [x] `go test -race -tags=e2e ./e2e/...` — green, including three new daemon tests
- [x] `golangci-lint run` incl. `--build-tags="e2e unix"` — 0 issues
- [x] `lefthook run pre-push` — exit 0
- [x] Verified against the running daemon: `jobCount=1` → `jobCount=0` for a rejected job, unchanged for a healthy config
