### PR TITLE
docs(changelog): cut 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-08-03
+
+A release about ofelia telling the truth about itself. A job the scheduler
+refused was reported as scheduled, `/health` claimed health it had never
+established, `validate` returned success on a config it had not checked, and
+shutdown ended the process before the hooks that stop the web server had run.
+Each of those looked fine from the outside, which is what made them worth
+fixing.
+
+Three changes alter behaviour you may be relying on. `ofelia validate` now
+exits non-zero when validation fails, so a pipeline step that silently passed
+will start failing — that is the point, but check yours before upgrading. That
+same command now also validates the jobs, so a config that passed before may
+not. And `/health` can now answer `degraded`; `/ready` is unchanged and still
+answers 200 for it.
+
 ### Added
 
 - **`ofelia validate` now validates the jobs, not just the `[global]` section.** It checked global keys and stopped there, so a `[job-run]` without an `image` or a `[job-exec]` without a `container` passed the gate and then failed on every tick at runtime. Each job type is now checked for the fields its runtime actually requires, and the schedule and command are required everywhere ([#778](https://github.com/netresearch/ofelia/pull/778)).


### PR DESCRIPTION
Cuts the accumulated `Unreleased` entries into `0.29.0`. No code changes; the version comes from the git tag via GoReleaser, so there is no version file to raise.

## Why minor rather than patch

No commit in `v0.28.1..HEAD` declares a breaking change, and the 56 commits are 15 `fix`, 13 `test`, 6 `ci`, 3 `docs`, 2 `feat`. The prefixes are not what decides it — three changes alter behaviour a user can be relying on, and they belong somewhere more visible than a patch:

- `ofelia validate` now exits non-zero when validation fails. A pipeline step that silently passed will start failing. That is exactly the defect being fixed, but it is a change worth seeing before an upgrade.
- That same command now validates the jobs, not only `[global]`, so a config that passed before may not.
- `/health` can now answer `degraded` where it always said `healthy`. `/ready` is unchanged and still answers 200 for `degraded`.

All three are named in the release's lead paragraph rather than left for a reader to find among the entries.

## Release readiness, checked

- `main` CI: 6 of 6 green — CI, CodeQL, Gitleaks, Zizmor, Template Drift, OpenSSF Scorecard
- No open pull requests
- **0 unresolved review threads** across all 14 pull requests merged since v0.28.1, counted per-PR via GraphQL rather than inferred from a green rollup
- No open issue is a release blocker; the 15 open ones are feature requests and upstream ports
- `## [Unreleased]` is left in place and empty, matching [cf61546](https://github.com/netresearch/ofelia/commit/cf61546)

`lefthook run pre-push` exit 0.

Tagging is deliberately not part of this PR — pushing `v0.29.0` triggers GoReleaser and the SLSA provenance build, per `CONTRIBUTING.md`.
