### PR TITLE
refactor(cli): move the shared job-registration tail into finishJob

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -605,55 +605,31 @@ func (c *Config) registerJob(name string, j core.Job) bool {
 }
 
 // registerAllJobs materializes every configured job and hands it to the
-// scheduler, in a fixed order per kind.
+// scheduler. The kinds are processed in the order below; within a kind
+// the order is Go's map iteration order, i.e. unspecified — nothing here
+// depends on it.
 //
-// One method per kind rather than one generic pass: the five prologues
-// genuinely differ — only the Docker-backed kinds take a provider and
-// runtime fields, only run and service inherit the global max-runtime —
-// and the config types embed different core jobs, so a shared interface
-// would have to be invented for the occasion. Splitting keeps each kind
-// readable on its own and leaves this function as what it says it is.
+// The five loops stay in one function on purpose. Their prologues really
+// do differ (only the Docker-backed kinds take a provider and initialize
+// runtime fields; only run and service inherit the global max-runtime),
+// and the config types embed different core jobs, so splitting them into
+// five methods only relocates the similarity into five signatures. What
+// they genuinely share is the tail, and that now lives in finishJob.
 func (c *Config) registerAllJobs() {
 	provider := c.dockerHandler.GetDockerProvider()
+	rejected := 0
+
 	wm := c.getWebhookManager()
 
-	rejected := c.registerExecJobs(provider, wm) +
-		c.registerRunJobs(provider, wm) +
-		c.registerLocalJobs(wm) +
-		c.registerServiceJobs(provider, wm) +
-		c.registerComposeJobs(wm)
-
-	// One line an operator can act on. Without it the only trace of a rejected
-	// job is a message among the startup noise, while the daemon reports
-	// itself healthy.
-	if rejected > 0 {
-		c.logger.Error("some jobs were not scheduled and will never run",
-			"rejected", rejected, "scheduled", len(c.sh.GetActiveJobs()))
-	}
-}
-
-// Each of the five below returns the number of jobs the scheduler refused.
-
-func (c *Config) registerExecJobs(provider core.DockerProvider, wm *middlewares.WebhookManager) int {
-	rejected := 0
 	for name, j := range c.ExecJobs {
 		_ = defaults.Set(j)
 		c.applyDefaultUser(&j.User)
 		j.Provider = provider
 		j.InitializeRuntimeFields()
 		j.Name = name
-		c.mergeNotificationDefaults(&j.SlackConfig, &j.MailConfig, &j.SaveConfig)
-		c.injectDedup(&j.SlackConfig, &j.MailConfig)
-		j.buildMiddlewares(c.logger, wm)
-		if !c.registerJob(name, j) {
-			rejected++
-		}
+		rejected += c.finishJob(name, j, &j.SlackConfig, &j.MailConfig, &j.SaveConfig,
+			func() { j.buildMiddlewares(c.logger, wm) })
 	}
-	return rejected
-}
-
-func (c *Config) registerRunJobs(provider core.DockerProvider, wm *middlewares.WebhookManager) int {
-	rejected := 0
 	for name, j := range c.RunJobs {
 		_ = defaults.Set(j)
 		c.applyDefaultUser(&j.User)
@@ -663,33 +639,15 @@ func (c *Config) registerRunJobs(provider core.DockerProvider, wm *middlewares.W
 		j.Provider = provider
 		j.InitializeRuntimeFields()
 		j.Name = name
-		c.mergeNotificationDefaults(&j.SlackConfig, &j.MailConfig, &j.SaveConfig)
-		c.injectDedup(&j.SlackConfig, &j.MailConfig)
-		j.buildMiddlewares(c.logger, wm)
-		if !c.registerJob(name, j) {
-			rejected++
-		}
+		rejected += c.finishJob(name, j, &j.SlackConfig, &j.MailConfig, &j.SaveConfig,
+			func() { j.buildMiddlewares(c.logger, wm) })
 	}
-	return rejected
-}
-
-func (c *Config) registerLocalJobs(wm *middlewares.WebhookManager) int {
-	rejected := 0
 	for name, j := range c.LocalJobs {
 		_ = defaults.Set(j)
 		j.Name = name
-		c.mergeNotificationDefaults(&j.SlackConfig, &j.MailConfig, &j.SaveConfig)
-		c.injectDedup(&j.SlackConfig, &j.MailConfig)
-		j.buildMiddlewares(c.logger, wm)
-		if !c.registerJob(name, j) {
-			rejected++
-		}
+		rejected += c.finishJob(name, j, &j.SlackConfig, &j.MailConfig, &j.SaveConfig,
+			func() { j.buildMiddlewares(c.logger, wm) })
 	}
-	return rejected
-}
-
-func (c *Config) registerServiceJobs(provider core.DockerProvider, wm *middlewares.WebhookManager) int {
-	rejected := 0
 	for name, j := range c.ServiceJobs {
 		_ = defaults.Set(j)
 		c.applyDefaultUser(&j.User)
@@ -699,29 +657,45 @@ func (c *Config) registerServiceJobs(provider core.DockerProvider, wm *middlewar
 		j.Provider = provider
 		j.InitializeRuntimeFields()
 		j.Name = name
-		c.mergeNotificationDefaults(&j.SlackConfig, &j.MailConfig, &j.SaveConfig)
-		c.injectDedup(&j.SlackConfig, &j.MailConfig)
-		j.buildMiddlewares(c.logger, wm)
-		if !c.registerJob(name, j) {
-			rejected++
-		}
+		rejected += c.finishJob(name, j, &j.SlackConfig, &j.MailConfig, &j.SaveConfig,
+			func() { j.buildMiddlewares(c.logger, wm) })
 	}
-	return rejected
-}
-
-func (c *Config) registerComposeJobs(wm *middlewares.WebhookManager) int {
-	rejected := 0
 	for name, j := range c.ComposeJobs {
 		_ = defaults.Set(j)
 		j.Name = name
-		c.mergeNotificationDefaults(&j.SlackConfig, &j.MailConfig, &j.SaveConfig)
-		c.injectDedup(&j.SlackConfig, &j.MailConfig)
-		j.buildMiddlewares(c.logger, wm)
-		if !c.registerJob(name, j) {
-			rejected++
-		}
+		rejected += c.finishJob(name, j, &j.SlackConfig, &j.MailConfig, &j.SaveConfig,
+			func() { j.buildMiddlewares(c.logger, wm) })
 	}
-	return rejected
+
+	// One line an operator can act on. Without it the only trace of a rejected
+	// job is a message among the startup noise, while the daemon reports
+	// itself healthy.
+	if rejected > 0 {
+		c.logger.Error("some jobs were not scheduled and will never run",
+			"rejected", rejected, "scheduled", registeredJobCount(c.sh))
+	}
+}
+
+// finishJob applies the settings every job kind shares — the notification
+// defaults, the dedup hook, the middleware chain — registers the job, and
+// reports 1 when the scheduler refused it so callers can accumulate
+// without a branch of their own.
+//
+// The notification configs come in as pointers and the middleware wiring
+// as a closure because the five *JobConfig types embed different core
+// jobs and share no interface. Inventing one to pass them implicitly
+// would be more machinery than this saves.
+func (c *Config) finishJob(name string, j core.Job,
+	slack *middlewares.SlackConfig, mail *middlewares.MailConfig, save *middlewares.SaveConfig,
+	buildMiddlewares func(),
+) int {
+	c.mergeNotificationDefaults(slack, mail, save)
+	c.injectDedup(slack, mail)
+	buildMiddlewares()
+	if c.registerJob(name, j) {
+		return 0
+	}
+	return 1
 }
 
 func (c *Config) injectDedup(slack *middlewares.SlackConfig, mail *middlewares.MailConfig) {

--- a/cli/config.go
+++ b/cli/config.go
@@ -604,12 +604,38 @@ func (c *Config) registerJob(name string, j core.Job) bool {
 	return true
 }
 
+// registerAllJobs materializes every configured job and hands it to the
+// scheduler, in a fixed order per kind.
+//
+// One method per kind rather than one generic pass: the five prologues
+// genuinely differ — only the Docker-backed kinds take a provider and
+// runtime fields, only run and service inherit the global max-runtime —
+// and the config types embed different core jobs, so a shared interface
+// would have to be invented for the occasion. Splitting keeps each kind
+// readable on its own and leaves this function as what it says it is.
 func (c *Config) registerAllJobs() {
 	provider := c.dockerHandler.GetDockerProvider()
-	rejected := 0
-
 	wm := c.getWebhookManager()
 
+	rejected := c.registerExecJobs(provider, wm) +
+		c.registerRunJobs(provider, wm) +
+		c.registerLocalJobs(wm) +
+		c.registerServiceJobs(provider, wm) +
+		c.registerComposeJobs(wm)
+
+	// One line an operator can act on. Without it the only trace of a rejected
+	// job is a message among the startup noise, while the daemon reports
+	// itself healthy.
+	if rejected > 0 {
+		c.logger.Error("some jobs were not scheduled and will never run",
+			"rejected", rejected, "scheduled", len(c.sh.GetActiveJobs()))
+	}
+}
+
+// Each of the five below returns the number of jobs the scheduler refused.
+
+func (c *Config) registerExecJobs(provider core.DockerProvider, wm *middlewares.WebhookManager) int {
+	rejected := 0
 	for name, j := range c.ExecJobs {
 		_ = defaults.Set(j)
 		c.applyDefaultUser(&j.User)
@@ -623,6 +649,11 @@ func (c *Config) registerAllJobs() {
 			rejected++
 		}
 	}
+	return rejected
+}
+
+func (c *Config) registerRunJobs(provider core.DockerProvider, wm *middlewares.WebhookManager) int {
+	rejected := 0
 	for name, j := range c.RunJobs {
 		_ = defaults.Set(j)
 		c.applyDefaultUser(&j.User)
@@ -639,6 +670,11 @@ func (c *Config) registerAllJobs() {
 			rejected++
 		}
 	}
+	return rejected
+}
+
+func (c *Config) registerLocalJobs(wm *middlewares.WebhookManager) int {
+	rejected := 0
 	for name, j := range c.LocalJobs {
 		_ = defaults.Set(j)
 		j.Name = name
@@ -649,6 +685,11 @@ func (c *Config) registerAllJobs() {
 			rejected++
 		}
 	}
+	return rejected
+}
+
+func (c *Config) registerServiceJobs(provider core.DockerProvider, wm *middlewares.WebhookManager) int {
+	rejected := 0
 	for name, j := range c.ServiceJobs {
 		_ = defaults.Set(j)
 		c.applyDefaultUser(&j.User)
@@ -665,6 +706,11 @@ func (c *Config) registerAllJobs() {
 			rejected++
 		}
 	}
+	return rejected
+}
+
+func (c *Config) registerComposeJobs(wm *middlewares.WebhookManager) int {
+	rejected := 0
 	for name, j := range c.ComposeJobs {
 		_ = defaults.Set(j)
 		j.Name = name
@@ -675,14 +721,7 @@ func (c *Config) registerAllJobs() {
 			rejected++
 		}
 	}
-
-	// One line an operator can act on. Without it the only trace of a rejected
-	// job is a message among the startup noise, while the daemon reports
-	// itself healthy.
-	if rejected > 0 {
-		c.logger.Error("some jobs were not scheduled and will never run",
-			"rejected", rejected, "scheduled", len(c.sh.GetActiveJobs()))
-	}
+	return rejected
 }
 
 func (c *Config) injectDedup(slack *middlewares.SlackConfig, mail *middlewares.MailConfig) {


### PR DESCRIPTION
Closes the last SonarCloud finding open on `main` and corrects the other half of #810, which I filed with the mechanism inverted.

## `registerAllJobs` — fixed

Five near-identical loops in one function, cognitive complexity 20 against a threshold of 15.

The first attempt split it into one method per job kind. That lowered the complexity but pushed the similarity between the run and service loops into new code, where SonarCloud measured it as 8.2% duplicated lines against a threshold of 3 — the metric correctly saying the split was half a refactor. Abstracting that similarity away would have meant inventing a shared interface with about a dozen accessor methods, because the two config types differ only in the core job they embed; that is more machinery than the seventeen lines are worth.

So the shape that landed is smaller. The kinds stay in one function, and what they genuinely share — the notification defaults, the dedup hook, the middleware chain, and the branch that counted a rejection — moves into `finishJob`. Because that helper returns the rejection count, no loop needs a branch of its own, and that alone takes the function under the threshold without touching the run and service prologues at all. Duplication on new code is 0.0%.

## Two findings from the review round

The doc comment I added promised registration "in a fixed order per kind", which Go's map iteration does not give. It now states that the order within a kind is unspecified and that nothing depends on it.

The startup summary counted `len(GetActiveJobs())`, which omits disabled jobs even though they stay registered — so it under-reported what was scheduled. It uses `registeredJobCount`, as `cli/daemon.go` already does. Pre-existing line that the refactor moved, which is how it surfaced.

## Auth vs. rate limiting — refuted, and my issue text was wrong

#810 states that `wrapMiddleware` "composes the chain so the per-IP rate limiter sees a request before the token check does", and derives from it that an anonymous flood can spend an authenticated client's budget. **That is backwards.** `wrapMiddleware` wraps inward-out, so `authMiddleware` is the outermost layer and runs first.

Measured rather than re-read: 150 anonymous requests to `/api/jobs` from one address, against a 100-per-minute budget, come back `map[401:150]` — every one turned away by auth, none counted by the limiter, and the address's budget still intact afterwards. The consequence the issue describes cannot occur.

The order actually in place is the defensible one: unauthenticated `/api/` requests are rejected before they can spend anyone's budget, while everything that passes auth — plus the static UI and the health endpoints, which auth lets through — is counted per IP. What stays unthrottled is token *validation* for a request carrying a bogus token, an HMAC comparison; moving the limiter outward to cover it would reintroduce exactly the shared-budget problem the issue wrongly claimed already exists. No change made.

My original review note (2026-08-26) said "auth-before-rate-limit", which was right; I inverted it when writing the issue up. That is worse than not filing at all, because the mechanism is what a fix would have been built on.

## CI note

`go-check / E2E Tests` failed once on this head with `websocket url timeout reached` — Chrome not coming up in the runner. Re-run, green. Not from this change: the same test passed on the previous commit of this branch, which touched the same file more heavily, and passes on `main`; the diff is one file with nothing browser-related in it.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_016HMCWKo6LHV83osTnC2MW2)_
