### PR TITLE
fix(security): move the toolchain to go1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/netresearch/ofelia
 
 go 1.26
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2


### PR DESCRIPTION
`go-check / govulncheck` is failing on every pull request in this repository, and nothing in the tree caused it.

## The findings

Six, all in the Go standard library, none in a dependency:

| | package | fixed in |
|---|---|---|
| GO-2026-6218 | `net/url` | go1.26.6 |
| GO-2026-6091 | `html/template` | go1.26.6 |
| GO-2026-6090 | `crypto/tls` | go1.26.6 |
| GO-2026-6089 | `net/http` | go1.26.6 |
| GO-2026-5972 | `encoding/asn1` | go1.26.6 |
| GO-2026-5026 | `net/http` | go1.26.6 |

Each was found reachable — govulncheck's symbol results name real call paths, for example `middlewares/slack.go:118` reaching `url.URL.Parse` through `http.Client.Do`, and `middlewares/mail.go:287` reaching `template.Template.Execute`. So these are not theoretical for this binary.

## The change

`go.mod` said `toolchain go1.26.5`. go1.26.6 is the current stable release, checked against `go.dev/dl` rather than assumed. It is the only version pin in the repository — a repo-wide sweep for the old string returns nothing else.

The reusable `go-check` workflow resolves its toolchain from `go-version-file`, which defaults to `go.mod`, so this one line is what CI installs. `GOTOOLCHAIN` is set to `local` in the govulncheck step, meaning Go will not silently fetch a different toolchain than the one set up — which is why the `go.mod` line has to be the thing that moves.

## Verification

**Not run locally**, and saying so rather than implying otherwise: this is a toolchain bump whose effect only shows under the CI-installed Go. The check that was failing is the one that has to report on this, and `govulncheck-strict=true` means it will fail loudly rather than warn if six findings become five.

Found while trying to merge #795, which is a harden-runner bump that inherited this failure and cannot merge until it clears.
