### PR TITLE
docs: sync the health, shutdown and version documentation with the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`ofelia validate` now validates the jobs, not just the `[global]` section.** It checked global keys and stopped there, so a `[job-run]` without an `image` or a `[job-exec]` without a `container` passed the gate and then failed on every tick at runtime. Each job type is now checked for the fields its runtime actually requires, and the schedule and command are required everywhere ([#778](https://github.com/netresearch/ofelia/pull/778)).
+
 ### Fixed
 
+- **`/health` reports `degraded` while a configured job is not scheduled.** The scheduler check was a stub that returned `healthy` unconditionally, with a comment saying a real implementation would check the scheduler. So a daemon whose job had a mistyped schedule — a job that never fires — served a green `/health`, which is the probe the integration docs tell operators to point a container healthcheck at. The check now names every job the scheduler refused. `/ready` still answers 200 for `degraded`: one job with a typo should not take a daemon out of rotation while its other jobs keep running. A corrected config reloaded at runtime clears the complaint without a restart ([#780](https://github.com/netresearch/ofelia/issues/780)).
+- **Shutdown no longer ends the process before its hooks have run.** The daemon watched the channel that closes when shutdown *starts*, not when it finishes, so everything after the first priority group was killed mid-flight — the web server was never stopped gracefully despite having a hook registered to do it, cutting any request in progress. Measured on a release build, `SIGTERM` reached the end of shutdown in 0 of 5 runs before the fix and 5 of 5 after ([#781](https://github.com/netresearch/ofelia/pull/781)).
+- **`/health` reported a version of `1.0.0` for every build ever shipped.** It was hardcoded at the call site, so the endpoint could not be used to tell which ofelia was answering. It now reports the running build, or `dev` when built without ldflags ([#781](https://github.com/netresearch/ofelia/pull/781)).
+- **A job the scheduler rejects is now reported as such instead of being counted as running.** Five registration errors were discarded, and the startup line reported the number of jobs in the *config* rather than the number actually scheduled — so an operator saw a healthy daemon and a job that silently did nothing. The rejection is now logged at error level, naming the job, and the count describes what is really scheduled ([#777](https://github.com/netresearch/ofelia/pull/777)).
+- **A failing command now leaves a non-zero exit status.** `ofelia validate` and every other subcommand returned 0 after logging the error, so `ofelia validate … || exit 1` in a pipeline never fired and a broken config passed the gate that exists to stop it ([#771](https://github.com/netresearch/ofelia/pull/771)).
+- **`ofelia --config=x daemon` is accepted, not only `ofelia daemon --config=x`.** `--config` and `--log-level` were pre-parsed out of argv, which made them look global while the parser rejected them in the position a user would naturally write them ([#776](https://github.com/netresearch/ofelia/pull/776)).
+- **Web credentials are only required when web authentication is enabled.** Validation demanded them unconditionally, so a config with the web UI open and unauthenticated — the default — failed a check it should have passed ([#775](https://github.com/netresearch/ofelia/pull/775)).
+- **A container without a `Config` no longer crashes the daemon.** Two places dereferenced that pointer unguarded while converting Docker's response, which panics for any container the daemon reports without one ([#768](https://github.com/netresearch/ofelia/pull/768)).
 - **An expanded job output no longer collapses on its own.** The web UI refreshes every five seconds, and with a job's history panel open that refresh rebuilt the whole table from scratch. Every `<details>` element was re-created without its `open` attribute, so any output a user had expanded snapped shut within five seconds of opening it — long enough to start reading, not long enough to finish. The history table now records which outputs are expanded before it re-renders and restores them afterwards, keyed by the execution's timestamp rather than its row position, so an expanded output also stays open when a new run appears above it. Only the user collapses an output now ([#764](https://github.com/netresearch/ofelia/issues/764)).
+
+### Documentation
+
+- **The documented health endpoints did not exist.** `docs/API.md` and `docs/PROJECT_INDEX.md` described `GET /health/liveness` and `GET /health/readiness`; the daemon serves `/health`, `/healthz`, `/ready` and `/live`. Both response shapes were wrong too. The OpenAPI description of `/health` did not match the served body either — it named `uptime` instead of `uptimeSeconds`, described `checks` as booleans where each is an object, omitted `timestamp` and `system`, and documented a 503 that `/health` never returns. All four endpoints are now specified, with shared `HealthResponse`, `HealthCheck` and `SystemInfo` schemas.
+- **`durationMs` in the health report carries nanoseconds.** It serialises a Go `time.Duration`, which marshals as nanoseconds, so a local Docker ping reads `8332586` rather than `8`. The unit is now stated wherever the field is documented. The field name remains as-is; renaming it would break every existing consumer.
+
+### CI
+
+- The e2e shutdown test asserted on the substring `"graceful shutdown"`, which also matches `"Starting graceful shutdown"` — the line logged *before* the first hook. It stayed green while shutdown was broken, and now requires the completion line ([#781](https://github.com/netresearch/ofelia/pull/781)).
+- Test results are reported to Codecov Test Analytics ([#769](https://github.com/netresearch/ofelia/pull/769)).
+- The zizmor policy that exempts first-party reusable workflows from the pin rule now comes from the organisation-level reusable rather than a copy in this repository. It was added here in [#766](https://github.com/netresearch/ofelia/pull/766) and removed again in [#783](https://github.com/netresearch/ofelia/pull/783) once the reusable supplied it — a local file takes precedence over the fetched one, so leaving the copy behind would have pinned this repository to an ageing policy.
 
 ## [0.28.1] - 2026-07-28
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -315,33 +315,90 @@ POST /api/scheduler/reload
 
 ## Monitoring
 
+Four endpoints, all unauthenticated:
+
+| Endpoint | Body | Status code |
+|---|---|---|
+| `GET /health` | full report | always `200` |
+| `GET /healthz` | full report (alias) | always `200` |
+| `GET /ready` | full report | `503` when `unhealthy`, else `200` |
+| `GET /live` | `OK` as plain text | always `200` |
+
 ### Health Check
 ```http
-GET /health/liveness
+GET /health
 ```
+
+`/health` answers `200` even while reporting a problem — the verdict is in the
+body, so a monitoring system can read *why*. Point a probe that must fail at
+`/ready` instead.
 
 **Response:**
 ```json
 {
-  "status": "healthy",
-  "timestamp": "2024-01-01T12:00:00Z"
+  "status": "degraded",
+  "timestamp": "2026-08-02T16:55:52Z",
+  "uptimeSeconds": 41.2,
+  "version": "v0.28.1",
+  "checks": {
+    "docker": {
+      "name": "docker",
+      "status": "healthy",
+      "message": "Docker 29.6.2 running with 25 containers",
+      "lastChecked": "2026-08-02T16:55:52Z",
+      "durationMs": 8332586
+    },
+    "scheduler": {
+      "name": "scheduler",
+      "status": "degraded",
+      "message": "1 configured job(s) are not scheduled and will not run: broken",
+      "lastChecked": "2026-08-02T16:55:52Z",
+      "durationMs": 3180
+    },
+    "system": {
+      "name": "system",
+      "status": "healthy",
+      "message": "System resources normal",
+      "lastChecked": "2026-08-02T16:55:52Z",
+      "durationMs": 553638
+    }
+  },
+  "system": {
+    "goVersion": "go1.26.0",
+    "goroutines": 24,
+    "cpus": 8,
+    "memoryAllocBytes": 3512976,
+    "memoryTotalBytes": 12730376,
+    "gcRuns": 1
+  }
 }
 ```
+
+`status` is the worst status among the checks. `version` is the running build,
+or `dev` when built without ldflags. Note that `durationMs` carries
+**nanoseconds** despite its name — it serialises a Go `time.Duration`.
+
+The `scheduler` check reports `degraded` and names every configured job the
+scheduler refused, so a job that never fires — an unparsable schedule, a
+duplicate name — is visible to monitoring rather than only in the startup log.
 
 ### Readiness Check
 ```http
-GET /health/readiness
+GET /ready
 ```
 
-**Response:**
-```json
-{
-  "ready": true,
-  "scheduler": "running",
-  "docker": "connected",
-  "database": "n/a"
-}
+Same body as `/health`. The status code carries the verdict: `503` when the
+overall status is `unhealthy`, `200` otherwise. `degraded` deliberately stays
+`200` — one job with a typo should not take a daemon out of rotation while its
+other jobs keep running.
+
+### Liveness Check
+```http
+GET /live
 ```
+
+Answers `200` with the plain-text body `OK` as long as the process serves HTTP.
+It runs no checks, so it never reports on Docker or the scheduler.
 
 ### Prometheus Metrics
 ```http

--- a/docs/PROJECT_INDEX.md
+++ b/docs/PROJECT_INDEX.md
@@ -131,8 +131,9 @@ ofelia_circuit_breaker_*       # Circuit breaker states
 ```
 
 ### Health Endpoints
-- `/health/liveness`: Service availability
-- `/health/readiness`: Service readiness
+- `/health`, `/healthz`: Full health report, always 200 — the verdict is in the body
+- `/ready`: Same report, 503 when the overall status is `unhealthy`
+- `/live`: Plain-text `OK` as long as the process serves HTTP, runs no checks
 - `/metrics`: Prometheus metrics endpoint
 
 ## 🔌 API Reference

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -319,7 +319,10 @@ GET    /api/jobs/removed       # Removed jobs
 
 # Config & Health
 GET    /api/config             # Current configuration
-GET    /health                 # Health check
+GET    /health                 # Full report, always 200 - verdict is in the body
+GET    /healthz                # Alias of /health
+GET    /ready                  # Same report, 503 when unhealthy
+GET    /live                   # Plain-text OK, runs no checks
 GET    /metrics                # Prometheus metrics
 ```
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -438,7 +438,9 @@ SDK provider failed to connect to Docker: pinging docker: context deadline excee
 Docker API version negotiation timed out; continuing with default API version
 ```
 
-`/health` returns non-2xx within ~5 seconds; `/ready` reports `unhealthy` for the `docker` check.
+Within ~5 seconds the `docker` check turns `unhealthy`, which makes the overall
+status `unhealthy` and `/ready` answer **503**. `/health` still answers 200 —
+it always does — so read its body rather than its status code.
 
 `ofelia doctor` reports each Docker call individually (Ping ~5s, `HasImageLocally` ~5s per image).
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -116,53 +116,79 @@ paths:
 
   /health:
     get:
-      summary: Health check endpoint
+      summary: Detailed health report
+      description: >-
+        Always answers 200, including while the report says `degraded` or
+        `unhealthy` — the status is in the body, not the status code, so a
+        monitoring system can read *why* rather than only that something is
+        wrong. Use /ready for a probe that fails the request.
       tags:
         - Monitoring
       security: []
       responses:
         '200':
-          description: Service is healthy
+          description: The current report, whatever its status
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  status:
-                    type: string
-                    enum: [healthy, degraded, unhealthy]
-                    example: healthy
-                  uptime:
-                    type: number
-                    description: Uptime in seconds
-                    example: 3600
-                  version:
-                    type: string
-                    example: "1.1.0"
-                  checks:
-                    type: object
-                    properties:
-                      docker:
-                        type: boolean
-                        example: true
-                      scheduler:
-                        type: boolean
-                        example: true
+                $ref: '#/components/schemas/HealthResponse'
+
+  /healthz:
+    get:
+      summary: Detailed health report (alias of /health)
+      tags:
+        - Monitoring
+      security: []
+      responses:
+        '200':
+          description: The current report, whatever its status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+
+  /ready:
+    get:
+      summary: Readiness probe
+      description: >-
+        Same body as /health, but the status code carries the verdict: 503 when
+        the overall status is `unhealthy`, 200 otherwise. `degraded` stays 200
+        on purpose — one job with an unparsable schedule should not take the
+        whole daemon out of rotation while its other jobs keep running.
+      tags:
+        - Monitoring
+      security: []
+      responses:
+        '200':
+          description: Ready — overall status is `healthy` or `degraded`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
         '503':
-          description: Service unhealthy
+          description: Not ready — overall status is `unhealthy`
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  status:
-                    type: string
-                    example: unhealthy
-                  errors:
-                    type: array
-                    items:
-                      type: string
-                    example: ["Docker connection failed"]
+                $ref: '#/components/schemas/HealthResponse'
+
+  /live:
+    get:
+      summary: Liveness probe
+      description: >-
+        Answers as long as the process serves HTTP at all. It runs no checks,
+        so it never reports on Docker or the scheduler.
+      tags:
+        - Monitoring
+      security: []
+      responses:
+        '200':
+          description: The process is running
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: OK
 
   /jobs:
     get:
@@ -327,6 +353,86 @@ components:
       description: Session cookie authentication
 
   schemas:
+    HealthCheck:
+      type: object
+      description: One individual check within the health report.
+      properties:
+        name:
+          type: string
+          example: scheduler
+        status:
+          type: string
+          enum: [healthy, degraded, unhealthy]
+          example: degraded
+        message:
+          type: string
+          description: Omitted when empty.
+          example: "1 configured job(s) are not scheduled and will not run: broken"
+        lastChecked:
+          type: string
+          format: date-time
+        durationMs:
+          type: integer
+          format: int64
+          description: >-
+            How long the check took, in **nanoseconds** despite the field name —
+            it serialises a Go time.Duration, which marshals as nanoseconds. A
+            local Docker ping reports roughly 8000000 here, i.e. 8 ms.
+          example: 8332586
+      required: [name, status, lastChecked, durationMs]
+
+    HealthResponse:
+      type: object
+      description: >-
+        The body served by /health, /healthz and /ready. `status` is the worst
+        status among `checks`: any unhealthy check makes the whole report
+        unhealthy, otherwise any degraded check makes it degraded.
+      properties:
+        status:
+          type: string
+          enum: [healthy, degraded, unhealthy]
+          example: degraded
+        timestamp:
+          type: string
+          format: date-time
+        uptimeSeconds:
+          type: number
+          example: 3600
+        version:
+          type: string
+          description: >-
+            The running build's version, or `dev` when built without ldflags.
+          example: v0.28.1
+        checks:
+          type: object
+          description: Keyed by check name — `docker`, `scheduler` and `system`.
+          additionalProperties:
+            $ref: '#/components/schemas/HealthCheck'
+        system:
+          $ref: '#/components/schemas/SystemInfo'
+      required: [status, timestamp, uptimeSeconds, version, checks, system]
+
+    SystemInfo:
+      type: object
+      properties:
+        goVersion:
+          type: string
+          example: go1.26.0
+        goroutines:
+          type: integer
+          example: 24
+        cpus:
+          type: integer
+          example: 8
+        memoryAllocBytes:
+          type: integer
+          format: int64
+        memoryTotalBytes:
+          type: integer
+          format: int64
+        gcRuns:
+          type: integer
+
     Job:
       type: object
       properties:

--- a/docs/packages/core.md
+++ b/docs/packages/core.md
@@ -130,6 +130,23 @@ type Scheduler struct {
 - `Start()`: Begin scheduling
 - `Stop()`: Graceful shutdown
 - `RunJob()`: Manual job trigger
+- `GetUnschedulableJobs()`: Jobs the scheduler refused, keyed by name with the
+  reason. A job whose schedule will not parse is configured but never runs, so
+  the health check reports it instead of leaving it in a startup log line. A
+  name that later registers clears its own entry, as does removing the job, so
+  a corrected config reloaded at runtime recovers without a restart. The
+  returned map is a copy.
+
+**Shutdown:** `ShutdownManager` runs hooks in priority groups, lowest first,
+each group completing before the next starts.
+
+- `ShutdownChan()` closes when shutdown **starts** — before the first hook runs.
+- `Done()` closes when every group has finished, including the path where a
+  hook overruns the timeout.
+
+Anything that ends the process must wait on `Done()`. Waiting on
+`ShutdownChan()` ends it while the hooks are still running, which leaves every
+group after the first killed in flight.
 
 ### Context
 

--- a/docs/packages/web.md
+++ b/docs/packages/web.md
@@ -166,16 +166,26 @@ const (
 
 **Checks Performed**:
 1. **Docker Connectivity**: Ping Docker daemon, get container count
-2. **Scheduler Status**: Verify scheduler is operational
+2. **Scheduler Status**: `healthy` while every configured job is scheduled.
+   `degraded` — naming each one — as soon as the scheduler refuses a job, since
+   an unparsable schedule or a duplicate name means that job never fires. A
+   checker constructed without a scheduler is also `degraded`, rather than
+   claiming health it cannot establish.
 3. **System Resources**: Monitor memory usage (healthy <75%, degraded <90%, unhealthy ≥90%)
 
 **Usage**:
 ```go
-// Create health checker
-healthChecker := web.NewHealthChecker(dockerClient, "1.0.0")
+// Create health checker. The scheduler may be nil, at the cost of the check
+// above; the version is what /health reports.
+healthChecker := web.NewHealthChecker(dockerClient, scheduler, cli.Version)
 
 // Register health endpoints
 server.RegisterHealthEndpoints(healthChecker)
+
+// The constructor starts a background loop that re-runs every check every 30s.
+// Stop ends it; the daemon calls this from a shutdown hook. Safe to call more
+// than once.
+defer healthChecker.Stop()
 
 // Health endpoints available:
 // GET /health     - Detailed health information (always 200 OK)
@@ -190,21 +200,21 @@ server.RegisterHealthEndpoints(healthChecker)
   "status": "healthy",
   "timestamp": "2025-01-15T10:30:00Z",
   "uptimeSeconds": 3600.5,
-  "version": "1.0.0",
+  "version": "v0.28.1",
   "checks": {
     "docker": {
       "name": "docker",
       "status": "healthy",
       "message": "Docker 24.0.7 running with 5 containers",
       "lastChecked": "2025-01-15T10:30:00Z",
-      "durationMs": 12
+      "durationMs": 8332586
     },
     "scheduler": {
       "name": "scheduler",
       "status": "healthy",
       "message": "Scheduler is operational",
       "lastChecked": "2025-01-15T10:30:00Z",
-      "durationMs": 1
+      "durationMs": 3180
     },
     "system": {
       "name": "system",
@@ -468,7 +478,8 @@ func main() {
     server := web.NewServer(":8080", scheduler, config, dockerClient)
 
     // Create health checker
-    healthChecker := web.NewHealthChecker(dockerClient, "1.0.0")
+    healthChecker := web.NewHealthChecker(dockerClient, scheduler, cli.Version)
+    defer healthChecker.Stop()
     server.RegisterHealthEndpoints(healthChecker)
 
     // Start server


### PR DESCRIPTION
The behaviour changed in #781 and the four PRs before it; the documentation did not. Auditing it against the code turned up errors older than any of those changes.

## Endpoints that do not exist

`docs/API.md` and `docs/PROJECT_INDEX.md` documented `GET /health/liveness` and `GET /health/readiness`. The daemon serves `/health`, `/healthz`, `/ready` and `/live` — `web/server.go:278-281`. Anyone who wired a probe from those docs pointed it at a 404. Both response shapes were invented too: readiness was documented as `{"ready": true, "scheduler": "running", "docker": "connected", "database": "n/a"}` and serves a full `HealthResponse`; `/live` serves the plain-text body `OK`, not JSON.

## An OpenAPI description that did not match the body

`/health` was the only health path in the spec, and its schema disagreed with the struct on nearly every field: `uptime` where the JSON key is `uptimeSeconds`, `checks` as a map of booleans where each value is an object with five fields, no `timestamp`, no `system`, and a `503` response that `/health` never returns — it always answers `200` and puts the verdict in the body. All four endpoints are now specified against shared `HealthResponse`, `HealthCheck` and `SystemInfo` schemas.

## `durationMs` carries nanoseconds

Worth stating plainly because it is a live trap for anyone reading the endpoint: the field serialises a Go `time.Duration`, which marshals as nanoseconds. A local Docker ping reports `8332586` — 8.3 ms, not 2.3 hours. Verified against a running daemon. The unit is now documented wherever the field appears. The name is left alone: renaming it would break every existing consumer, and that is an API decision, not a docs one.

## Brought in line with the merged behaviour

- The scheduler check is no longer a stub, so it reports `degraded` and names every job the scheduler refused; a checker with no scheduler says so rather than claiming health.
- `NewHealthChecker` takes the scheduler and the build's version — the two-argument form with a hardcoded `"1.0.0"` appeared twice in `docs/packages/web.md`.
- The checker has a `Stop`, and the daemon calls it from a shutdown hook.
- `docs/packages/core.md` now distinguishes `ShutdownChan()` (closes when shutdown *starts*) from `Done()` (closes when every hook group has finished), which is exactly the confusion that let the process exit mid-shutdown.
- `docs/TROUBLESHOOTING.md` claimed `/health` returns non-2xx when Docker is unreachable. It does not; `/ready` returns 503.

## Changelog

`Unreleased` listed only the collapsing-output fix while eight further user-facing changes had merged. No version bump — this records what is already on `main`.

## Verification

- `yq -e '.' docs/openapi.yaml` parses; all three new `$ref` targets resolve
- No `health/liveness` or `health/readiness` remains anywhere but the changelog entry describing the fix
- Every documented shape and message checked against `web/health.go`, `web/server.go` and a live `/health` capture — the "healthy" scheduler message is still `Scheduler is operational`, which an earlier draft of this PR had wrongly rewritten
- `lefthook run pre-push` exit 0
