### PR TITLE
fix(health): report degraded while a configured job is not scheduled, and finish shutdown

### DIFF
--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -163,7 +163,25 @@ func (c *DaemonCommand) boot() (err error) {
 	if c.dockerHandler != nil {
 		dockerProvider = c.dockerHandler.GetDockerProvider()
 	}
-	c.healthChecker = web.NewHealthChecker(dockerProvider, c.scheduler, "1.0.0")
+	// The version was hardcoded to "1.0.0", so /health reported the same
+	// number for every build ever shipped and could not be used to tell which
+	// ofelia was answering. Dev builds have no ldflags and say so.
+	reportedVersion := Version
+	if reportedVersion == "" {
+		reportedVersion = "dev"
+	}
+	c.healthChecker = web.NewHealthChecker(dockerProvider, c.scheduler, reportedVersion)
+
+	// Stop the checker's periodic loop on shutdown, after the server that
+	// serves its result has gone (priority 20).
+	c.shutdownManager.RegisterHook(core.ShutdownHook{
+		Name:     "health-checker",
+		Priority: 30,
+		Hook: func(context.Context) error {
+			c.healthChecker.Stop()
+			return nil
+		},
+	})
 
 	// Create graceful scheduler with shutdown support
 	gracefulScheduler := core.NewGracefulScheduler(c.scheduler, c.shutdownManager)
@@ -264,11 +282,14 @@ func (c *DaemonCommand) start() error {
 	// Start listening for shutdown signals
 	c.shutdownManager.ListenForShutdown()
 
-	// Set up a goroutine to close done channel when shutdown completes
+	// Set up a goroutine to close done channel when shutdown completes.
+	//
+	// This waited on ShutdownChan, which is closed when shutdown *starts*, so
+	// the process exited while the hooks were still running: only the first
+	// priority group (the scheduler) ever ran, and the web server was never
+	// stopped gracefully despite the hook registered for it.
 	go func() {
-		<-c.shutdownManager.ShutdownChan()
-		// Give some time for graceful shutdown to complete
-		// The shutdown manager handles the actual shutdown process
+		<-c.shutdownManager.Done()
 		c.closeDone()
 	}()
 

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -163,7 +163,7 @@ func (c *DaemonCommand) boot() (err error) {
 	if c.dockerHandler != nil {
 		dockerProvider = c.dockerHandler.GetDockerProvider()
 	}
-	c.healthChecker = web.NewHealthChecker(dockerProvider, "1.0.0")
+	c.healthChecker = web.NewHealthChecker(dockerProvider, c.scheduler, "1.0.0")
 
 	// Create graceful scheduler with shutdown support
 	gracefulScheduler := core.NewGracefulScheduler(c.scheduler, c.shutdownManager)

--- a/core/scheduler.go
+++ b/core/scheduler.go
@@ -58,9 +58,15 @@ type Scheduler struct {
 	retryExecutor     *RetryExecutor
 	jobsByName        map[string]Job
 	disabledNames     map[string]struct{}
-	metricsRecorder   MetricsRecorder
-	clock             Clock
-	onJobComplete     func(jobName string, success bool)
+	// unschedulable records jobs the scheduler refused, keyed by name with the
+	// reason as the value. A refused job never runs, and the only earlier trace
+	// was a log line; keeping it here lets the health report say so, and covers
+	// jobs added long after startup from Docker labels as well as those from
+	// the config.
+	unschedulable   map[string]string
+	metricsRecorder MetricsRecorder
+	clock           Clock
+	onJobComplete   func(jobName string, success bool)
 }
 
 // concurrencySemaphore holds a swappable semaphore channel used by the
@@ -342,6 +348,7 @@ func (s *Scheduler) AddJob(j Job) error {
 // on demand via RunJob() which delegates to go-cron's TriggerEntryByName().
 func (s *Scheduler) AddJobWithTags(j Job, tags ...string) error {
 	if j.GetSchedule() == "" {
+		s.recordUnschedulable(j.GetName(), ErrEmptySchedule)
 		return ErrEmptySchedule
 	}
 
@@ -365,12 +372,17 @@ func (s *Scheduler) AddJobWithTags(j Job, tags ...string) error {
 			"Failed to register job %q - %q - %q",
 			j.GetName(), j.GetCommand(), j.GetSchedule(),
 		))
+		s.recordUnschedulable(j.GetName(), err)
 		return fmt.Errorf("add cron job: %w", err)
 	}
 	j.SetCronJobID(uint64(id))
 	s.mu.Lock()
 	s.Jobs = append(s.Jobs, j)
 	s.jobsByName[j.GetName()] = j
+	// A name that registers now is no longer unschedulable: a corrected config
+	// reloaded at runtime has to clear the old complaint, or the health report
+	// would stay degraded until a restart.
+	delete(s.unschedulable, j.GetName())
 	s.mu.Unlock()
 
 	if IsTriggeredSchedule(j.GetSchedule()) {
@@ -408,6 +420,9 @@ func (s *Scheduler) RemoveJob(j Job) error {
 		}
 	}
 	delete(s.jobsByName, j.GetName())
+	// A job removed from the config is no longer expected to run, so a past
+	// refusal stops being a complaint about the current state.
+	delete(s.unschedulable, j.GetName())
 	delete(s.disabledNames, j.GetName())
 	s.Removed = append(s.Removed, j)
 	s.mu.Unlock()
@@ -633,6 +648,34 @@ func (s *Scheduler) GetActiveJobs() []Job {
 		}
 	}
 	return jobs
+}
+
+// recordUnschedulable notes that a job was refused, so the health report can
+// say a configured job is not running rather than leaving it to whoever reads
+// the startup log.
+func (s *Scheduler) recordUnschedulable(name string, reason error) {
+	if name == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.unschedulable == nil {
+		s.unschedulable = make(map[string]string)
+	}
+	s.unschedulable[name] = reason.Error()
+}
+
+// GetUnschedulableJobs returns a copy of the jobs the scheduler refused,
+// keyed by job name with the reason as the value. Empty means every job that
+// was offered is registered.
+func (s *Scheduler) GetUnschedulableJobs() map[string]string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make(map[string]string, len(s.unschedulable))
+	for name, reason := range s.unschedulable {
+		out[name] = reason
+	}
+	return out
 }
 
 // getJob finds a job in the provided slice by name.

--- a/core/scheduler_unschedulable_test.go
+++ b/core/scheduler_unschedulable_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package core
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A refused job is remembered so /health can name it. That memory has to end
+// when the job does, or an operator who fixed the problem by deleting the job
+// would be left with a permanently degraded daemon and no job to blame it on.
+
+func TestSchedulerRecordsRefusedJob(t *testing.T) {
+	t.Parallel()
+
+	job := &TestJob{}
+	job.Name = "broken"
+	job.Schedule = "not-a-schedule"
+
+	sc := NewScheduler(newDiscardLogger())
+	require.Error(t, sc.AddJob(job))
+
+	refused := sc.GetUnschedulableJobs()
+	require.Contains(t, refused, "broken")
+	assert.NotEmpty(t, refused["broken"], "the recorded reason is what makes the report actionable")
+}
+
+// TestSchedulerRemoveJobClearsUnschedulable covers the removal half: dropping
+// the job from the config has to drop the complaint with it.
+func TestSchedulerRemoveJobClearsUnschedulable(t *testing.T) {
+	t.Parallel()
+
+	job := &TestJob{}
+	job.Name = "broken"
+	job.Schedule = "not-a-schedule"
+
+	sc := NewScheduler(newDiscardLogger())
+	require.Error(t, sc.AddJob(job))
+	require.Contains(t, sc.GetUnschedulableJobs(), "broken")
+
+	require.NoError(t, sc.RemoveJob(job))
+
+	assert.NotContains(t, sc.GetUnschedulableJobs(), "broken",
+		"a job removed from the config still held /health degraded")
+}
+
+// TestSchedulerGetUnschedulableJobsIsACopy pins that callers cannot reach into
+// the scheduler's state through the returned map: the health checker reads it
+// on every check, and a shared map would be a data race as well as a way to
+// silently erase a refusal.
+func TestSchedulerGetUnschedulableJobsIsACopy(t *testing.T) {
+	t.Parallel()
+
+	job := &TestJob{}
+	job.Name = "broken"
+	job.Schedule = "not-a-schedule"
+
+	sc := NewScheduler(newDiscardLogger())
+	require.Error(t, sc.AddJob(job))
+
+	delete(sc.GetUnschedulableJobs(), "broken")
+
+	assert.Contains(t, sc.GetUnschedulableJobs(), "broken")
+}

--- a/core/shutdown.go
+++ b/core/shutdown.go
@@ -22,6 +22,7 @@ type ShutdownManager struct {
 	hooks          []ShutdownHook
 	mu             sync.Mutex
 	shutdownChan   chan struct{}
+	doneChan       chan struct{}
 	isShuttingDown bool
 	logger         *slog.Logger
 }
@@ -43,6 +44,7 @@ func NewShutdownManager(logger *slog.Logger, timeout time.Duration) *ShutdownMan
 		timeout:      timeout,
 		hooks:        make([]ShutdownHook, 0),
 		shutdownChan: make(chan struct{}),
+		doneChan:     make(chan struct{}),
 		logger:       logger,
 	}
 }
@@ -88,6 +90,10 @@ func (sm *ShutdownManager) Shutdown() error {
 	}
 	sm.isShuttingDown = true
 	sm.mu.Unlock()
+
+	// Only one caller ever gets past the guard above, so this closes once and
+	// covers every return path below, including the timeout.
+	defer close(sm.doneChan)
 
 	sm.logger.Info(fmt.Sprintf("Starting graceful shutdown (timeout: %v)", sm.timeout))
 
@@ -179,6 +185,15 @@ func (sm *ShutdownManager) runHookGroup(ctx context.Context, hooks []ShutdownHoo
 // ShutdownChan returns a channel that's closed when shutdown starts
 func (sm *ShutdownManager) ShutdownChan() <-chan struct{} {
 	return sm.shutdownChan
+}
+
+// Done returns a channel that's closed once every hook has run.
+//
+// ShutdownChan only says shutdown *began* — it is closed before the first hook
+// executes. Anything that ends the process must wait on this instead, or the
+// later priority groups are killed mid-flight and never run at all.
+func (sm *ShutdownManager) Done() <-chan struct{} {
+	return sm.doneChan
 }
 
 // IsShuttingDown returns true if shutdown is in progress

--- a/core/shutdown_done_test.go
+++ b/core/shutdown_done_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package core
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The daemon ends the process when it sees shutdown finish. It used to watch
+// ShutdownChan, which is closed *before* the first hook runs, so everything
+// after the first priority group was killed mid-flight — the web server was
+// never stopped gracefully even though a hook was registered to do it. Done is
+// the signal that actually means finished, and these pin that meaning.
+
+func TestShutdownDoneClosesOnlyAfterEveryHookRan(t *testing.T) {
+	t.Parallel()
+
+	sm := NewShutdownManager(newDiscardLogger(), 5*time.Second)
+
+	var mu sync.Mutex
+	var ran []string
+	for _, h := range []struct {
+		name     string
+		priority int
+	}{{"first", 10}, {"second", 20}} {
+		sm.RegisterHook(ShutdownHook{
+			Name:     h.name,
+			Priority: h.priority,
+			Hook: func(context.Context) error {
+				mu.Lock()
+				defer mu.Unlock()
+				ran = append(ran, h.name)
+				return nil
+			},
+		})
+	}
+
+	select {
+	case <-sm.Done():
+		t.Fatal("Done was closed before shutdown had even started")
+	default:
+	}
+
+	require.NoError(t, sm.Shutdown())
+
+	select {
+	case <-sm.Done():
+	default:
+		t.Fatal("Done was not closed once Shutdown returned")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"first", "second"}, ran,
+		"every priority group has to run, in order, before Done closes")
+}
+
+// TestShutdownDoneClosesWhenAHookTimesOut pins the other half: a hook that
+// overruns the deadline must not leave whoever waits on Done blocked forever.
+func TestShutdownDoneClosesWhenAHookTimesOut(t *testing.T) {
+	t.Parallel()
+
+	sm := NewShutdownManager(newDiscardLogger(), 50*time.Millisecond)
+	sm.RegisterHook(ShutdownHook{
+		Name:     "overruns",
+		Priority: 10,
+		Hook: func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+
+	require.Error(t, sm.Shutdown())
+
+	select {
+	case <-sm.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("Done stayed open after a hook overran the shutdown timeout")
+	}
+}

--- a/e2e/graceful_shutdown_test.go
+++ b/e2e/graceful_shutdown_test.go
@@ -29,7 +29,16 @@ func TestE2E_GracefulShutdown_SIGTERM(t *testing.T) {
 `
 
 	configPath := writeConfig(t, configBody)
-	daemon := startDaemon(t, configPath)
+	// The web server is enabled so the shutdown exercises more than one hook
+	// priority group, which is what the completion assertion below is about.
+	//
+	// It is worth knowing what this test can and cannot catch: exiting without
+	// waiting for the hooks is a race, and a release build loses it every time
+	// (measured 0/5 completions), but this harness builds with -race, whose
+	// instrumentation reliably flips the outcome (5/5). So the assertion below
+	// would not have failed on the broken code here. The deterministic guard
+	// for that is TestShutdownDoneClosesOnlyAfterEveryHookRan in core.
+	daemon := startDaemon(t, configPath, "--enable-web", "--web-address="+reserveLoopbackAddr(t))
 	defer daemon.shutdown(t, 10*time.Second) // safety net in case signal is lost
 
 	// Let the scheduler tick at least once so there is actual work to
@@ -64,10 +73,16 @@ func TestE2E_GracefulShutdown_SIGTERM(t *testing.T) {
 
 	// Verify the shutdown banner is emitted — proves the signal reached
 	// ShutdownManager rather than the process being killed by a harness.
+	//
+	// The second needle used to be "graceful shutdown", which also matches
+	// "Starting graceful shutdown" — logged *before* the first hook runs. So
+	// this passed while the daemon exited mid-shutdown and every hook group
+	// after the first was killed in flight. Only the completion line requires
+	// that all of them actually finished.
 	out := daemon.stdout.String()
 	for _, needle := range []string{
 		"Received shutdown signal",
-		"graceful shutdown",
+		"Graceful shutdown completed successfully",
 	} {
 		if !strings.Contains(out, needle) {
 			t.Errorf("expected shutdown log to mention %q, got:\nstdout=%s",

--- a/web/auth_integration_test.go
+++ b/web/auth_integration_test.go
@@ -106,7 +106,7 @@ func TestServerWithAuthEnabled(t *testing.T) {
 
 	t.Run("health_endpoints_bypass_auth", func(t *testing.T) {
 		endpoints := []string{"/health", "/healthz", "/ready", "/live"}
-		hc := webpkg.NewHealthChecker(nil, "test")
+		hc := webpkg.NewHealthChecker(nil, nil, "test")
 		srv.RegisterHealthEndpoints(hc)
 
 		for _, ep := range endpoints {

--- a/web/health.go
+++ b/web/health.go
@@ -10,6 +10,8 @@ import (
 	"maps"
 	"net/http"
 	"runtime"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -64,17 +66,22 @@ type SystemInfo struct {
 type HealthChecker struct {
 	startTime      time.Time
 	dockerProvider core.DockerProvider
+	scheduler      *core.Scheduler
 	version        string
 	checks         map[string]HealthCheck
 	mu             sync.RWMutex
 	checkInterval  time.Duration
 }
 
-// NewHealthChecker creates a new health checker
-func NewHealthChecker(dockerProvider core.DockerProvider, version string) *HealthChecker {
+// NewHealthChecker creates a new health checker.
+//
+// The scheduler may be nil, in which case the scheduler check reports what it
+// can see rather than claiming health it has not established.
+func NewHealthChecker(dockerProvider core.DockerProvider, scheduler *core.Scheduler, version string) *HealthChecker {
 	hc := &HealthChecker{
 		startTime:      time.Now(),
 		dockerProvider: dockerProvider,
+		scheduler:      scheduler,
 		version:        version,
 		checks:         make(map[string]HealthCheck),
 		checkInterval:  30 * time.Second,
@@ -164,7 +171,20 @@ func (hc *HealthChecker) checkDocker() {
 	hc.mu.Unlock()
 }
 
-// checkScheduler verifies scheduler is operational
+// checkScheduler reports whether every configured job is actually registered.
+//
+// This used to answer "healthy" unconditionally, with a note that a real
+// implementation would check the scheduler. So a daemon with a mistyped
+// schedule — a job that never fires — still served a green /health, which is
+// the probe the integration docs tell operators to point their container
+// healthcheck at. The failure it was most worth reporting was the one it could
+// not see.
+//
+// A refused job makes this degraded rather than unhealthy on purpose: /ready
+// answers 503 only for unhealthy, and taking a daemon out of rotation because
+// one job of twenty has a typo would trade a silent failure for a louder one.
+// Degraded shows up in the body of /health and /healthz, where an operator or
+// an alert rule can act on it, without stopping the jobs that do work.
 func (hc *HealthChecker) checkScheduler() {
 	start := time.Now()
 	check := HealthCheck{
@@ -174,14 +194,33 @@ func (hc *HealthChecker) checkScheduler() {
 		Message:     "Scheduler is operational",
 	}
 
-	// In a real implementation, this would check the actual scheduler
-	// For now, we'll assume it's healthy if the service is running
+	if hc.scheduler == nil {
+		check.Status = HealthStatusDegraded
+		check.Message = "No scheduler wired to the health checker"
+	} else if refused := hc.scheduler.GetUnschedulableJobs(); len(refused) > 0 {
+		check.Status = HealthStatusDegraded
+		check.Message = fmt.Sprintf(
+			"%d configured job(s) are not scheduled and will not run: %s",
+			len(refused), strings.Join(sortedNames(refused), ", "),
+		)
+	}
 
 	check.Duration = time.Since(start)
 
 	hc.mu.Lock()
 	hc.checks["scheduler"] = check
 	hc.mu.Unlock()
+}
+
+// sortedNames returns the keys in a stable order, so the message does not
+// change between checks purely because Go randomizes map iteration.
+func sortedNames(m map[string]string) []string {
+	names := make([]string, 0, len(m))
+	for name := range m {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // checkSystemResources checks system resource usage

--- a/web/health.go
+++ b/web/health.go
@@ -71,6 +71,8 @@ type HealthChecker struct {
 	checks         map[string]HealthCheck
 	mu             sync.RWMutex
 	checkInterval  time.Duration
+	stop           chan struct{}
+	stopOnce       sync.Once
 }
 
 // NewHealthChecker creates a new health checker.
@@ -85,12 +87,23 @@ func NewHealthChecker(dockerProvider core.DockerProvider, scheduler *core.Schedu
 		version:        version,
 		checks:         make(map[string]HealthCheck),
 		checkInterval:  30 * time.Second,
+		stop:           make(chan struct{}),
 	}
 
 	// Start background health checks
 	go hc.runPeriodicChecks()
 
 	return hc
+}
+
+// Stop ends the periodic check loop.
+//
+// Without it the loop ran until the process exited, so every checker ever
+// constructed kept a goroutine alive — harmless for the daemon's single
+// long-lived instance, but tests that build one per case leaked one each.
+// Safe to call more than once and from several goroutines.
+func (hc *HealthChecker) Stop() {
+	hc.stopOnce.Do(func() { close(hc.stop) })
 }
 
 // runPeriodicChecks runs health checks periodically
@@ -101,8 +114,13 @@ func (hc *HealthChecker) runPeriodicChecks() {
 	// Run initial checks
 	hc.performAllChecks()
 
-	for range ticker.C {
-		hc.performAllChecks()
+	for {
+		select {
+		case <-hc.stop:
+			return
+		case <-ticker.C:
+			hc.performAllChecks()
+		}
 	}
 }
 

--- a/web/health_scheduler_test.go
+++ b/web/health_scheduler_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package web
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/netresearch/ofelia/core"
+	"github.com/netresearch/ofelia/test"
+)
+
+// The scheduler check answered "healthy" unconditionally, with a note saying a
+// real implementation would check the scheduler. So a daemon whose job had a
+// mistyped schedule — a job that never fires — still served a green /health,
+// which is the probe the integration docs tell operators to point a container
+// healthcheck at. These pin that it now reports what it can actually see.
+
+func newSchedulerWithJobs(t *testing.T, jobs ...core.Job) *core.Scheduler {
+	t.Helper()
+	s := core.NewScheduler(test.NewTestLogger())
+	for _, j := range jobs {
+		// Rejections are the point of several of these cases, so the error is
+		// deliberately not asserted here.
+		_ = s.AddJob(j)
+	}
+	return s
+}
+
+func localJob(name, schedule string) core.Job {
+	return &core.LocalJob{BareJob: core.BareJob{Name: name, Schedule: schedule, Command: "true"}}
+}
+
+// checkSchedulerNow runs the check once and returns what it recorded, without
+// waiting for the periodic loop.
+func checkSchedulerNow(t *testing.T, s *core.Scheduler) HealthCheck {
+	t.Helper()
+	hc := NewHealthChecker(nil, s, "test")
+	hc.checkScheduler()
+
+	hc.mu.RLock()
+	defer hc.mu.RUnlock()
+	return hc.checks["scheduler"]
+}
+
+func TestCheckScheduler_HealthyWhenEveryJobIsRegistered(t *testing.T) {
+	t.Parallel()
+
+	got := checkSchedulerNow(t, newSchedulerWithJobs(t,
+		localJob("a", "@every 1h"),
+		localJob("b", "@daily"),
+	))
+
+	if got.Status != HealthStatusHealthy {
+		t.Errorf("status = %q, want healthy (message: %s)", got.Status, got.Message)
+	}
+}
+
+// TestCheckScheduler_DegradedWhenAJobWasRefused is the case the stub could not
+// see: the daemon is running, but a configured job is not.
+func TestCheckScheduler_DegradedWhenAJobWasRefused(t *testing.T) {
+	t.Parallel()
+
+	got := checkSchedulerNow(t, newSchedulerWithJobs(t,
+		localJob("fine", "@every 1h"),
+		localJob("broken", "not-a-schedule"),
+	))
+
+	if got.Status != HealthStatusDegraded {
+		t.Fatalf("status = %q, want degraded", got.Status)
+	}
+	// The name is what turns the report into something actionable.
+	if !strings.Contains(got.Message, "broken") {
+		t.Errorf("message does not name the refused job: %q", got.Message)
+	}
+	if strings.Contains(got.Message, "fine") {
+		t.Errorf("message names a job that registered fine: %q", got.Message)
+	}
+}
+
+// TestCheckScheduler_RecoversWhenTheJobIsFixed covers the runtime half: a
+// config reloaded with the schedule corrected has to clear the complaint, or
+// the report would stay degraded until someone restarted the daemon.
+func TestCheckScheduler_RecoversWhenTheJobIsFixed(t *testing.T) {
+	t.Parallel()
+
+	s := newSchedulerWithJobs(t, localJob("job", "not-a-schedule"))
+	if got := checkSchedulerNow(t, s); got.Status != HealthStatusDegraded {
+		t.Fatalf("status before the fix = %q, want degraded", got.Status)
+	}
+
+	if err := s.AddJob(localJob("job", "@every 1h")); err != nil {
+		t.Fatalf("re-adding the corrected job: %v", err)
+	}
+
+	if got := checkSchedulerNow(t, s); got.Status != HealthStatusHealthy {
+		t.Errorf("status after the fix = %q, want healthy (message: %s)", got.Status, got.Message)
+	}
+}
+
+// TestCheckScheduler_NoSchedulerIsNotHealth pins that an unwired checker says
+// so rather than claiming health it has not established — the exact habit that
+// made the old stub useless.
+func TestCheckScheduler_NoSchedulerIsNotHealth(t *testing.T) {
+	t.Parallel()
+
+	if got := checkSchedulerNow(t, nil); got.Status == HealthStatusHealthy {
+		t.Errorf("a checker with no scheduler reported healthy: %q", got.Message)
+	}
+}

--- a/web/health_scheduler_test.go
+++ b/web/health_scheduler_test.go
@@ -34,14 +34,17 @@ func localJob(name, schedule string) core.Job {
 
 // checkSchedulerNow runs the check once and returns what it recorded, without
 // waiting for the periodic loop.
+//
+// The result is read back through GetHealth rather than off the checker's map,
+// so these keep passing when the storage behind the report changes; Stop ends
+// the loop the constructor starts, which otherwise outlives every case.
 func checkSchedulerNow(t *testing.T, s *core.Scheduler) HealthCheck {
 	t.Helper()
 	hc := NewHealthChecker(nil, s, "test")
+	t.Cleanup(hc.Stop)
 	hc.checkScheduler()
 
-	hc.mu.RLock()
-	defer hc.mu.RUnlock()
-	return hc.checks["scheduler"]
+	return hc.GetHealth().Checks["scheduler"]
 }
 
 func TestCheckScheduler_HealthyWhenEveryJobIsRegistered(t *testing.T) {

--- a/web/health_test.go
+++ b/web/health_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestHealthChecker(t *testing.T) {
-	hc := NewHealthChecker(nil, "1.0.0")
+	hc := NewHealthChecker(nil, nil, "1.0.0")
 
 	var health HealthResponse
 	testutil.Eventually(t, func() bool {
@@ -53,7 +53,7 @@ func TestHealthChecker(t *testing.T) {
 }
 
 func TestLivenessHandler(t *testing.T) {
-	hc := NewHealthChecker(nil, "1.0.0")
+	hc := NewHealthChecker(nil, nil, "1.0.0")
 	handler := hc.LivenessHandler()
 
 	req := httptest.NewRequest(http.MethodGet, "/live", nil)
@@ -73,7 +73,7 @@ func TestLivenessHandler(t *testing.T) {
 }
 
 func TestReadinessHandler(t *testing.T) {
-	hc := NewHealthChecker(nil, "1.0.0")
+	hc := NewHealthChecker(nil, nil, "1.0.0")
 
 	testutil.Eventually(t, func() bool {
 		return len(hc.GetHealth().Checks) > 0
@@ -110,7 +110,7 @@ func TestReadinessHandler(t *testing.T) {
 }
 
 func TestHealthHandler(t *testing.T) {
-	hc := NewHealthChecker(nil, "1.0.0")
+	hc := NewHealthChecker(nil, nil, "1.0.0")
 
 	testutil.Eventually(t, func() bool {
 		return len(hc.GetHealth().Checks) > 0
@@ -205,7 +205,7 @@ func TestHealthStatus(t *testing.T) {
 }
 
 func TestSystemResourceCheck(t *testing.T) {
-	hc := NewHealthChecker(nil, "1.0.0")
+	hc := NewHealthChecker(nil, nil, "1.0.0")
 
 	// Trigger system resource check
 	hc.checkSystemResources()

--- a/web/route_auth_test.go
+++ b/web/route_auth_test.go
@@ -51,7 +51,7 @@ func newAuthTestServer(t *testing.T) (*Server, *HealthChecker) {
 	srv := NewServerWithAuth("", core.NewScheduler(newDiscardLogger()), nil, nil, authCfg)
 	require.NotNil(t, srv, "NewServerWithAuth returned nil")
 
-	hc := NewHealthChecker(nil, "test")
+	hc := NewHealthChecker(nil, nil, "test")
 	srv.RegisterHealthEndpoints(hc)
 
 	t.Cleanup(func() {

--- a/web/server_mutation_test.go
+++ b/web/server_mutation_test.go
@@ -118,7 +118,7 @@ func TestRegisterHealthEndpoints_UIFSSubSuccess(t *testing.T) {
 	srv := NewServer("", sched, nil, nil)
 	require.NotNil(t, srv)
 
-	hc := NewHealthChecker(nil, "test-version")
+	hc := NewHealthChecker(nil, nil, "test-version")
 	// Give the health checker time to run initial checks.
 	time.Sleep(100 * time.Millisecond)
 	srv.RegisterHealthEndpoints(hc)

--- a/web/server_test.go
+++ b/web/server_test.go
@@ -792,7 +792,7 @@ func TestRegisterHealthEndpoints(t *testing.T) {
 	sched := core.NewScheduler(stubDiscardLogger())
 	srv := webpkg.NewServer("", sched, nil, nil)
 
-	hc := webpkg.NewHealthChecker(nil, "test-version")
+	hc := webpkg.NewHealthChecker(nil, nil, "test-version")
 	// Give the health checker time to run initial checks
 	time.Sleep(50 * time.Millisecond)
 


### PR DESCRIPTION
Closes #780. Follows from the #773 discussion: the daemon should not refuse to start on a rejected job, but it should stop claiming to be fine.

## The check could not see the failure it existed to report

```go
func (hc *HealthChecker) checkScheduler() {
    check := HealthCheck{Name: "scheduler", Status: HealthStatusHealthy,
                         Message: "Scheduler is operational"}

    // In a real implementation, this would check the actual scheduler
    // For now, we'll assume it's healthy if the service is running
```

A daemon with a mistyped schedule — a job that never fires — served a green `/health`, which is the probe `docs/INTEGRATION_PATTERNS.md` tells operators to point a container healthcheck at. After #777 the rejection is on stderr at startup, and nothing a monitoring system polls reflected it. Log lines get read once someone already suspects a problem.

## Where the state lives, and why there

The scheduler records the jobs it refuses, keyed by name with the reason.

Recording it in the scheduler rather than in the config loader is what makes this cover **jobs added long after startup** from Docker labels (`--docker-poll-interval`), not only those read from the INI at boot — every path that adds a job goes through `AddJob`. A name that later registers clears its own entry, as does removing the job, so a corrected config reloaded at runtime recovers **without a restart** instead of staying degraded until someone notices.

## Degraded, not unhealthy

Per the comment at `health.go:24`, only `unhealthy` makes `/ready` answer 503. Taking a daemon out of rotation because one job of twenty has a typo would trade a silent failure for a louder one. `degraded` appears in the body of `/health` and `/healthz`, where an operator or an alert rule can act on it, while the jobs that do work keep running.

## Verified against a running daemon

One good job and one unschedulable one:

```json
{ "status": "degraded",
  "checks": { "scheduler": {
      "status": "degraded",
      "message": "1 configured job(s) are not scheduled and will not run: broken" } } }
```

`/ready` still answers **200**. With both jobs valid it reports `healthy` with the original message.

A checker constructed without a scheduler reports `degraded` rather than `healthy` — claiming health it has not established is the habit that made the old stub useless. That widens `NewHealthChecker` by one parameter; the callers in tests pass `nil`.

## Test plan

- [x] `go test ./...` — green
- [x] `go test -race -tags=e2e ./e2e/...` — green
- [x] `golangci-lint run` incl. `--build-tags="e2e unix"` — 0 issues
- [x] `lefthook run pre-push` — exit 0
- [x] Both directions checked against the real binary and its HTTP endpoints, including that `/ready` stays 200
- [x] Recovery covered: a refused job that later registers clears the complaint


---

## Follow-up from review

Addressing the review found two further defects, both in the same family as the one above — a mechanism that looked like it worked because nothing checked whether it did.

### The health checker's loop could not be stopped

`runPeriodicChecks` ran `for range ticker.C` with no exit. Harmless for the daemon's single instance, a leaked goroutine per case in tests. `Stop()` ends it, and the daemon calls it via a shutdown hook.

### Shutdown ended the process before its hooks had run

Wiring that hook up showed it never ran. The daemon ended the process on `ShutdownChan`, which is closed when shutdown **starts**:

```go
<-c.shutdownManager.ShutdownChan()
// Give some time for graceful shutdown to complete   <- it does not
c.closeDone()
```

So only the first priority group ever executed. The web server has a hook registered to stop it gracefully, and that hook was killed mid-flight along with any request in progress. Measured on a release build, `SIGTERM` reached the end of shutdown in **0 of 5 runs**; with the fix, **5 of 5**.

The e2e test that covers shutdown asserted on the substring `"graceful shutdown"` — which also matches `"Starting graceful shutdown"`, logged *before* the first hook. That is why it stayed green. It now requires the completion line.

One caveat worth stating plainly: the e2e harness builds with `-race`, and the instrumentation reliably flips this race (5 of 5 runs complete even on the broken code). So the strengthened e2e assertion would **not** have caught this regression by itself. The deterministic guard is `TestShutdownDoneClosesOnlyAfterEveryHookRan` in `core`.

### `/health` reported a version of `1.0.0` for every build

Hardcoded at the call site, so the endpoint could not be used to tell which ofelia was answering. It now reports the build's version, or `dev` when there are no ldflags.

## Verification of the follow-up

```
$ ofelia daemon --config=… (log-level=debug, web enabled), then SIGTERM
Executing shutdown hook: scheduler (priority: 10)      ... completed successfully
Executing shutdown hook: http-server (priority: 20)    ... completed successfully
Executing shutdown hook: health-checker (priority: 30) ... completed successfully
Graceful shutdown completed successfully
```

Before the fix, that log ended after the `scheduler` hook.
