### PR TITLE
chore: Go 1.27 toolchain, lint fixes, go fix modernization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ The project's lefthook `commit-msg` hook validates the presence of
 
 ### Prerequisites
 
-- Go 1.25 or higher
+- Go 1.26 or higher
 - Docker (for integration and E2E tests)
 - Docker Swarm enabled (for service job tests)
 

--- a/Makefile
+++ b/Makefile
@@ -54,14 +54,14 @@ tidy:
 .PHONY: lint
 lint:
 	@mkdir -p $(BUILD_PATH)/.tools
-	@GOTOOLCHAIN=go1.26.5 GOBIN=$(BUILD_PATH)/.tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+	@GOTOOLCHAIN=go1.27.0 GOBIN=$(BUILD_PATH)/.tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	@$(BUILD_PATH)/.tools/golangci-lint version || true
 	@$(BUILD_PATH)/.tools/golangci-lint run --timeout=5m
 
 .PHONY: lint-fix
 lint-fix:
 	@mkdir -p $(BUILD_PATH)/.tools
-	@GOTOOLCHAIN=go1.26.5 GOBIN=$(BUILD_PATH)/.tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+	@GOTOOLCHAIN=go1.27.0 GOBIN=$(BUILD_PATH)/.tools go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	@$(BUILD_PATH)/.tools/golangci-lint run --fix --timeout=5m
 
 .PHONY: lint-full

--- a/cli/config_decode.go
+++ b/cli/config_decode.go
@@ -168,7 +168,7 @@ func mapstructureKeyForField(field reflect.StructField) string {
 		return ""
 	}
 	if tag != "" {
-		if name := strings.SplitN(tag, ",", 2)[0]; name != "" && name != "-" {
+		if name, _, _ := strings.Cut(tag, ","); name != "" && name != "-" {
 			return name
 		}
 	}

--- a/cli/config_drift_test.go
+++ b/cli/config_drift_test.go
@@ -76,7 +76,7 @@ func assertDocumented(t *testing.T, docs string, f reflect.StructField, containe
 	if tag == "" {
 		return
 	}
-	name := strings.SplitN(tag, ",", 2)[0]
+	name, _, _ := strings.Cut(tag, ",")
 	if name == "" || name == "-" {
 		return // squash on the embed itself, or explicitly ignored
 	}

--- a/cli/config_webhook.go
+++ b/cli/config_webhook.go
@@ -405,7 +405,7 @@ func applyWebhookLabelParams(config *middlewares.WebhookConfig, params map[strin
 			config.Preset = val
 		case "id":
 			config.ID = val
-		case "secret": //nolint:goconst // matches gcfg:"secret" struct tag — Go syntax requires literal in tag
+		case "secret":
 			config.Secret = val
 		case "url":
 			config.URL = val

--- a/cli/docker-labels.go
+++ b/cli/docker-labels.go
@@ -527,7 +527,7 @@ func (c *Config) filterGlobalLabelKey(key, value, containerName string, globalCo
 
 func hasServiceLabel(labels map[string]string) bool {
 	for k, v := range labels {
-		if k == serviceLabel && v == "true" { //nolint:goconst // Docker labels are stringly-typed — value is the literal "true"
+		if k == serviceLabel && v == "true" {
 			return true
 		}
 	}

--- a/cli/doctor_docker_timeout_test.go
+++ b/cli/doctor_docker_timeout_test.go
@@ -86,9 +86,13 @@ func (h *hangingDoctorProvider) InspectExec(_ context.Context, _ string) (*domai
 func (h *hangingDoctorProvider) RunExec(_ context.Context, _ string, _ *domain.ExecConfig, _, _ io.Writer) (int, error) {
 	return 0, nil
 }
-func (h *hangingDoctorProvider) PullImage(_ context.Context, _ string) error           { return nil }
+
+func (h *hangingDoctorProvider) PullImage(_ context.Context, _ string) error { return nil }
+
 func (h *hangingDoctorProvider) EnsureImage(_ context.Context, _ string, _ bool) error { return nil }
-func (h *hangingDoctorProvider) ConnectNetwork(_ context.Context, _, _ string) error   { return nil }
+
+func (h *hangingDoctorProvider) ConnectNetwork(_ context.Context, _, _ string) error { return nil }
+
 func (h *hangingDoctorProvider) FindNetworkByName(_ context.Context, _ string) ([]domain.Network, error) {
 	return nil, nil
 }

--- a/config/validator.go
+++ b/config/validator.go
@@ -387,11 +387,11 @@ func (cv *Validator2) validateSpecificStringField(v *Validator, path string, str
 	switch fieldKey(path) {
 	case keySchedule, "cron":
 		cv.validateCronField(v, path, str)
-	case "email-to", "email-from": //nolint:goconst // see comment above switch
+	case "email-to", "email-from":
 		cv.validateEmailField(v, path, str)
 	case "web-address", "pprof-address":
 		cv.validateAddressField(v, path, str)
-	case "log-level": //nolint:goconst // see comment above switch
+	case "log-level":
 		cv.validateLogLevelField(v, path, str)
 	case keyCommand, "cmd":
 		cv.validateCommandField(v, path, str)

--- a/core/adapters/docker/service_convert_test.go
+++ b/core/adapters/docker/service_convert_test.go
@@ -110,9 +110,9 @@ func TestConvertToSwarmSpec(t *testing.T) {
 					ContainerSpec: domain.ContainerSpec{Image: "nginx"},
 					RestartPolicy: &domain.ServiceRestartPolicy{
 						Condition:   domain.RestartConditionOnFailure,
-						Delay:       durationPtr(5 * time.Second),
-						MaxAttempts: uint64Ptr(3),
-						Window:      durationPtr(2 * time.Minute),
+						Delay:       new(5 * time.Second),
+						MaxAttempts: new(uint64(3)),
+						Window:      new(2 * time.Minute),
 					},
 				},
 			},
@@ -219,7 +219,7 @@ func TestConvertToSwarmSpec(t *testing.T) {
 					ContainerSpec: domain.ContainerSpec{Image: "nginx"},
 				},
 				Mode: domain.ServiceMode{
-					Replicated: &domain.ReplicatedService{Replicas: uint64Ptr(3)},
+					Replicated: &domain.ReplicatedService{Replicas: new(uint64(3))},
 				},
 			},
 			validate: func(t *testing.T, result swarm.ServiceSpec) {
@@ -451,11 +451,3 @@ func TestConvertFromSwarmTask(t *testing.T) {
 }
 
 // --- Helper functions ---
-
-func durationPtr(d time.Duration) *time.Duration {
-	return &d
-}
-
-func uint64Ptr(v uint64) *uint64 {
-	return &v
-}

--- a/core/adapters/docker/service_roundtrip_test.go
+++ b/core/adapters/docker/service_roundtrip_test.go
@@ -166,9 +166,9 @@ func TestServiceSpec_RoundTrip_RestartPolicy(t *testing.T) {
 			},
 			RestartPolicy: &domain.ServiceRestartPolicy{
 				Condition:   domain.RestartConditionOnFailure,
-				Delay:       durationPtr(10 * time.Second),
-				MaxAttempts: uint64Ptr(5),
-				Window:      durationPtr(3 * time.Minute),
+				Delay:       new(10 * time.Second),
+				MaxAttempts: new(uint64(5)),
+				Window:      new(3 * time.Minute),
 			},
 		},
 	}
@@ -251,7 +251,7 @@ func TestServiceSpec_RoundTrip_ModeReplicated(t *testing.T) {
 		},
 		Mode: domain.ServiceMode{
 			Replicated: &domain.ReplicatedService{
-				Replicas: uint64Ptr(3),
+				Replicas: new(uint64(3)),
 			},
 		},
 	}

--- a/core/docker_sdk_provider.go
+++ b/core/docker_sdk_provider.go
@@ -397,7 +397,7 @@ func (p *SDKDockerProvider) FindNetworkByName(ctx context.Context, networkName s
 
 	opts := domain.NetworkListOptions{
 		Filters: map[string][]string{
-			"name": {networkName}, //nolint:goconst // Docker SDK filter key — coincidental collision with other "name" string literals
+			"name": {networkName},
 		},
 	}
 

--- a/core/resilience.go
+++ b/core/resilience.go
@@ -304,7 +304,7 @@ func (cb *CircuitBreaker) GetMetrics() map[string]any {
 	defer cb.mu.Unlock()
 
 	return map[string]any{
-		"name":             cb.name, //nolint:goconst // metrics map key — coincidental collision with other "name" literals
+		"name":             cb.name,
 		"state":            cb.state.String(),
 		"total_calls":      atomic.LoadUint64(&cb.totalCalls),
 		"total_successes":  atomic.LoadUint64(&cb.totalSuccesses),

--- a/core/runjob_unit_test.go
+++ b/core/runjob_unit_test.go
@@ -453,8 +453,7 @@ func TestRunJobUnit_WatchContainer(t *testing.T) {
 					t.Errorf("expected ErrUnexpected, got %v", err)
 				}
 			} else {
-				var nze NonZeroExitError
-				if !errors.As(err, &nze) {
+				if _, ok := errors.AsType[NonZeroExitError](err); !ok {
 					t.Errorf("expected NonZeroExitError, got %T: %v", err, err)
 				}
 			}

--- a/core/scheduler.go
+++ b/core/scheduler.go
@@ -448,7 +448,9 @@ func (s *Scheduler) RemoveJobsByTag(tag string) int {
 	defer s.mu.Unlock()
 
 	for _, entry := range entries {
-		// Find and remove from Jobs slice (iterate backwards for safe removal)
+		// Find and remove from Jobs slice. slices.Backward captures the
+		// slice header once, so the break right after the removal is what
+		// keeps this safe — no iteration step runs over the stale header.
 		for i, job := range slices.Backward(s.Jobs) {
 			if job.GetCronJobID() == uint64(entry.ID) {
 				s.Logger.Info(fmt.Sprintf("Job removed by tag %q: %q", tag, job.GetName()))

--- a/core/scheduler.go
+++ b/core/scheduler.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
+	"slices"
 	"sync"
 	"time"
 
@@ -447,8 +449,7 @@ func (s *Scheduler) RemoveJobsByTag(tag string) int {
 
 	for _, entry := range entries {
 		// Find and remove from Jobs slice (iterate backwards for safe removal)
-		for i := len(s.Jobs) - 1; i >= 0; i-- {
-			job := s.Jobs[i]
+		for i, job := range slices.Backward(s.Jobs) {
 			if job.GetCronJobID() == uint64(entry.ID) {
 				s.Logger.Info(fmt.Sprintf("Job removed by tag %q: %q", tag, job.GetName()))
 				delete(s.jobsByName, job.GetName())
@@ -672,9 +673,7 @@ func (s *Scheduler) GetUnschedulableJobs() map[string]string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	out := make(map[string]string, len(s.unschedulable))
-	for name, reason := range s.unschedulable {
-		out[name] = reason
-	}
+	maps.Copy(out, s.unschedulable)
 	return out
 }
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 ### Prerequisites
 
-- Go 1.25+
+- Go 1.26+
 - Docker and Docker Compose
 - Git
 - **Recommended**: [direnv](https://direnv.net/) for automatic environment setup
@@ -30,7 +30,7 @@ direnv allow
 ```
 
 The `.envrc` file automatically:
-- ✅ Verifies Go 1.25+ installation
+- ✅ Verifies Go 1.26+ installation
 - ✅ Checks required tools (golangci-lint, gosec, docker)
 - ✅ **Enforces Git hooks setup** - prevents commits without hooks
 - ✅ Sets up development aliases and environment variables

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/netresearch/ofelia
 
 go 1.26
 
-toolchain go1.26.6
+toolchain go1.27.0
 
 require (
 	github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2

--- a/middlewares/preset_client_cache_test.go
+++ b/middlewares/preset_client_cache_test.go
@@ -34,9 +34,9 @@ func TestPresetLoader_ClientReused(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	var factoryCalls int32
+	var factoryCalls atomic.Int32
 	SetTransportFactoryForTest(func() *http.Transport {
-		atomic.AddInt32(&factoryCalls, 1)
+		factoryCalls.Add(1)
 		return &http.Transport{}
 	})
 	t.Cleanup(func() { SetTransportFactoryForTest(NewSafeTransport) })
@@ -54,7 +54,7 @@ func TestPresetLoader_ClientReused(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, preset2)
 
-	assert.Equal(t, int32(1), atomic.LoadInt32(&factoryCalls),
+	assert.Equal(t, int32(1), factoryCalls.Load(),
 		"TransportFactory must be invoked exactly once: the *http.Client is cached on the loader")
 
 	// Pointer-identity check: the loader must expose the same *http.Client

--- a/middlewares/preset_security_test.go
+++ b/middlewares/preset_security_test.go
@@ -62,8 +62,7 @@ func TestPresetLoader_LoadFromURL_PinsTLSVerificationPosture(t *testing.T) {
 
 	// Stronger contract: the underlying error chain should include a
 	// CertificateVerificationError when running on modern Go.
-	var certErr *tls.CertificateVerificationError
-	if errors.As(err, &certErr) {
+	if certErr, ok := errors.AsType[*tls.CertificateVerificationError](err); ok {
 		assert.NotNil(t, certErr.UnverifiedCertificates,
 			"CertificateVerificationError should expose the unverified chain")
 	}

--- a/middlewares/slack_mutation_test.go
+++ b/middlewares/slack_mutation_test.go
@@ -26,9 +26,9 @@ import (
 func TestSlackPushMessage_NilClient(t *testing.T) {
 	t.Parallel()
 
-	var called int32
+	var called atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&called, 1)
+		called.Add(1)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()
@@ -54,7 +54,7 @@ func TestSlackPushMessage_NilClient(t *testing.T) {
 
 	// Verify that the client was created (not nil anymore)
 	assert.NotNil(t, m.Client, "pushMessage should create a client when Client is nil")
-	assert.Equal(t, int32(1), atomic.LoadInt32(&called),
+	assert.Equal(t, int32(1), called.Load(),
 		"pushMessage should succeed even with initially nil client")
 }
 
@@ -64,9 +64,9 @@ func TestSlackPushMessage_NilClient(t *testing.T) {
 func TestSlackPushMessage_ExistingClient(t *testing.T) {
 	t.Parallel()
 
-	var called int32
+	var called atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&called, 1)
+		called.Add(1)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer ts.Close()
@@ -94,7 +94,7 @@ func TestSlackPushMessage_ExistingClient(t *testing.T) {
 	// Verify the original client is preserved (not overwritten)
 	assert.Equal(t, 42*time.Second, m.Client.Timeout,
 		"existing client should not be overwritten")
-	assert.Equal(t, int32(1), atomic.LoadInt32(&called))
+	assert.Equal(t, int32(1), called.Load())
 }
 
 // TestSlackPushMessage_HTTPError kills CONDITIONALS_NEGATION at slack.go:109
@@ -139,9 +139,9 @@ func TestSlackPushMessage_HTTPError(t *testing.T) {
 func TestSlackPushMessage_Non200Status(t *testing.T) {
 	t.Parallel()
 
-	var called int32
+	var called atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&called, 1)
+		called.Add(1)
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer ts.Close()
@@ -166,7 +166,7 @@ func TestSlackPushMessage_Non200Status(t *testing.T) {
 
 	m.pushMessage(ctx)
 
-	assert.Equal(t, int32(1), atomic.LoadInt32(&called))
+	assert.Equal(t, int32(1), called.Load())
 	// The logger should have received an error about non-200
 	assert.True(t, handler.HasError("non-200"), "non-200 status should be logged as error")
 }

--- a/middlewares/webhook_mutation_test.go
+++ b/middlewares/webhook_mutation_test.go
@@ -32,9 +32,9 @@ func TestSendWithRetry_ZeroRetries(t *testing.T) {
 	SetTransportFactoryForTest(func() *http.Transport { return http.DefaultTransport.(*http.Transport).Clone() })
 	defer SetTransportFactoryForTest(NewSafeTransport)
 
-	var attempts int32
+	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -68,7 +68,7 @@ func TestSendWithRetry_ZeroRetries(t *testing.T) {
 
 	err = webhook.sendWithRetry(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, int32(1), atomic.LoadInt32(&attempts), "with RetryCount=0, exactly 1 attempt should be made")
+	assert.Equal(t, int32(1), attempts.Load(), "with RetryCount=0, exactly 1 attempt should be made")
 }
 
 // TestSendWithRetry_AllAttemptsFail kills:
@@ -84,9 +84,9 @@ func TestSendWithRetry_AllAttemptsFail(t *testing.T) {
 	SetTransportFactoryForTest(func() *http.Transport { return http.DefaultTransport.(*http.Transport).Clone() })
 	defer SetTransportFactoryForTest(NewSafeTransport)
 
-	var attempts int32
+	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer server.Close()
@@ -120,7 +120,7 @@ func TestSendWithRetry_AllAttemptsFail(t *testing.T) {
 
 	err = webhook.sendWithRetry(ctx)
 	require.Error(t, err)
-	assert.Equal(t, int32(3), atomic.LoadInt32(&attempts),
+	assert.Equal(t, int32(3), attempts.Load(),
 		"with RetryCount=2, exactly 3 attempts (initial + 2 retries) should be made")
 	assert.Contains(t, err.Error(), "all 3 attempts failed")
 }
@@ -356,9 +356,9 @@ func TestSendWithRetry_ExactRetryCount_One(t *testing.T) {
 	SetTransportFactoryForTest(func() *http.Transport { return http.DefaultTransport.(*http.Transport).Clone() })
 	defer SetTransportFactoryForTest(NewSafeTransport)
 
-	var attempts int32
+	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer server.Close()
@@ -393,7 +393,7 @@ func TestSendWithRetry_ExactRetryCount_One(t *testing.T) {
 	err = webhook.sendWithRetry(ctx)
 	require.Error(t, err)
 	// RetryCount=1 means exactly 2 attempts: initial + 1 retry
-	assert.Equal(t, int32(2), atomic.LoadInt32(&attempts),
+	assert.Equal(t, int32(2), attempts.Load(),
 		"with RetryCount=1, exactly 2 attempts should be made")
 }
 
@@ -406,9 +406,9 @@ func TestSendWithRetry_SucceedsOnSecondAttempt(t *testing.T) {
 	SetTransportFactoryForTest(func() *http.Transport { return http.DefaultTransport.(*http.Transport).Clone() })
 	defer SetTransportFactoryForTest(NewSafeTransport)
 
-	var attempts int32
+	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&attempts, 1)
+		n := attempts.Add(1)
 		if n == 1 {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
@@ -446,7 +446,7 @@ func TestSendWithRetry_SucceedsOnSecondAttempt(t *testing.T) {
 
 	err = webhook.sendWithRetry(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, int32(2), atomic.LoadInt32(&attempts),
+	assert.Equal(t, int32(2), attempts.Load(),
 		"should succeed on 2nd attempt and stop retrying")
 }
 
@@ -459,9 +459,9 @@ func TestWebhookRun_TriggerFiltering(t *testing.T) {
 	SetTransportFactoryForTest(func() *http.Transport { return http.DefaultTransport.(*http.Transport).Clone() })
 	defer SetTransportFactoryForTest(NewSafeTransport)
 
-	var called int32
+	var called atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&called, 1)
+		called.Add(1)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -495,7 +495,7 @@ func TestWebhookRun_TriggerFiltering(t *testing.T) {
 	ctx.Stop(nil)
 
 	_ = webhook.Run(ctx)
-	assert.Equal(t, int32(0), atomic.LoadInt32(&called),
+	assert.Equal(t, int32(0), called.Load(),
 		"webhook with TriggerError should not fire on success")
 
 	// TriggerError: should send on failure
@@ -506,7 +506,7 @@ func TestWebhookRun_TriggerFiltering(t *testing.T) {
 	ctx2.Stop(errors.New("job failed"))
 
 	_ = webhook.Run(ctx2)
-	assert.Equal(t, int32(1), atomic.LoadInt32(&called),
+	assert.Equal(t, int32(1), called.Load(),
 		"webhook with TriggerError should fire on failure")
 }
 

--- a/ofelia.go
+++ b/ofelia.go
@@ -170,8 +170,7 @@ func run(args []string) int {
 			return exitOK
 		}
 
-		var flagErr *flags.Error
-		if errors.As(err, &flagErr) {
+		if _, ok := errors.AsType[*flags.Error](err); ok {
 			parser.WriteHelp(os.Stdout)
 			_, _ = fmt.Fprintf(os.Stdout, "\n%s\n", cli.VersionString())
 		}

--- a/test/testutil/eventually_test.go
+++ b/test/testutil/eventually_test.go
@@ -24,9 +24,9 @@ func TestEventually_ConditionTrueImmediately(t *testing.T) {
 func TestEventually_ConditionBecomesTrueAfterDelay(t *testing.T) {
 	t.Parallel()
 
-	var counter int32
+	var counter atomic.Int32
 	result := Eventually(t, func() bool {
-		return atomic.AddInt32(&counter, 1) >= 3
+		return counter.Add(1) >= 3
 	}, WithTimeout(1*time.Second), WithInterval(10*time.Millisecond))
 
 	if !result {
@@ -68,10 +68,10 @@ func TestNever_ConditionBecomesTrue(t *testing.T) {
 	t.Parallel()
 
 	mockT := &mockTB{}
-	var counter int32
+	var counter atomic.Int32
 
 	result := Never(mockT, func() bool {
-		return atomic.AddInt32(&counter, 1) >= 2
+		return counter.Add(1) >= 2
 	}, WithTimeout(1*time.Second), WithInterval(10*time.Millisecond))
 
 	if result {
@@ -142,9 +142,9 @@ func TestWaitForClose_ChannelCloses(t *testing.T) {
 func TestEventuallyWithT_CollectsErrors(t *testing.T) {
 	t.Parallel()
 
-	var counter int32
+	var counter atomic.Int32
 	result := EventuallyWithT(t, func(collect *T) bool {
-		count := atomic.AddInt32(&counter, 1)
+		count := counter.Add(1)
 		if count < 3 {
 			collect.Errorf("not ready yet, count=%d", count)
 			return false

--- a/web/middleware_mutation_test.go
+++ b/web/middleware_mutation_test.go
@@ -176,9 +176,9 @@ func TestMiddleware_BoundaryExactlyAtWindow(t *testing.T) {
 	rl.requests[hostIP] = []time.Time{time.Now().Add(-window)}
 	rl.mu.Unlock()
 
-	var successCount int32
+	var successCount atomic.Int32
 	handler := rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&successCount, 1)
+		successCount.Add(1)
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -190,7 +190,7 @@ func TestMiddleware_BoundaryExactlyAtWindow(t *testing.T) {
 	handler.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code, "request should succeed when old entry is exactly at window boundary")
-	assert.Equal(t, int32(1), atomic.LoadInt32(&successCount))
+	assert.Equal(t, int32(1), successCount.Load())
 }
 
 // TestMiddleware_RecentRequestCountedForLimit verifies that a request just

--- a/web/middleware_test.go
+++ b/web/middleware_test.go
@@ -19,15 +19,15 @@ func TestRateLimiter(t *testing.T) {
 	rl := newRateLimiter(10, time.Second)
 
 	// Create a test handler that counts successful requests
-	var successCount int32
+	var successCount atomic.Int32
 	handler := rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&successCount, 1)
+		successCount.Add(1)
 		w.WriteHeader(http.StatusOK)
 	}))
 
 	// Send 20 requests rapidly (should hit rate limit)
 	var wg sync.WaitGroup
-	var rateLimitedCount int32
+	var rateLimitedCount atomic.Int32
 
 	for range 20 {
 		wg.Go(func() {
@@ -38,7 +38,7 @@ func TestRateLimiter(t *testing.T) {
 			handler.ServeHTTP(w, req)
 
 			if w.Code == http.StatusTooManyRequests {
-				atomic.AddInt32(&rateLimitedCount, 1)
+				rateLimitedCount.Add(1)
 			}
 		})
 	}
@@ -46,8 +46,8 @@ func TestRateLimiter(t *testing.T) {
 	wg.Wait()
 
 	// Check results
-	success := atomic.LoadInt32(&successCount)
-	limited := atomic.LoadInt32(&rateLimitedCount)
+	success := successCount.Load()
+	limited := rateLimitedCount.Load()
 
 	t.Logf("Rate Limiting Test Results:")
 	t.Logf("  Requests sent:        20")
@@ -68,9 +68,9 @@ func TestRateLimiterWindow(t *testing.T) {
 	// Create rate limiter: 5 requests per 100ms
 	rl := newRateLimiter(5, 100*time.Millisecond)
 
-	var successCount int32
+	var successCount atomic.Int32
 	handler := rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&successCount, 1)
+		successCount.Add(1)
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -116,9 +116,9 @@ func TestRateLimiterWindow(t *testing.T) {
 func TestRateLimiterPerIP(t *testing.T) {
 	rl := newRateLimiter(3, time.Second)
 
-	var successCount int32
+	var successCount atomic.Int32
 	handler := rl.middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&successCount, 1)
+		successCount.Add(1)
 		w.WriteHeader(http.StatusOK)
 	}))
 
@@ -148,7 +148,7 @@ func TestRateLimiterPerIP(t *testing.T) {
 		}
 	}
 
-	success := atomic.LoadInt32(&successCount)
+	success := successCount.Load()
 	if success != 6 {
 		t.Errorf("Expected 6 successful requests (3 per IP), got %d", success)
 	}


### PR DESCRIPTION
## Description

Full Go 1.27 update in four commits:

1. **Toolchain go1.26.6 → go1.27.0** — CI resolves its Go version from `go.mod` via the shared `netresearch/.github` go-check workflow. Also bumps the two Makefile `GOTOOLCHAIN` pins for the golangci-lint install, and corrects the prerequisite in `docs/DEVELOPMENT.md` and `CONTRIBUTING.md` from "Go 1.25+" to "Go 1.26+" (the `go` directive has required 1.26 already).
2. **Lint fixes under the 1.27 toolchain** — gofumpt's new closing-paren placement in one test file, and removal of six `//nolint:goconst` directives that nolintlint now reports as unused (goconst no longer fires there; all annotated literals sit below the config's `min-occurrences: 6`, and `.golangci.yml` is untouched by this PR).
3. **`go fix` modernization** across 14 files — `strings.Cut` (2 sites), `slices.Backward` (RemoveJobsByTag), `maps.Copy`, `errors.AsType[T]` (3 sites), `atomic.Int32` migrations in six test files, and inlining of the `durationPtr`/`uint64Ptr` test helpers to `new(expr)` with the now-unused helpers removed.
4. **Review-round comment fix** — the `slices.Backward` removal in RemoveJobsByTag is safe because of the `break` after the removal (the range form captures the slice header once); the comment now says so instead of describing the old index loop.

The `go` directive stays at 1.26.

## Testing

`go build ./...`, `go vet ./...`, `golangci-lint run` (0 issues) and `go test -race ./...` (14 packages, all pass) under go1.27.0; `go mod tidy` is a no-op. An independent review agent proved the `slices.Backward` rewrite equivalent for all inputs (including duplicate cron IDs), verified the goconst occurrence counts against the config, and found no weakened assertions.

The advisory SonarCloud check is red on new-code duplication (5.3% vs 3%) — the mechanical `atomic.Int32` test rewrites count as "new code"; not in the required-checks ruleset.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_01L7tF9XuJfAfFk4yuY5KfPK)_