### PR TITLE
docs: describe the real API instead of a fictional one

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,551 +1,228 @@
 # Ofelia API Documentation
 
 ## Overview
-Ofelia provides a RESTful API for job management, monitoring, and configuration. All API endpoints are available when the web UI is enabled with `--enable-web`.
+
+Ofelia serves a JSON API when the web server is enabled (`--enable-web`, default address `:8081`).
+Every API route lives under the `/api/` prefix; the health endpoints live at the server root.
+This document describes the endpoints that exist in the code (`web/server.go` — the `routes`
+table is the source of truth); if you find a mismatch, that is a bug in this file.
+
+Two general rules:
+
+- All mutating endpoints are `POST` and take a JSON body. Any other method returns
+  `405 Method Not Allowed`.
+- A malformed JSON body returns `400 Bad Request`; an unknown job name returns
+  `404 Not Found`; internal failures return `500 Internal Server Error` with a short
+  plain-text message.
 
 ## Authentication
 
-### JWT Authentication
-The API uses JWT tokens for authentication when security is enabled.
+Authentication is optional and disabled unless the daemon is configured with web auth.
+When disabled, the auth endpoints below are not registered and every other endpoint is open.
 
-#### Login
+When enabled, all `/api/` routes except `/api/login`, `/api/auth/status` and
+`/api/csrf-token` require authentication via either:
+
+- the `auth_token` cookie set by login (`HttpOnly`, `SameSite=Strict`; `Secure` when the
+  request arrived over TLS or with `X-Forwarded-Proto: https`), or
+- an `Authorization: Bearer <token>` header carrying the token returned by login.
+
+### Login
+
 ```http
 POST /api/login
 Content-Type: application/json
 
-{
-  "username": "admin",
-  "password": "secret"
-}
+{"username": "admin", "password": "secret"}
 ```
 
-**Response:**
+Response `200 OK` (and the `auth_token` cookie):
+
 ```json
-{
-  "token": "<jwt-token>",
-  "expires": "2024-01-01T00:00:00Z"
-}
+{"token": "<token>", "csrf_token": "<csrf-token>", "expires_in": 86400}
 ```
 
-#### Using the Token
-Include the JWT token in the Authorization header:
+Failed credentials return `401 Unauthorized`; repeated failures are rate limited per client IP.
+There is no refresh endpoint — log in again when the token expires.
+
+### Logout
+
 ```http
-Authorization: Bearer <jwt-token>
+POST /api/logout
 ```
 
-#### Refresh Token
+Clears the auth cookie. Returns `204 No Content`.
+
+### Auth status
+
 ```http
-POST /api/refresh
-Authorization: Bearer <current-token>
+GET /api/auth/status
 ```
 
-**Response:**
+Reports whether authentication is enabled and whether the caller is authenticated.
+
+### CSRF token
+
+```http
+GET /api/csrf-token
+```
+
+Returns the CSRF token for the session; the web UI sends it with the login form.
+
+## Jobs
+
+### List jobs
+
+```http
+GET /api/jobs            # active jobs
+GET /api/jobs/removed    # jobs removed from the configuration
+GET /api/jobs/disabled   # disabled (paused) jobs
+```
+
+Each returns a JSON **array** of job objects:
+
 ```json
-{
-  "token": "<jwt-token>",
-  "expires": "2024-01-01T00:00:00Z"
-}
-```
-
-## Job Management
-
-### List All Jobs
-```http
-GET /api/jobs
-```
-
-**Response:**
-```json
-{
-  "jobs": [
-    {
-      "name": "backup",
-      "type": "exec",
-      "schedule": "@daily",
-      "command": "backup.sh",
-      "container": "myapp",
-      "lastRun": "2024-01-01T00:00:00Z",
-      "nextRun": "2024-01-02T00:00:00Z",
-      "status": "success",
-      "origin": "config",
-      "enabled": true
-    },
-    {
-      "name": "cleanup",
-      "type": "run",
-      "schedule": "0 2 * * *",
-      "image": "alpine:latest",
-      "command": "cleanup.sh",
-      "lastRun": "2024-01-01T02:00:00Z",
-      "nextRun": "2024-01-02T02:00:00Z",
-      "status": "running",
-      "origin": "docker-label",
-      "enabled": true
-    }
-  ],
-  "total": 2,
-  "running": 1
-}
-```
-
-### Get Job Details
-```http
-GET /api/job/{name}
-```
-
-**Response:**
-```json
-{
-  "name": "backup",
-  "type": "exec",
-  "schedule": "@daily",
-  "command": "backup.sh",
-  "container": "myapp",
-  "user": "nobody",
-  "environment": ["BACKUP_DIR=/data"],
-  "tty": false,
-  "lastRun": "2024-01-01T00:00:00Z",
-  "nextRun": "2024-01-02T00:00:00Z",
-  "status": "success",
-  "origin": "config",
-  "enabled": true,
-  "history": [
-    {
-      "executionId": "550e8400-e29b-41d4-a716-446655440000",
-      "startTime": "2024-01-01T00:00:00Z",
-      "endTime": "2024-01-01T00:05:00Z",
+[
+  {
+    "name": "backup",
+    "type": "run",
+    "schedule": "@daily",
+    "command": "backup.sh",
+    "running": false,
+    "lastRun": {
+      "date": "2026-08-26T00:00:00Z",
       "duration": 300000000000,
-      "status": "success",
-      "output": "Backup completed successfully",
-      "error": null
-    }
-  ],
-  "metrics": {
-    "totalRuns": 30,
-    "successfulRuns": 29,
-    "failedRuns": 1,
-    "averageDuration": 285000000000,
-    "lastSuccess": "2024-01-01T00:00:00Z",
-    "lastFailure": "2023-12-15T00:00:00Z"
+      "failed": false,
+      "skipped": false,
+      "stdout": "…",
+      "stderr": ""
+    },
+    "nextRuns": ["2026-08-27T00:00:00Z"],
+    "prevRuns": ["2026-08-26T00:00:00Z"],
+    "origin": "ini",
+    "config": {"…": "full job configuration as JSON"}
   }
-}
+]
 ```
 
-### Trigger Job Execution
+`lastRun` is omitted when the job has never run. `duration` values are Go
+`time.Duration` nanoseconds. `origin` is one of `ini`, `label`, `api`, `web`.
+
+### Job history
+
 ```http
-POST /api/job/{name}/run
+GET /api/jobs/{name}/history
 ```
 
-**Response:**
-```json
-{
-  "executionId": "550e8400-e29b-41d4-a716-446655440001",
-  "job": "backup",
-  "startTime": "2024-01-01T12:00:00Z",
-  "status": "running"
-}
-```
+Returns a JSON array of executions in the shape of `lastRun` above (plus an
+`error` string when the execution errored). `404 Not Found` for unknown jobs or
+job types without history.
 
-### Update Job Configuration
+### Run a job now
+
 ```http
-PUT /api/job/{name}
+POST /api/jobs/run
+Content-Type: application/json
+
+{"name": "backup"}
+```
+
+Returns `204 No Content` on success.
+
+### Disable / enable a job
+
+```http
+POST /api/jobs/disable
+POST /api/jobs/enable
+Content-Type: application/json
+
+{"name": "backup"}
+```
+
+Returns `204 No Content`. Works for jobs of every origin — disabling an
+INI/label job from the API is the supported way to suppress it temporarily, and
+the disabled state is persisted across restarts.
+
+### Create a job
+
+```http
+POST /api/jobs/create
 Content-Type: application/json
 
 {
-  "schedule": "0 3 * * *",
-  "command": "backup.sh --verbose",
-  "environment": ["BACKUP_DIR=/data", "COMPRESSION=gzip"]
+  "name": "cleanup",
+  "type": "run",
+  "schedule": "0 2 * * *",
+  "image": "alpine:latest",
+  "command": "cleanup.sh"
 }
 ```
 
-**Response:**
-```json
-{
-  "name": "backup",
-  "updated": true,
-  "message": "Job configuration updated successfully"
-}
-```
+The request body (`jobRequest`) accepts:
 
-### Delete Job
-```http
-DELETE /api/job/{name}
-```
-
-**Response:**
-```json
-{
-  "name": "backup",
-  "deleted": true,
-  "message": "Job deleted successfully"
-}
-```
-
-### Enable/Disable Job
-```http
-PATCH /api/job/{name}/toggle
-```
-
-**Response:**
-```json
-{
-  "name": "backup",
-  "enabled": false,
-  "message": "Job disabled"
-}
-```
-
-## Execution Management
-
-### Get Execution Status
-```http
-GET /api/execution/{executionId}
-```
-
-**Response:**
-```json
-{
-  "executionId": "550e8400-e29b-41d4-a716-446655440001",
-  "job": "backup",
-  "startTime": "2024-01-01T12:00:00Z",
-  "endTime": "2024-01-01T12:05:00Z",
-  "duration": 300000000000,
-  "status": "success",
-  "output": "Backup completed\n1000 files processed",
-  "error": null,
-  "exitCode": 0
-}
-```
-
-### Stop Running Execution
-```http
-POST /api/execution/{executionId}/stop
-```
-
-**Response:**
-```json
-{
-  "executionId": "550e8400-e29b-41d4-a716-446655440001",
-  "stopped": true,
-  "message": "Execution stopped"
-}
-```
-
-### Get Execution Logs
-```http
-GET /api/execution/{executionId}/logs
-```
-
-**Response:**
-```json
-{
-  "executionId": "550e8400-e29b-41d4-a716-446655440001",
-  "logs": [
-    {
-      "timestamp": "2024-01-01T12:00:00Z",
-      "level": "info",
-      "message": "Starting backup process"
-    },
-    {
-      "timestamp": "2024-01-01T12:00:01Z",
-      "level": "info",
-      "message": "Scanning files..."
-    },
-    {
-      "timestamp": "2024-01-01T12:05:00Z",
-      "level": "info",
-      "message": "Backup completed successfully"
-    }
-  ]
-}
-```
-
-## Scheduler Control
-
-### Get Scheduler Status
-```http
-GET /api/scheduler/status
-```
-
-**Response:**
-```json
-{
-  "running": true,
-  "startTime": "2024-01-01T00:00:00Z",
-  "uptime": 86400,
-  "totalJobs": 15,
-  "activeJobs": 12,
-  "runningJobs": 2,
-  "nextJob": {
-    "name": "cleanup",
-    "scheduledTime": "2024-01-02T02:00:00Z"
-  }
-}
-```
-
-### Start/Stop Scheduler
-```http
-POST /api/scheduler/start
-POST /api/scheduler/stop
-```
-
-**Response:**
-```json
-{
-  "running": true,
-  "message": "Scheduler started"
-}
-```
-
-### Reload Configuration
-```http
-POST /api/scheduler/reload
-```
-
-**Response:**
-```json
-{
-  "reloaded": true,
-  "jobsAdded": 2,
-  "jobsUpdated": 1,
-  "jobsRemoved": 0,
-  "message": "Configuration reloaded successfully"
-}
-```
-
-## Monitoring
-
-Four endpoints, all unauthenticated:
-
-| Endpoint | Body | Status code |
+| Field | Type | Notes |
 |---|---|---|
-| `GET /health` | full report | always `200` |
-| `GET /healthz` | full report (alias) | always `200` |
-| `GET /ready` | full report | `503` when `unhealthy`, else `200` |
-| `GET /live` | `OK` as plain text | always `200` |
+| `name` | string | required; ≤256 chars, no control characters |
+| `type` | string | `run`, `exec`, `local`, `service-run`, `compose` |
+| `schedule` | string | cron expression or `@shortcut` |
+| `command` | string | |
+| `image` | string | `run` jobs |
+| `container` | string | `exec` jobs |
+| `file` | string | `compose` jobs |
+| `service` | string | `service-run` jobs |
+| `exec` | bool | `compose` jobs: exec in a running service |
 
-### Health Check
+Returns `201 Created`. Validation failures return `400 Bad Request`.
+API-created jobs are persisted and survive restarts.
+
+### Update a job
+
 ```http
-GET /health
+POST /api/jobs/update
+Content-Type: application/json
 ```
 
-`/health` answers `200` even while reporting a problem — the verdict is in the
-body, so a monitoring system can read *why*. Point a probe that must fail at
-`/ready` instead.
+Same body as create. Full replace: omitted optional fields reset to their
+defaults. Returns `200 OK` when an existing job was updated, `201 Created` when
+the job did not exist and was created.
 
-**Response:**
-```json
-{
-  "status": "degraded",
-  "timestamp": "2026-08-02T16:55:52Z",
-  "uptimeSeconds": 41.2,
-  "version": "v0.28.1",
-  "checks": {
-    "docker": {
-      "name": "docker",
-      "status": "healthy",
-      "message": "Docker 29.6.2 running with 25 containers",
-      "lastChecked": "2026-08-02T16:55:52Z",
-      "durationMs": 8332586
-    },
-    "scheduler": {
-      "name": "scheduler",
-      "status": "degraded",
-      "message": "1 configured job(s) are not scheduled and will not run: broken",
-      "lastChecked": "2026-08-02T16:55:52Z",
-      "durationMs": 3180
-    },
-    "system": {
-      "name": "system",
-      "status": "healthy",
-      "message": "System resources normal",
-      "lastChecked": "2026-08-02T16:55:52Z",
-      "durationMs": 553638
-    }
-  },
-  "system": {
-    "goVersion": "go1.26.0",
-    "goroutines": 24,
-    "cpus": 8,
-    "memoryAllocBytes": 3512976,
-    "memoryTotalBytes": 12730376,
-    "gcRuns": 1
-  }
-}
-```
+### Delete a job
 
-`status` is the worst status among the checks. `version` is the running build,
-or `dev` when built without ldflags. Note that `durationMs` carries
-**nanoseconds** despite its name — it serialises a Go `time.Duration`.
-
-The `scheduler` check reports `degraded` and names every configured job the
-scheduler refused, so a job that never fires — an unparsable schedule, a
-duplicate name — is visible to monitoring rather than only in the startup log.
-
-### Readiness Check
 ```http
-GET /ready
+POST /api/jobs/delete
+Content-Type: application/json
+
+{"name": "cleanup"}
 ```
 
-Same body as `/health`. The status code carries the verdict: `503` when the
-overall status is `unhealthy`, `200` otherwise. `degraded` deliberately stays
-`200` — one job with a typo should not take a daemon out of rotation while its
-other jobs keep running.
-
-### Liveness Check
-```http
-GET /live
-```
-
-Answers `200` with the plain-text body `OK` as long as the process serves HTTP.
-It runs no checks, so it never reports on Docker or the scheduler.
-
-### Prometheus Metrics
-```http
-GET /metrics
-```
-
-**Response:**
-```text
-# HELP ofelia_jobs_total Total number of jobs executed
-# TYPE ofelia_jobs_total counter
-ofelia_jobs_total 1234
-
-# HELP ofelia_jobs_failed_total Total number of failed jobs
-# TYPE ofelia_jobs_failed_total counter
-ofelia_jobs_failed_total 12
-
-# HELP ofelia_jobs_running Number of currently running jobs
-# TYPE ofelia_jobs_running gauge
-ofelia_jobs_running 2
-
-# HELP ofelia_job_duration_seconds Job execution duration in seconds
-# TYPE ofelia_job_duration_seconds histogram
-ofelia_job_duration_seconds_bucket{le="0.1"} 100
-ofelia_job_duration_seconds_bucket{le="0.5"} 500
-...
-```
+Returns `204 No Content`. Jobs owned by the INI file or Docker labels return
+`403 Forbidden` — edit the owning configuration to remove them (or use
+`/api/jobs/disable` to suppress them); only API/web-created jobs can be deleted
+here.
 
 ## Configuration
 
-### Get Current Configuration
 ```http
 GET /api/config
 ```
 
-**Response:**
-```json
-{
-  "global": {
-    "dockerHost": "unix:///var/run/docker.sock",
-    "dockerPollInterval": 30,
-    "dockerEvents": true,
-    "slackURL": "https://hooks.slack.com/...",
-    "emailFrom": "ofelia@example.com",
-    "emailTo": "admin@example.com"
-  },
-  "jobs": {
-    "exec": [...],
-    "run": [...],
-    "local": [...],
-    "service": [...]
-  }
-}
-```
+Returns the running daemon configuration as JSON, with the job collections
+stripped (use the job endpoints for those).
 
-### Update Global Configuration
+## Health
+
+Registered at the server root (not under `/api/`, no authentication):
+
 ```http
-PATCH /api/config/global
-Content-Type: application/json
-
-{
-  "dockerPollInterval": 60,
-  "slackChannel": "#alerts"
-}
+GET /health    # aggregate health report
+GET /healthz   # alias of /health
+GET /ready     # readiness probe
+GET /live      # liveness probe
 ```
 
-## WebSocket Events
+## Errors
 
-### Subscribe to Real-time Events
-```javascript
-const ws = new WebSocket('ws://localhost:8080/api/ws');
-
-ws.onmessage = (event) => {
-  const data = JSON.parse(event.data);
-  console.log('Event:', data.type, data.payload);
-};
-```
-
-**Event Types:**
-- `job.started`: Job execution started
-- `job.completed`: Job execution completed
-- `job.failed`: Job execution failed
-- `job.added`: New job added
-- `job.updated`: Job configuration updated
-- `job.removed`: Job removed
-- `scheduler.started`: Scheduler started
-- `scheduler.stopped`: Scheduler stopped
-
-## Error Responses
-
-All endpoints return consistent error responses:
-
-```json
-{
-  "error": {
-    "code": "JOB_NOT_FOUND",
-    "message": "Job 'backup' not found",
-    "details": {
-      "job": "backup",
-      "timestamp": "2024-01-01T12:00:00Z"
-    }
-  }
-}
-```
-
-### Error Codes
-- `UNAUTHORIZED`: Missing or invalid authentication
-- `FORBIDDEN`: Insufficient permissions
-- `JOB_NOT_FOUND`: Job does not exist
-- `INVALID_SCHEDULE`: Invalid cron expression
-- `DOCKER_ERROR`: Docker API error
-- `EXECUTION_ERROR`: Job execution failed
-- `VALIDATION_ERROR`: Invalid input data
-- `INTERNAL_ERROR`: Server error
-
-## Rate Limiting
-
-API requests are rate-limited to prevent abuse:
-
-- **Default limit**: 100 requests per minute
-- **Burst capacity**: 10 requests
-
-Rate limit headers:
-```http
-X-RateLimit-Limit: 100
-X-RateLimit-Remaining: 95
-X-RateLimit-Reset: 1704067200
-```
-
-## CORS Configuration
-
-Cross-Origin Resource Sharing (CORS) can be configured:
-
-```yaml
-cors:
-  allowed_origins:
-    - http://localhost:3000
-    - https://app.example.com
-  allowed_methods:
-    - GET
-    - POST
-    - PUT
-    - DELETE
-  allowed_headers:
-    - Authorization
-    - Content-Type
-  max_age: 86400
-```
-
----
-*See also: [Web Package](./packages/web.md) | [Configuration Guide](./CONFIGURATION.md) | [Project Index](./PROJECT_INDEX.md)*
+Errors are plain-text messages with the appropriate status code:
+`400` invalid body or validation failure, `401` unauthenticated (auth enabled),
+`403` config-owned job on delete, `404` unknown job, `405` wrong method,
+`500` internal failure. Login attempts are rate limited per client IP.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,8 +1,10 @@
 openapi: 3.0.3
 info:
   title: Ofelia Job Scheduler API
-  description: REST API for Ofelia Docker job scheduler with authentication and metrics
-  version: 1.1.0
+  description: >-
+    REST API of the Ofelia web server (--enable-web). Paths mirror the route
+    table in web/server.go; docs/API.md carries the narrative version.
+  version: 1.2.0
   contact:
     name: Ofelia Support
     url: https://github.com/netresearch/ofelia
@@ -11,21 +13,18 @@ info:
     url: https://opensource.org/licenses/MIT
 
 servers:
-  - url: http://localhost:8080
-    description: Local development server
-  - url: https://ofelia.example.com
-    description: Production server
+  - url: http://localhost:8081
+    description: Local ofelia web server (default --web-address)
 
 security:
   - BearerAuth: []
   - CookieAuth: []
 
 paths:
-  /login:
+  /api/login:
     post:
-      summary: Authenticate user
-      tags:
-        - Authentication
+      summary: Authenticate (only registered when web auth is enabled)
+      tags: [Authentication]
       security: []
       requestBody:
         required: true
@@ -33,524 +32,272 @@ paths:
           application/json:
             schema:
               type: object
-              required:
-                - username
-                - password
+              required: [username, password]
               properties:
-                username:
-                  type: string
-                  example: admin
-                password:
-                  type: string
-                  format: password
-                  example: secret123
+                username: {type: string}
+                password: {type: string}
       responses:
-        '200':
-          description: Authentication successful
-          headers:
-            Set-Cookie:
-              schema:
-                type: string
-                example: auth_token=abc123; Path=/; HttpOnly; Secure; SameSite=Strict
+        "200":
+          description: Authenticated; auth_token cookie is set alongside the JSON body
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  token:
-                    type: string
-                    example: "<jwt-token>"
-                  expires_in:
-                    type: number
-                    example: 3600
-        '401':
-          description: Invalid credentials
-          content:
-            text/plain:
-              schema:
-                type: string
-                example: Invalid credentials
-        '400':
-          description: Bad request
-          content:
-            text/plain:
-              schema:
-                type: string
-                example: Invalid request body
-
-  /logout:
+                  token: {type: string}
+                  csrf_token: {type: string}
+                  expires_in: {type: number, description: seconds}
+        "401": {$ref: "#/components/responses/PlainError"}
+        "429": {$ref: "#/components/responses/PlainError"}
+  /api/logout:
     post:
-      summary: Logout user
-      tags:
-        - Authentication
+      summary: Clear the auth cookie
+      tags: [Authentication]
       responses:
-        '200':
-          description: Logout successful
-          content:
-            text/plain:
-              schema:
-                type: string
-                example: Logged out successfully
-
-  /metrics:
+        "204": {description: Logged out}
+  /api/auth/status:
     get:
-      summary: Get Prometheus metrics
-      tags:
-        - Monitoring
+      summary: Whether auth is enabled and the caller is authenticated
+      tags: [Authentication]
       security: []
       responses:
-        '200':
-          description: Prometheus metrics in text format
+        "200": {description: Status object}
+  /api/csrf-token:
+    get:
+      summary: CSRF token for the session (used by the login form)
+      tags: [Authentication]
+      security: []
+      responses:
+        "200": {description: Token object}
+
+  /api/jobs:
+    get:
+      summary: List active jobs
+      tags: [Jobs]
+      responses:
+        "200":
+          description: Array of jobs
           content:
-            text/plain:
+            application/json:
               schema:
-                type: string
-                example: |
-                  # HELP ofelia_jobs_total Total number of jobs executed
-                  # TYPE ofelia_jobs_total counter
-                  ofelia_jobs_total 42
-                  
-                  # HELP ofelia_jobs_running Number of currently running jobs
-                  # TYPE ofelia_jobs_running gauge
-                  ofelia_jobs_running 3
+                type: array
+                items: {$ref: "#/components/schemas/Job"}
+  /api/jobs/removed:
+    get:
+      summary: List jobs removed from the configuration
+      tags: [Jobs]
+      responses:
+        "200":
+          description: Array of jobs
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {$ref: "#/components/schemas/Job"}
+  /api/jobs/disabled:
+    get:
+      summary: List disabled (paused) jobs
+      tags: [Jobs]
+      responses:
+        "200":
+          description: Array of jobs
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {$ref: "#/components/schemas/Job"}
+  /api/jobs/{jobName}/history:
+    get:
+      summary: Execution history of one job
+      tags: [Jobs]
+      parameters:
+        - name: jobName
+          in: path
+          required: true
+          schema: {type: string}
+      responses:
+        "200":
+          description: Array of executions
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {$ref: "#/components/schemas/Execution"}
+        "404": {$ref: "#/components/responses/PlainError"}
+
+  /api/jobs/run:
+    post:
+      summary: Trigger a job now
+      tags: [Job mutations]
+      requestBody: {$ref: "#/components/requestBodies/JobName"}
+      responses:
+        "204": {description: Job triggered}
+        "400": {$ref: "#/components/responses/PlainError"}
+        "404": {$ref: "#/components/responses/PlainError"}
+        "405": {$ref: "#/components/responses/PlainError"}
+        "500": {$ref: "#/components/responses/PlainError"}
+  /api/jobs/disable:
+    post:
+      summary: Disable (pause) a job of any origin; persisted across restarts
+      tags: [Job mutations]
+      requestBody: {$ref: "#/components/requestBodies/JobName"}
+      responses:
+        "204": {description: Job disabled}
+        "400": {$ref: "#/components/responses/PlainError"}
+        "404": {$ref: "#/components/responses/PlainError"}
+        "405": {$ref: "#/components/responses/PlainError"}
+        "500": {$ref: "#/components/responses/PlainError"}
+  /api/jobs/enable:
+    post:
+      summary: Re-enable a disabled job
+      tags: [Job mutations]
+      requestBody: {$ref: "#/components/requestBodies/JobName"}
+      responses:
+        "204": {description: Job enabled}
+        "400": {$ref: "#/components/responses/PlainError"}
+        "404": {$ref: "#/components/responses/PlainError"}
+        "405": {$ref: "#/components/responses/PlainError"}
+        "500": {$ref: "#/components/responses/PlainError"}
+  /api/jobs/create:
+    post:
+      summary: Create a job (persisted across restarts)
+      tags: [Job mutations]
+      requestBody: {$ref: "#/components/requestBodies/JobRequest"}
+      responses:
+        "201": {description: Job created}
+        "400": {$ref: "#/components/responses/PlainError"}
+        "405": {$ref: "#/components/responses/PlainError"}
+  /api/jobs/update:
+    post:
+      summary: Update a job (full replace; creates it when missing)
+      tags: [Job mutations]
+      requestBody: {$ref: "#/components/requestBodies/JobRequest"}
+      responses:
+        "200": {description: Job updated}
+        "201": {description: Job did not exist and was created}
+        "400": {$ref: "#/components/responses/PlainError"}
+        "405": {$ref: "#/components/responses/PlainError"}
+        "500": {$ref: "#/components/responses/PlainError"}
+  /api/jobs/delete:
+    post:
+      summary: Delete an API/web-created job
+      tags: [Job mutations]
+      requestBody: {$ref: "#/components/requestBodies/JobName"}
+      responses:
+        "204": {description: Job deleted}
+        "400": {$ref: "#/components/responses/PlainError"}
+        "403":
+          description: Job is owned by INI/label config; edit the source or use /api/jobs/disable
+        "404": {$ref: "#/components/responses/PlainError"}
+        "405": {$ref: "#/components/responses/PlainError"}
+
+  /api/config:
+    get:
+      summary: Running configuration (job collections stripped)
+      tags: [Configuration]
+      responses:
+        "200": {description: Configuration object}
 
   /health:
     get:
-      summary: Detailed health report
-      description: >-
-        Always answers 200, including while the report says `degraded` or
-        `unhealthy` — the status is in the body, not the status code, so a
-        monitoring system can read *why* rather than only that something is
-        wrong. Use /ready for a probe that fails the request.
-      tags:
-        - Monitoring
+      summary: Aggregate health report
+      tags: [Health]
       security: []
       responses:
-        '200':
-          description: The current report, whatever its status
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HealthResponse'
-
+        "200": {description: Healthy}
+        "503": {description: Unhealthy}
   /healthz:
     get:
-      summary: Detailed health report (alias of /health)
-      tags:
-        - Monitoring
+      summary: Alias of /health
+      tags: [Health]
       security: []
       responses:
-        '200':
-          description: The current report, whatever its status
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HealthResponse'
-
+        "200": {description: Healthy}
+        "503": {description: Unhealthy}
   /ready:
     get:
       summary: Readiness probe
-      description: >-
-        Same body as /health, but the status code carries the verdict: 503 when
-        the overall status is `unhealthy`, 200 otherwise. `degraded` stays 200
-        on purpose — one job with an unparsable schedule should not take the
-        whole daemon out of rotation while its other jobs keep running.
-      tags:
-        - Monitoring
+      tags: [Health]
       security: []
       responses:
-        '200':
-          description: Ready — overall status is `healthy` or `degraded`
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HealthResponse'
-        '503':
-          description: Not ready — overall status is `unhealthy`
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HealthResponse'
-
+        "200": {description: Ready}
+        "503": {description: Not ready}
   /live:
     get:
       summary: Liveness probe
-      description: >-
-        Answers as long as the process serves HTTP at all. It runs no checks,
-        so it never reports on Docker or the scheduler.
-      tags:
-        - Monitoring
+      tags: [Health]
       security: []
       responses:
-        '200':
-          description: The process is running
-          content:
-            text/plain:
-              schema:
-                type: string
-                example: OK
-
-  /jobs:
-    get:
-      summary: List all jobs
-      tags:
-        - Jobs
-      parameters:
-        - name: status
-          in: query
-          schema:
-            type: string
-            enum: [all, running, scheduled, disabled]
-            default: all
-          description: Filter jobs by status
-      responses:
-        '200':
-          description: List of jobs
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Job'
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-
-  /jobs/{jobName}:
-    parameters:
-      - name: jobName
-        in: path
-        required: true
-        schema:
-          type: string
-        description: Name of the job
-    
-    get:
-      summary: Get job details
-      tags:
-        - Jobs
-      responses:
-        '200':
-          description: Job details
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/JobDetails'
-        '404':
-          description: Job not found
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-    
-    post:
-      summary: Run job manually
-      tags:
-        - Jobs
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                wait:
-                  type: boolean
-                  default: false
-                  description: Wait for job completion
-      responses:
-        '200':
-          description: Job started successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  jobId:
-                    type: string
-                    example: "job-123"
-                  status:
-                    type: string
-                    example: "started"
-        '404':
-          description: Job not found
-        '409':
-          description: Job already running
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-    
-    delete:
-      summary: Disable job
-      tags:
-        - Jobs
-      responses:
-        '200':
-          description: Job disabled
-        '404':
-          description: Job not found
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-
-  /jobs/{jobName}/enable:
-    parameters:
-      - name: jobName
-        in: path
-        required: true
-        schema:
-          type: string
-    post:
-      summary: Enable job
-      tags:
-        - Jobs
-      responses:
-        '200':
-          description: Job enabled
-        '404':
-          description: Job not found
-        '401':
-          $ref: '#/components/responses/Unauthorized'
-
-  /jobs/{jobName}/history:
-    parameters:
-      - name: jobName
-        in: path
-        required: true
-        schema:
-          type: string
-    get:
-      summary: Get job execution history
-      tags:
-        - Jobs
-      parameters:
-        - name: limit
-          in: query
-          schema:
-            type: integer
-            minimum: 1
-            maximum: 100
-            default: 10
-      responses:
-        '200':
-          description: Job history
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/JobExecution'
-        '404':
-          description: Job not found
-        '401':
-          $ref: '#/components/responses/Unauthorized'
+        "200": {description: Alive}
 
 components:
   securitySchemes:
     BearerAuth:
       type: http
       scheme: bearer
-      description: JWT token authentication
-    
     CookieAuth:
       type: apiKey
       in: cookie
       name: auth_token
-      description: Session cookie authentication
-
+  requestBodies:
+    JobName:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [name]
+            properties:
+              name: {type: string, maxLength: 256}
+    JobRequest:
+      required: true
+      content:
+        application/json:
+          schema: {$ref: "#/components/schemas/JobRequest"}
+  responses:
+    PlainError:
+      description: Plain-text error message
+      content:
+        text/plain:
+          schema: {type: string}
   schemas:
-    HealthCheck:
+    JobRequest:
       type: object
-      description: One individual check within the health report.
+      required: [name, type]
       properties:
-        name:
-          type: string
-          example: scheduler
-        status:
-          type: string
-          enum: [healthy, degraded, unhealthy]
-          example: degraded
-        message:
-          type: string
-          description: Omitted when empty.
-          example: "1 configured job(s) are not scheduled and will not run: broken"
-        lastChecked:
-          type: string
-          format: date-time
-        durationMs:
-          type: integer
-          format: int64
-          description: >-
-            How long the check took, in **nanoseconds** despite the field name —
-            it serialises a Go time.Duration, which marshals as nanoseconds. A
-            local Docker ping reports roughly 8000000 here, i.e. 8 ms.
-          example: 8332586
-      required: [name, status, lastChecked, durationMs]
-
-    HealthResponse:
-      type: object
-      description: >-
-        The body served by /health, /healthz and /ready. `status` is the worst
-        status among `checks`: any unhealthy check makes the whole report
-        unhealthy, otherwise any degraded check makes it degraded.
-      properties:
-        status:
-          type: string
-          enum: [healthy, degraded, unhealthy]
-          example: degraded
-        timestamp:
-          type: string
-          format: date-time
-        uptimeSeconds:
-          type: number
-          example: 3600
-        version:
-          type: string
-          description: >-
-            The running build's version, or `dev` when built without ldflags.
-          example: v0.28.1
-        checks:
-          type: object
-          description: Keyed by check name — `docker`, `scheduler` and `system`.
-          additionalProperties:
-            $ref: '#/components/schemas/HealthCheck'
-        system:
-          $ref: '#/components/schemas/SystemInfo'
-      required: [status, timestamp, uptimeSeconds, version, checks, system]
-
-    SystemInfo:
-      type: object
-      properties:
-        goVersion:
-          type: string
-          example: go1.26.0
-        goroutines:
-          type: integer
-          example: 24
-        cpus:
-          type: integer
-          example: 8
-        memoryAllocBytes:
-          type: integer
-          format: int64
-        memoryTotalBytes:
-          type: integer
-          format: int64
-        gcRuns:
-          type: integer
-
+        name: {type: string, maxLength: 256}
+        type: {type: string, enum: [run, exec, local, service-run, compose]}
+        schedule: {type: string}
+        command: {type: string}
+        image: {type: string, description: run jobs}
+        container: {type: string, description: exec jobs}
+        file: {type: string, description: compose jobs}
+        service: {type: string, description: service-run jobs}
+        exec: {type: boolean, description: "compose jobs: exec in a running service"}
     Job:
       type: object
       properties:
-        name:
-          type: string
-          example: "backup-database"
-        schedule:
-          type: string
-          example: "0 2 * * *"
-        command:
-          type: string
-          example: "pg_dump database > backup.sql"
-        type:
-          type: string
-          enum: [local, exec, run, service, compose]
-          example: "exec"
-        status:
-          type: string
-          enum: [scheduled, running, disabled]
-          example: "scheduled"
-        lastRun:
-          type: string
-          format: date-time
-          example: "2024-01-15T02:00:00Z"
-        nextRun:
-          type: string
-          format: date-time
-          example: "2024-01-16T02:00:00Z"
+        name: {type: string}
+        type: {type: string}
+        schedule: {type: string}
+        command: {type: string}
+        running: {type: boolean}
+        lastRun: {$ref: "#/components/schemas/Execution"}
         nextRuns:
           type: array
-          items:
-            type: string
-            format: date-time
-          description: Next 5 scheduled execution times
-          example: ["2024-01-16T02:00:00Z", "2024-01-17T02:00:00Z"]
+          items: {type: string, format: date-time}
         prevRuns:
           type: array
-          items:
-            type: string
-            format: date-time
-          description: Previous 5 execution times
-          example: ["2024-01-15T02:00:00Z", "2024-01-14T02:00:00Z"]
-
-    JobDetails:
-      allOf:
-        - $ref: '#/components/schemas/Job'
-        - type: object
-          properties:
-            container:
-              type: string
-              example: "postgres-db"
-              description: For exec jobs
-            image:
-              type: string
-              example: "alpine:latest"
-              description: For run jobs
-            network:
-              type: string
-              example: "bridge"
-            environment:
-              type: array
-              items:
-                type: string
-              example: ["DB_HOST=localhost", "DB_USER=admin"]
-            volumes:
-              type: array
-              items:
-                type: string
-              example: ["/data:/backup"]
-            user:
-              type: string
-              example: "root"
-            workingDir:
-              type: string
-              example: "/app"
-
-    JobExecution:
+          items: {type: string, format: date-time}
+        origin: {type: string, enum: [ini, label, api, web]}
+        config: {type: object, description: full job configuration}
+    Execution:
       type: object
       properties:
-        executionId:
-          type: string
-          example: "exec-456"
-        startTime:
-          type: string
-          format: date-time
-          example: "2024-01-15T02:00:00Z"
-        endTime:
-          type: string
-          format: date-time
-          example: "2024-01-15T02:05:30Z"
-        duration:
-          type: number
-          description: Duration in seconds
-          example: 330
-        status:
-          type: string
-          enum: [success, failure, timeout]
-          example: "success"
-        exitCode:
-          type: integer
-          example: 0
-        output:
-          type: string
-          example: "Backup completed successfully"
-        error:
-          type: string
-          example: ""
-
-  responses:
-    Unauthorized:
-      description: Authentication required
-      content:
-        text/plain:
-          schema:
-            type: string
-            example: Unauthorized
-      headers:
-        WWW-Authenticate:
-          schema:
-            type: string
-            example: Bearer realm="Ofelia"
+        date: {type: string, format: date-time}
+        duration: {type: integer, description: nanoseconds}
+        failed: {type: boolean}
+        skipped: {type: boolean}
+        error: {type: string}
+        stdout: {type: string}
+        stderr: {type: string}


### PR DESCRIPTION
Fixes #805. `docs/API.md` documented endpoints that have never existed (`GET /api/job/{name}`, `PUT /api/job/{name}`, `PATCH …/toggle`, execution and scheduler-control routes, WebSocket events), and `openapi.yaml` carried the same fiction plus `/metrics`, which the web server does not mount. Both files are rewritten from the route table in `web/server.go` and the verified handler shapes: the three job listings with the real `apiJob` schema, `/api/jobs/{name}/history`, all POST mutations including the 403 origin gate on delete, the real login response and cookie semantics (no refresh endpoint exists), `/api/config` with stripped job collections, and the root-level health endpoints. Default server address corrected to `:8081`.

Documents current main only — nothing from the in-flight #789/#797 is included; both can now extend a spec that matches reality (as their reviews requested).

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_01L7tF9XuJfAfFk4yuY5KfPK)_