### PR TITLE
ci: adopt the template's zizmor policy comment

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -6,8 +6,9 @@ rules:
   unpinned-uses:
     config:
       policies:
-        # First-party reusable workflows track @main by policy and are
-        # never SHA-pinned, so fixes propagate to all consumers.
+        # First-party `uses:` — reusable workflows AND composite actions —
+        # track @main by policy and are never SHA-pinned, so a fix propagates
+        # to every consumer without a bump in dozens of repos.
         "netresearch/*": ref-pin
         # Everything else must be pinned to a full commit SHA.
         "*": hash-pin


### PR DESCRIPTION
`main` has been failing the template-drift check since 13:47Z today, and every open PR inherits it.

The go-app template reworded one comment in [netresearch/.github@00f5783](https://github.com/netresearch/.github/commit/00f57831) — from "reusable workflows" to "`uses:` — reusable workflows AND composite actions" — and this consumer was never synced. Only the comment differs; `"netresearch/*": ref-pin` and `"*": hash-pin` are byte-identical either side.

The file is now byte-identical to `templates/go-app/.github/zizmor.yml` (`sha256 bcf5a56f…`), which is what the drift job compares against.

Worth noting for the fleet: every other repo on the `go-app` template that has not adopted this comment is red for the same reason. This PR only fixes ofelia.
