### PR TITLE
feat(config): validate jobs, not just the global section

### DIFF
--- a/cli/validate_test.go
+++ b/cli/validate_test.go
@@ -20,9 +20,14 @@ func TestValidateExecuteValidFile(t *testing.T) {
 	// Not parallel: modifies global os.Stdout which races with other tests.
 
 	configFile := filepath.Join(t.TempDir(), "config.ini")
+	// container is part of a runnable job-exec: without it every run fails
+	// with `run_exec container "": invalid container name or ID`. The fixture
+	// omitted it and this test asserted the config was valid, which is what
+	// job validation now catches.
 	content := `
 [job-exec "foo"]
 schedule = @every 10s
+container = some-container
 command = echo "foo"
 `
 	err := os.WriteFile(configFile, []byte(content), 0o644)

--- a/config/validator.go
+++ b/config/validator.go
@@ -208,6 +208,13 @@ func (cv *Validator2) Validate() error {
 
 // validateStruct recursively validates struct fields based on tags
 func (cv *Validator2) validateStruct(v *Validator, obj any, path string) {
+	cv.validateStructIn(v, obj, path, false)
+}
+
+// validateStructIn is validateStruct with the job flag, which travels down
+// through nested and squashed structs so an embedded job field is still
+// recognized as being inside a job.
+func (cv *Validator2) validateStructIn(v *Validator, obj any, path string, inJob bool) {
 	val, ok := derefToStruct(obj)
 	if !ok {
 		return
@@ -226,14 +233,35 @@ func (cv *Validator2) validateStruct(v *Validator, obj any, path string) {
 		fieldPath := resolveFieldPath(path, fieldType.Name, fieldType.Tag.Get("gcfg"), mapstructureTag)
 
 		// Handle nested structs
-		if field.Kind() == reflect.Struct && mapstructureTag != ",squash" {
-			cv.validateStruct(v, field.Interface(), fieldPath)
+		if field.Kind() == reflect.Struct {
+			squashed := mapstructureTag == ",squash"
+			if !squashed {
+				cv.validateStructIn(v, field.Interface(), fieldPath, inJob)
+				continue
+			}
+			// A squashed struct contributes its fields at the parent's level,
+			// so it is walked with the parent's path. Only inside a job:
+			// every job type embeds core.<Kind>Job and, through it, BareJob,
+			// which is where schedule and command live — skipping squashed
+			// structs is why a job's schedule was never checked. Outside a job
+			// the old behavior stands, so the global section is untouched by
+			// this change.
+			if inJob {
+				cv.validateStructIn(v, field.Interface(), path, inJob)
+			}
 			continue
 		}
 
-		// Validate based on field type and value. The enclosing struct travels
-		// with it so a field can be required conditionally on a sibling.
-		cv.validateField(v, val, field, fieldPath, defaultTag)
+		// Job sections are maps keyed by the name the user wrote; walk them so
+		// a job's fields are validated at all. Skipping maps meant no job was
+		// ever reachable by the validator.
+		if field.Kind() == reflect.Map {
+			cv.validateJobMap(v, field, fieldPath)
+			continue
+		}
+
+		// Validate based on field type and value
+		cv.validateField(v, field, fieldCtx{parent: val, path: fieldPath, defaultTag: defaultTag, inJob: inJob})
 	}
 }
 
@@ -274,17 +302,29 @@ func resolveFieldPath(parentPath, fieldName, gcfgTag, mapstructureTag string) st
 	return fieldPath
 }
 
+// fieldCtx carries what a field needs beyond its own value: the struct it
+// belongs to (so a requirement can be conditional on a sibling), its config
+// key, its default tag, and whether it sits inside a job section.
+type fieldCtx struct {
+	parent     reflect.Value
+	path       string
+	defaultTag string
+	// inJob suppresses the "a field with no default is required" rule. That
+	// rule is a heuristic tuned to the global section; applied to a job it
+	// would demand nearly every key a job can carry. What a job genuinely
+	// needs is stated in jobRequirements and checked separately.
+	inJob bool
+}
+
 // validateField validates individual fields based on their type and tags
-func (cv *Validator2) validateField(
-	v *Validator, parent, field reflect.Value, path string, defaultTag string,
-) {
+func (cv *Validator2) validateField(v *Validator, field reflect.Value, ctx fieldCtx) {
 	switch field.Kind() {
 	case reflect.String:
-		cv.validateStringField(v, parent, field, path, defaultTag)
+		cv.validateStringField(v, field, ctx)
 	case reflect.Int, reflect.Int64:
-		cv.validateIntField(v, field, path)
+		cv.validateIntField(v, field, ctx.path)
 	case reflect.Slice:
-		cv.validateSliceField(v, field, path)
+		cv.validateSliceField(v, field, ctx.path)
 	case reflect.Invalid, reflect.Bool, reflect.Int8, reflect.Int16, reflect.Int32,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
 		reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128,
@@ -299,25 +339,33 @@ func (cv *Validator2) validateField(
 }
 
 // validateStringField validates string type fields
-func (cv *Validator2) validateStringField(
-	v *Validator, parent, field reflect.Value, path string, defaultTag string,
-) {
+func (cv *Validator2) validateStringField(v *Validator, field reflect.Value, ctx fieldCtx) {
 	str := field.String()
 
 	// Skip validation for fields with defaults when they're empty
-	if defaultTag != "" && str == "" {
+	if ctx.defaultTag != "" && str == "" {
 		return
 	}
 
 	// Check for required fields
-	if defaultTag == "" && str == "" && !cv.isOptionalField(path) && cv.gateIsOpen(parent, path) {
-		v.ValidateRequired(path, str)
+	if ctx.defaultTag == "" && str == "" && !ctx.inJob &&
+		!cv.isOptionalField(ctx.path) && cv.gateIsOpen(ctx.parent, ctx.path) {
+		v.ValidateRequired(ctx.path, str)
 	}
 
 	// Validate specific string fields
 	if str != "" {
-		cv.validateSpecificStringField(v, path, str)
+		cv.validateSpecificStringField(v, ctx.path, str)
 	}
+}
+
+// fieldKey returns the config key a path ends in, dropping any section
+// qualifier the path carries for reporting.
+func fieldKey(path string) string {
+	if i := strings.LastIndex(path, "."); i >= 0 {
+		return strings.ToLower(path[i+1:])
+	}
+	return strings.ToLower(path)
 }
 
 // validateSpecificStringField validates specific string field formats
@@ -327,12 +375,17 @@ func (cv *Validator2) validateSpecificStringField(v *Validator, path string, str
 		return // Stop validation if security check fails
 	}
 
-	// Validate based on field type. The case strings are user-facing INI key
-	// names; Go struct tags (gcfg:"…" / mapstructure:"…") on Config require
-	// them as literals there too, so extracting constants only relocates the
-	// duplication. Suppressing keeps the switch readable.
-	switch path {
-	case "schedule", "cron": //nolint:goconst // see comment above switch
+	// Match on the last segment of the path. Inside a job the path is
+	// qualified with its section ("job-local \"backup\".schedule") so the error
+	// says which job is at fault, while the key that selects the check is the
+	// bare field name. Without this the schedule of a job was never checked:
+	// the qualified path matched no case and fell through silently.
+	//
+	// The case strings are user-facing INI key names; Go struct tags
+	// (gcfg:"…" / mapstructure:"…") on Config require them as literals there
+	// too, so extracting constants only relocates the duplication.
+	switch fieldKey(path) {
+	case keySchedule, "cron":
 		cv.validateCronField(v, path, str)
 	case "email-to", "email-from": //nolint:goconst // see comment above switch
 		cv.validateEmailField(v, path, str)
@@ -340,9 +393,9 @@ func (cv *Validator2) validateSpecificStringField(v *Validator, path string, str
 		cv.validateAddressField(v, path, str)
 	case "log-level": //nolint:goconst // see comment above switch
 		cv.validateLogLevelField(v, path, str)
-	case "command", "cmd":
+	case keyCommand, "cmd":
 		cv.validateCommandField(v, path, str)
-	case "image":
+	case keyImage:
 		cv.validateImageField(v, path, str)
 	case "save-folder", "working_dir":
 		cv.validatePathField(v, path, str)
@@ -571,4 +624,142 @@ func (cv *Validator2) isValidLogLevel(level string) bool {
 	}
 	level = strings.ToLower(level)
 	return slices.Contains(validLevels, level)
+}
+
+// INI keys named in more than one place here: the switch that picks a format
+// check, and the table of what each job kind needs. They were literals in both
+// until the table arrived, at which point the same key existed twice with
+// nothing tying the two together.
+const (
+	keySchedule  = "schedule"
+	keyCommand   = "command"
+	keyImage     = "image"
+	keyContainer = "container"
+)
+
+// jobRequirement is one thing a job of a given kind must carry. Several field
+// names mean "at least one of these", which is how job-run accepts either an
+// image to start or an existing container to reuse.
+type jobRequirement struct {
+	fields []string
+	// why is appended to the error so the message says what the field is for
+	// rather than only that it is missing.
+	why string
+}
+
+// jobRequirements states what each job section needs in order to run.
+//
+// The entries are taken from what the runtime already demands, not invented
+// here: core.RunJob.Validate returns ErrImageOrContainer, core.RunServiceJob
+// .Validate returns ErrImageRequired, ExecJob execs by container id and
+// command, LocalJob runs a command, and ComposeJob shells out with a file and
+// a service. Checking them here moves those failures from "the job silently
+// never runs" to "validate says so".
+var jobRequirements = map[string][]jobRequirement{
+	"job-exec": {
+		{fields: []string{keyContainer}, why: "the container to exec in"},
+		{fields: []string{keyCommand}, why: "the command to run"},
+	},
+	"job-run": {
+		{fields: []string{keyImage, keyContainer}, why: "an image to start or an existing container to reuse"},
+	},
+	"job-local": {
+		{fields: []string{keyCommand}, why: "the command to run"},
+	},
+	"job-service-run": {
+		{fields: []string{keyImage}, why: "the image to create the swarm service from"},
+	},
+	"job-compose": {
+		{fields: []string{"file"}, why: "the compose file"},
+		{fields: []string{"service"}, why: "the service to run"},
+	},
+}
+
+// scheduleRequirement applies to every job kind: without a schedule there is
+// nothing to register the job under.
+var scheduleRequirement = jobRequirement{fields: []string{keySchedule}, why: "when to run"}
+
+// validateJobMap walks the jobs of one section. Each entry is validated like
+// any other struct — so formats are checked — and then against the
+// requirements for its kind.
+func (cv *Validator2) validateJobMap(v *Validator, m reflect.Value, section string) {
+	if m.Kind() != reflect.Map || m.IsNil() {
+		return
+	}
+
+	reqs, known := jobRequirements[section]
+	for _, key := range m.MapKeys() {
+		entry := m.MapIndex(key)
+		val, ok := derefToStruct(entry.Interface())
+		if !ok {
+			continue
+		}
+
+		// Field-level checks (formats, ranges) for everything the job carries.
+		// The path carries the section and the job name so an error names the
+		// job the user wrote rather than a bare key.
+		cv.validateStructIn(v, entry.Interface(), fmt.Sprintf("%s %q", section, key.String()), true)
+
+		if !known {
+			continue
+		}
+		jobName := key.String()
+		for _, req := range append([]jobRequirement{scheduleRequirement}, reqs...) {
+			cv.checkJobRequirement(v, val, section, jobName, req)
+		}
+	}
+}
+
+// checkJobRequirement reports a requirement that no field satisfies.
+func (cv *Validator2) checkJobRequirement(
+	v *Validator, job reflect.Value, section, jobName string, req jobRequirement,
+) {
+	for _, name := range req.fields {
+		if strings.TrimSpace(fieldValueByKey(job, name)) != "" {
+			return
+		}
+	}
+
+	v.AddError(
+		fmt.Sprintf("%s %q: %s", section, jobName, strings.Join(req.fields, " or ")),
+		"",
+		fmt.Sprintf("is required (%s)", req.why),
+	)
+}
+
+// fieldValueByKey returns the string value of the field carrying the given
+// config key, searching embedded structs because a job's schedule and command
+// live on the BareJob it embeds rather than on the job type itself.
+func fieldValueByKey(val reflect.Value, key string) string {
+	if val.Kind() != reflect.Struct {
+		return ""
+	}
+
+	typ := val.Type()
+	for fieldType := range typ.Fields() {
+		field := val.FieldByIndex(fieldType.Index)
+
+		// Embedded structs are descended into even when the embedded type is
+		// unexported: the job types embed exported ones today, but the values
+		// are only read here, never handed out, so there is no reason for the
+		// lookup to depend on that staying true.
+		if fieldType.Anonymous && field.Kind() == reflect.Struct {
+			if found := fieldValueByKey(field, key); found != "" {
+				return found
+			}
+			continue
+		}
+
+		if !fieldType.IsExported() {
+			continue
+		}
+		if resolveFieldPath("", fieldType.Name, fieldType.Tag.Get("gcfg"), fieldType.Tag.Get("mapstructure")) != key &&
+			!strings.EqualFold(fieldType.Name, key) {
+			continue
+		}
+		if field.Kind() == reflect.String {
+			return field.String()
+		}
+	}
+	return ""
 }

--- a/config/validator_boundary_test.go
+++ b/config/validator_boundary_test.go
@@ -432,7 +432,7 @@ func TestValidator2ValidateStringFieldDefaults(t *testing.T) {
 			v := NewValidator()
 
 			field := reflect.ValueOf(tt.value)
-			cv.validateStringField(v, reflect.Value{}, field, tt.path, tt.defaultTag)
+			cv.validateStringField(v, field, fieldCtx{path: tt.path, defaultTag: tt.defaultTag})
 
 			if v.HasErrors() != tt.wantError {
 				t.Errorf("validateStringField(%q, %q, %q) hasError = %v, want %v",

--- a/config/validator_jobs_test.go
+++ b/config/validator_jobs_test.go
@@ -1,0 +1,190 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// The validator walks structs and used to skip maps, and every job lives in
+// one — so no job was ever reachable by it. A job with an unparsable schedule
+// passed validation, the daemon logged a warning and started, and the job
+// never fired. These pin that jobs are inspected, and that what is demanded of
+// them is what the runtime actually needs rather than whatever happens to lack
+// a default tag.
+
+// jobsConfig mirrors the real shape closely enough to exercise the traversal:
+// job sections are maps of name to a struct that embeds its runtime job, which
+// in turn embeds the fields every job shares.
+type BareJobFields struct {
+	Schedule string
+	Command  string
+}
+
+type ExecJobFields struct {
+	BareJobFields `mapstructure:",squash"`
+	Container     string
+}
+
+type RunJobFields struct {
+	BareJobFields `mapstructure:",squash"`
+	Image         string
+	Container     string
+}
+
+type jobsConfig struct {
+	ExecJobs  map[string]*ExecJobFields `gcfg:"job-exec"`
+	RunJobs   map[string]*RunJobFields  `gcfg:"job-run"`
+	LocalJobs map[string]*BareJobFields `gcfg:"job-local"`
+}
+
+func validateJobs(t *testing.T, cfg *jobsConfig) error {
+	t.Helper()
+	return NewConfigValidator(cfg).Validate()
+}
+
+// TestJobValidation_CatchesUnparsableSchedule is the case from the report: the
+// schedule is present, so no required-field check fires, but it cannot be
+// parsed and the job would never run.
+func TestJobValidation_CatchesUnparsableSchedule(t *testing.T) {
+	t.Parallel()
+
+	err := validateJobs(t, &jobsConfig{
+		LocalJobs: map[string]*BareJobFields{
+			"broken": {Schedule: "not-a-schedule", Command: "echo hi"},
+		},
+	})
+	if err == nil {
+		t.Fatal("an unparsable schedule was accepted")
+	}
+	if !strings.Contains(err.Error(), "broken") {
+		t.Errorf("the error does not name the offending job: %v", err)
+	}
+	if !strings.Contains(err.Error(), "cron") {
+		t.Errorf("the error does not say what is wrong with it: %v", err)
+	}
+}
+
+func TestJobValidation_AcceptsValidSchedules(t *testing.T) {
+	t.Parallel()
+
+	for _, schedule := range []string{"@every 30s", "@daily", "0 */5 * * * *", "0 0 * * *"} {
+		t.Run(schedule, func(t *testing.T) {
+			t.Parallel()
+			err := validateJobs(t, &jobsConfig{
+				LocalJobs: map[string]*BareJobFields{"ok": {Schedule: schedule, Command: "echo hi"}},
+			})
+			if err != nil {
+				t.Errorf("schedule %q was rejected: %v", schedule, err)
+			}
+		})
+	}
+}
+
+// TestJobValidation_RequiresWhatTheRuntimeNeeds covers the per-kind
+// requirements. Each case omits exactly one thing the job cannot run without.
+func TestJobValidation_RequiresWhatTheRuntimeNeeds(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		cfg     *jobsConfig
+		missing string
+	}{
+		{
+			name:    "job-local without a command",
+			cfg:     &jobsConfig{LocalJobs: map[string]*BareJobFields{"j": {Schedule: "@daily"}}},
+			missing: "command",
+		},
+		{
+			name:    "job without a schedule",
+			cfg:     &jobsConfig{LocalJobs: map[string]*BareJobFields{"j": {Command: "echo hi"}}},
+			missing: "schedule",
+		},
+		{
+			name: "job-exec without a container",
+			cfg: &jobsConfig{ExecJobs: map[string]*ExecJobFields{
+				"j": {BareJobFields: BareJobFields{Schedule: "@daily", Command: "echo hi"}},
+			}},
+			missing: "container",
+		},
+		{
+			name: "job-run without an image or a container",
+			cfg: &jobsConfig{RunJobs: map[string]*RunJobFields{
+				"j": {BareJobFields: BareJobFields{Schedule: "@daily"}},
+			}},
+			missing: "image or container",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateJobs(t, tc.cfg)
+			if err == nil {
+				t.Fatalf("a job missing %s was accepted", tc.missing)
+			}
+			if !strings.Contains(err.Error(), tc.missing) {
+				t.Errorf("the error does not name %q: %v", tc.missing, err)
+			}
+			if !strings.Contains(err.Error(), `"j"`) {
+				t.Errorf("the error does not name the job: %v", err)
+			}
+		})
+	}
+}
+
+// TestJobValidation_EitherOrIsSatisfiedByOne pins that job-run accepts an
+// image or an existing container, matching core.RunJob.Validate. Demanding
+// both would reject configurations that run today.
+func TestJobValidation_EitherOrIsSatisfiedByOne(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]*RunJobFields{
+		"image only":     {BareJobFields: BareJobFields{Schedule: "@daily"}, Image: "alpine:3.20"},
+		"container only": {BareJobFields: BareJobFields{Schedule: "@daily"}, Container: "existing"},
+		"both":           {BareJobFields: BareJobFields{Schedule: "@daily"}, Image: "alpine:3.20", Container: "existing"},
+	}
+
+	for name, job := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if err := validateJobs(t, &jobsConfig{RunJobs: map[string]*RunJobFields{"j": job}}); err != nil {
+				t.Errorf("a job-run with %s was rejected: %v", name, err)
+			}
+		})
+	}
+}
+
+// TestJobValidation_DoesNotDemandOptionalFields is the guard against the
+// obvious way to get this wrong. The rule that a field without a default tag
+// is required is tuned to the global section; letting it loose on jobs would
+// demand nearly every key a job can carry and reject configurations that work.
+func TestJobValidation_DoesNotDemandOptionalFields(t *testing.T) {
+	t.Parallel()
+
+	type WideJob struct {
+		BareJobFields `mapstructure:",squash"`
+		Container     string
+		User          string
+		Network       string
+		Workdir       string
+		Entrypoint    string
+	}
+	type wideConfig struct {
+		ExecJobs map[string]*WideJob `gcfg:"job-exec"`
+	}
+
+	// Everything the runtime needs is present; the rest is left empty on
+	// purpose, as most real configs do.
+	cfg := &wideConfig{ExecJobs: map[string]*WideJob{
+		"j": {BareJobFields: BareJobFields{Schedule: "@daily", Command: "echo hi"}, Container: "c"},
+	}}
+
+	if err := NewConfigValidator(cfg).Validate(); err != nil {
+		t.Errorf("optional job fields were demanded: %v", err)
+	}
+}

--- a/config/validator_mutation_test.go
+++ b/config/validator_mutation_test.go
@@ -454,7 +454,7 @@ func TestValidateStringField_DefaultTagConditions(t *testing.T) {
 			t.Parallel()
 			v := NewValidator()
 			field := reflect.ValueOf(tt.value)
-			cv.validateStringField(v, reflect.Value{}, field, tt.path, tt.defaultTag)
+			cv.validateStringField(v, field, fieldCtx{path: tt.path, defaultTag: tt.defaultTag})
 			if v.HasErrors() != tt.wantError {
 				t.Errorf("validateStringField(%q, %q, %q) hasErrors=%v, want %v",
 					tt.value, tt.path, tt.defaultTag, v.HasErrors(), tt.wantError)
@@ -826,7 +826,7 @@ func TestMut_Line280_DefaultTagEmptyString(t *testing.T) {
 		cv := &Validator2{sanitizer: NewSanitizer()}
 		v := NewValidator()
 		field := reflect.ValueOf("")
-		cv.validateStringField(v, reflect.Value{}, field, "schedule", "some-default")
+		cv.validateStringField(v, field, fieldCtx{path: "schedule", defaultTag: "some-default"})
 
 		if v.HasErrors() {
 			t.Error("empty value with default tag must skip validation (no error expected)")
@@ -838,7 +838,7 @@ func TestMut_Line280_DefaultTagEmptyString(t *testing.T) {
 		cv := &Validator2{sanitizer: NewSanitizer()}
 		v := NewValidator()
 		field := reflect.ValueOf("GARBAGE_CRON!!!")
-		cv.validateStringField(v, reflect.Value{}, field, "schedule", "some-default")
+		cv.validateStringField(v, field, fieldCtx{path: "schedule", defaultTag: "some-default"})
 
 		if !v.HasErrors() {
 			t.Error("non-empty value with default tag must still be validated (invalid cron → error)")
@@ -850,7 +850,7 @@ func TestMut_Line280_DefaultTagEmptyString(t *testing.T) {
 		cv := &Validator2{sanitizer: NewSanitizer()}
 		v := NewValidator()
 		field := reflect.ValueOf("")
-		cv.validateStringField(v, reflect.Value{}, field, "schedule", "") // no default, required
+		cv.validateStringField(v, field, fieldCtx{path: "schedule", defaultTag: ""}) // no default, required
 
 		if !v.HasErrors() {
 			t.Error("empty value without default on required field must produce error")
@@ -862,7 +862,7 @@ func TestMut_Line280_DefaultTagEmptyString(t *testing.T) {
 		cv := &Validator2{sanitizer: NewSanitizer()}
 		v := NewValidator()
 		field := reflect.ValueOf("")
-		cv.validateStringField(v, reflect.Value{}, field, "image", "") // no default, optional
+		cv.validateStringField(v, field, fieldCtx{path: "image", defaultTag: ""}) // no default, optional
 
 		if v.HasErrors() {
 			t.Error("empty value without default on optional field should not error")

--- a/e2e/config_validation_test.go
+++ b/e2e/config_validation_test.go
@@ -155,3 +155,58 @@ func TestE2E_Validate_WebCredentialsOnlyWhenAuthEnabled(t *testing.T) {
 		}
 	}
 }
+
+// TestE2E_Validate_RejectsUnparsableSchedule is the case #773 was opened for.
+//
+// The config parses as INI and is only wrong semantically: the schedule cannot
+// be parsed, so the scheduler refuses the job and it never runs. validate used
+// to accept it, because the validator walked structs and skipped maps — and
+// every job lives in one, so no job was reachable by it at all.
+func TestE2E_Validate_RejectsUnparsableSchedule(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeConfig(t, `[job-local "broken"]
+  schedule = not-a-schedule
+  command = echo hi
+`)
+
+	stdout, stderr, err := runCommand(t, "validate", "--config="+configPath)
+	assertExitCode(t, err, 1, stdout, stderr)
+
+	combined := stdout + stderr
+	for _, needle := range []string{"broken", "cron"} {
+		if !strings.Contains(combined, needle) {
+			t.Errorf("expected the error to mention %q, got:\nstdout=%s\nstderr=%s", needle, stdout, stderr)
+		}
+	}
+}
+
+// TestE2E_Validate_RejectsJobMissingWhatItNeeds covers the requirement side:
+// a job-exec with no container fails on every single run with
+// `run_exec container "": invalid container name or ID`. Catching it here
+// turns a job that fails forever into a config error caught before deployment.
+func TestE2E_Validate_RejectsJobMissingWhatItNeeds(t *testing.T) {
+	t.Parallel()
+
+	configPath := writeConfig(t, `[job-exec "no-container"]
+  schedule = @every 30s
+  command = echo hi
+`)
+
+	stdout, stderr, err := runCommand(t, "validate", "--config="+configPath)
+	assertExitCode(t, err, 1, stdout, stderr)
+
+	if !strings.Contains(stdout+stderr, "container") {
+		t.Errorf("expected the missing container to be named, got:\nstdout=%s\nstderr=%s", stdout, stderr)
+	}
+}
+
+// TestE2E_Validate_AcceptsTheShippedExample guards the other direction with
+// the configuration the project hands to new users: adding job checks must not
+// start rejecting it.
+func TestE2E_Validate_AcceptsTheShippedExample(t *testing.T) {
+	t.Parallel()
+
+	stdout, stderr, err := runCommand(t, "validate", "--config=../example/ofelia.ini")
+	assertExitCode(t, err, 0, stdout, stderr)
+}


### PR DESCRIPTION
Closes #773. Depends on nothing; complements #777, which fixed the daemon half.

## The validator never saw a job

It walks structs and skipped maps — and every job lives in one. So an unparsable schedule passed `validate` with the strict flag on or off, and the only later sign was a warning while the daemon started and the job never fired.

Two things were needed to reach a job's fields:

- **Job sections are maps**, so the walk descends into them.
- **Every job type embeds `core.<Kind>Job`, which embeds `BareJob`** — where `schedule` and `command` live. Squashed structs were skipped too, so even after traversing the maps the schedule stayed invisible. They are now descended into **only inside a job**, so the global section keeps the behaviour it had.

## Strict, but not the wrong kind of strict

Applying the existing rule to jobs would have rejected configurations that work today. *"A field with no `default` tag is required"* is a heuristic tuned to the global section; on a job it demands nearly every key a job can carry.

So that rule is suppressed inside jobs, and what a job needs is stated explicitly — taken from what the runtime already demands, not invented here:

| section | required | source |
|---|---|---|
| `job-exec` | `container`, `command` | `RunExec(ctx, j.Container, …)` |
| `job-run` | `image` **or** `container` | `core.RunJob.Validate` → `ErrImageOrContainer` |
| `job-service-run` | `image` | `core.RunServiceJob.Validate` → `ErrImageRequired` |
| `job-local` | `command` | `args.GetArgs(j.Command)` |
| `job-compose` | `file`, `service` | the `docker compose -f … run` it builds |
| all | `schedule` | nothing to register the job under otherwise |

Errors name the section and the job the user wrote:

```
config validation error for field 'job-exec "foo": container':
  is required (the container to exec in)
```

## Impact measured, not assumed

Every config in the repo still validates clean: `example/ofelia.ini`, `test/test-config.ini`, `test/run-job/ofelia.ini`. There is an e2e test pinning the shipped example specifically, so adding job checks cannot start rejecting the file new users are handed.

**One existing fixture had to change rather than the rule.** `TestValidateExecuteValidFile` declared a `job-exec` with no `container` and asserted the config was valid. It is not — verified against the running daemon, that job fails on *every tick*:

```
error: job run: exec run: run_exec container "": invalid container name or ID: value is empty
```

The test was pinning a config that cannot work. This is precisely the class of failure the change exists to catch, so the fixture gained a container.

## Note on the constants

`command`, `image`, `container` and `schedule` are now constants. They were literals in the format switch, which carried a comment arguing that extracting them only relocates duplication — true while they appeared once. The requirements table makes them appear in two independent lists with nothing tying them together, which is what goconst was pointing at.

## Test plan

- [x] `go test ./...` — green
- [x] `go test -race -tags=e2e ./e2e/...` — green
- [x] `golangci-lint run` incl. `--build-tags="e2e unix"` — 0 issues
- [x] `lefthook run pre-push` — exit 0
- [x] All three repo configs validate clean, before and after
- [x] Each requirement verified to fire, and each valid form verified to pass (including `job-run` with only a container)
