### PR TITLE
fix(web): keep the log scrolled where the reader left it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,8 +217,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   run's output threw the reader back to the top on the next 5s refresh,
   which made a long log effectively unreadable. The refresh rebuilds the
   history table, so the element that owns the scrollbar was replaced; the
-  scroll offset is now carried across, and a reader sitting at the bottom
-  of a still-growing log stays at the bottom
+  scroll offset is now carried across the rebuild
   ([#808](https://github.com/netresearch/ofelia/issues/808)).
 - **The Exec-mode switch reports its own state.** `role="switch"` on the
   create/edit form's Exec checkbox overrides the input's implicit role,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reason an edit or delete button is inert lived only in a data
   attribute; the bubble now carries `role="tooltip"` and its anchor
   `aria-describedby` (WCAG 2.2 SC 1.4.13 for the dismissal).
+- **A long log stays where you scrolled it.** Scrolling to the bottom of a
+  run's output threw the reader back to the top on the next 5s refresh,
+  which made a long log effectively unreadable. The refresh rebuilds the
+  history table, so the element that owns the scrollbar was replaced; the
+  scroll offset is now carried across, and a reader sitting at the bottom
+  of a still-growing log stays at the bottom
+  ([#808](https://github.com/netresearch/ofelia/issues/808)).
 - **The Exec-mode switch reports its own state.** `role="switch"` on the
   create/edit form's Exec checkbox overrides the input's implicit role,
   and with it the checked state the browser would otherwise expose — so

--- a/e2e/web_ui_log_scroll_test.go
+++ b/e2e/web_ui_log_scroll_test.go
@@ -1,0 +1,112 @@
+//go:build e2e && unix
+// +build e2e,unix
+
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package e2e
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+// TestE2E_WebUI_LogScrollSurvivesRefresh pins the fix for
+// https://github.com/netresearch/ofelia/issues/808.
+//
+// The reporter scrolled to the bottom of a long log and was thrown back to
+// the top about a second later, which makes a long log unreadable. The
+// cause is that the 5s poll rebuilds the history table via innerHTML: every
+// <pre> that owns the scrollbar is replaced, and a fresh element starts at
+// scrollTop 0. Keeping the row expanded across the refresh was already
+// handled (#764); where the reader had scrolled inside it was not.
+//
+// The job below produces a log far taller than the 20rem the output block
+// is capped at, and runs often enough that the history really does change
+// between ticks — a run that never changes would be skipped by the render
+// guard and would prove nothing.
+func TestE2E_WebUI_LogScrollSurvivesRefresh(t *testing.T) {
+	browserPath := chromeExecutable()
+	if browserPath == "" {
+		t.Skip("no Chrome/Chromium executable found")
+	}
+
+	addr := reserveLoopbackAddr(t)
+	configBody := `
+[job-local "chatty"]
+  schedule = @every 3s
+  command = sh -c 'seq 1 300 | sed "s/^/log line /"'
+`
+	configPath := writeConfig(t, configBody)
+	daemon := startDaemon(t, configPath, "--enable-web", "--web-address="+addr)
+	t.Cleanup(func() { daemon.shutdown(t, 15*time.Second) })
+
+	if err := daemon.waitForLog(`Job \"chatty\"`, 20*time.Second); err != nil {
+		t.Fatalf("job did not run before the UI check: %v\nstdout=%s", err, daemon.stdout.String())
+	}
+
+	allocCtx, cancelAlloc := chromedp.NewExecAllocator(context.Background(),
+		append(chromedp.DefaultExecAllocatorOptions[:],
+			chromedp.ExecPath(browserPath),
+		)...)
+	t.Cleanup(cancelAlloc)
+
+	browserCtx, cancelBrowser := chromedp.NewContext(allocCtx)
+	t.Cleanup(cancelBrowser)
+	ctx, cancelTimeout := context.WithTimeout(browserCtx, 120*time.Second)
+	t.Cleanup(cancelTimeout)
+
+	const (
+		jobRow        = `#jobs tbody tr[data-job-name="chatty"] button.job-name`
+		historyToggle = `#history tbody button[data-action="toggle-output"]`
+		openOutput    = `#history tbody tr.output-row.open pre`
+	)
+
+	var scrolledTo, maxScroll, afterRefresh float64
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate("http://"+addr+"/"),
+		chromedp.WaitVisible(jobRow, chromedp.ByQuery),
+		chromedp.Click(jobRow, chromedp.ByQuery),
+		chromedp.WaitVisible(historyToggle, chromedp.ByQuery),
+
+		// Expand a run's output, then scroll it to the bottom the way the
+		// reporter did.
+		chromedp.Evaluate(`document.querySelector('`+historyToggle+`').click(); true`, nil),
+		chromedp.Sleep(500*time.Millisecond),
+		chromedp.Evaluate(`(() => {
+			const pre = document.querySelector('`+openOutput+`');
+			if (!pre) return -1;
+			pre.scrollTop = pre.scrollHeight;
+			return pre.scrollTop;
+		})()`, &scrolledTo),
+		chromedp.Evaluate(`(() => {
+			const pre = document.querySelector('`+openOutput+`');
+			return pre ? pre.scrollHeight - pre.clientHeight : -1;
+		})()`, &maxScroll),
+
+		// Outlast a full refresh cycle plus another run of the job, so the
+		// history genuinely changes and the table is genuinely rebuilt.
+		chromedp.Sleep(uiRefreshInterval+4*time.Second),
+		chromedp.Evaluate(`(() => {
+			const pre = document.querySelector('`+openOutput+`');
+			return pre ? pre.scrollTop : -1;
+		})()`, &afterRefresh),
+	); err != nil {
+		t.Fatalf("driving the web UI failed: %v", err)
+	}
+
+	if maxScroll <= 0 {
+		t.Fatalf("the output block did not overflow (max scroll %.0f), so this test could not "+
+			"observe scrolling at all — the fixture log is too short for the block height", maxScroll)
+	}
+	if scrolledTo <= 0 {
+		t.Fatalf("could not scroll the output block (scrollTop %.0f)", scrolledTo)
+	}
+	if afterRefresh <= 0 {
+		t.Fatalf("the refresh reset the log to the top: scrollTop was %.0f before and %.0f after "+
+			"(issue #808)", scrolledTo, afterRefresh)
+	}
+}

--- a/e2e/web_ui_log_scroll_test.go
+++ b/e2e/web_ui_log_scroll_test.go
@@ -8,6 +8,7 @@ package e2e
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -70,7 +71,8 @@ func TestE2E_WebUI_LogScrollSurvivesRefresh(t *testing.T) {
 		lastOpenPre = `(() => { const p = document.querySelectorAll('#history tbody tr.output-row.open pre'); return p[p.length - 1]; })()`
 	)
 
-	var scrolledTo, maxScroll, afterRefresh float64
+	var scrolledTo, maxScroll, afterRefresh, bottomAfter float64
+	var newestKeyBefore string
 	if err := chromedp.Run(ctx,
 		chromedp.Navigate("http://"+addr+"/"),
 		chromedp.WaitVisible(jobRow, chromedp.ByQuery),
@@ -101,15 +103,42 @@ func TestE2E_WebUI_LogScrollSurvivesRefresh(t *testing.T) {
 			return pre ? pre.scrollHeight - pre.clientHeight : -1;
 		})()`, &maxScroll),
 
-		// Outlast a full refresh cycle plus another run of the job, so the
-		// history genuinely changes and the table is genuinely rebuilt.
-		chromedp.Sleep(uiRefreshInterval+4*time.Second),
+		// The newest run's key, so the wait below can tell a rebuilt table
+		// from a table nothing happened to.
+		chromedp.Evaluate(`(() => {
+			const all = document.querySelectorAll('`+historyToggle+`');
+			const b = all[all.length - 1];
+			return b ? String(b.dataset.key) : '';
+		})()`, &newestKeyBefore),
+	); err != nil {
+		t.Fatalf("driving the web UI failed: %v", err)
+	}
+
+	// Wait for the table to actually be rebuilt rather than assuming it. A
+	// bare sleep would pass even if the refresh had stopped happening —
+	// precisely the condition this test exists to notice. A different
+	// newest key proves a new execution landed and the poll re-rendered
+	// the table around the block whose scroll position is under test.
+	newestChanged := `(() => {
+		const all = document.querySelectorAll('` + historyToggle + `');
+		const b = all[all.length - 1];
+		return !!b && String(b.dataset.key) !== ` + strconv.Quote(newestKeyBefore) + `;
+	})()`
+	if err := chromedp.Run(ctx,
+		chromedp.Poll(newestChanged, nil, chromedp.WithPollingTimeout(40*time.Second)),
 		chromedp.Evaluate(`(() => {
 			const pre = `+lastOpenPre+`;
 			return pre ? pre.scrollTop : -1;
 		})()`, &afterRefresh),
+		// The bottom as it stands AFTER the rebuild: comparing only against
+		// the old absolute offset would pass even if the block had grown
+		// and the reader were no longer at the end of it.
+		chromedp.Evaluate(`(() => {
+			const pre = `+lastOpenPre+`;
+			return pre ? pre.scrollHeight - pre.clientHeight : -1;
+		})()`, &bottomAfter),
 	); err != nil {
-		t.Fatalf("driving the web UI failed: %v", err)
+		t.Fatalf("waiting for the refresh failed: %v", err)
 	}
 
 	if maxScroll <= 0 {
@@ -128,5 +157,9 @@ func TestE2E_WebUI_LogScrollSurvivesRefresh(t *testing.T) {
 		t.Fatalf("the refresh moved the log away from where the reader left it: scrollTop was "+
 			"%.0f (bottom, max %.0f) before and %.0f after (issue #808)",
 			scrolledTo, maxScroll, afterRefresh)
+	}
+	if afterRefresh < bottomAfter-tolerance {
+		t.Fatalf("the reader was at the bottom and is no longer: scrollTop %.0f against a "+
+			"post-refresh bottom of %.0f (issue #808)", afterRefresh, bottomAfter)
 	}
 }

--- a/e2e/web_ui_log_scroll_test.go
+++ b/e2e/web_ui_log_scroll_test.go
@@ -29,6 +29,8 @@ import (
 // between ticks — a run that never changes would be skipped by the render
 // guard and would prove nothing.
 func TestE2E_WebUI_LogScrollSurvivesRefresh(t *testing.T) {
+	t.Parallel()
+
 	browserPath := chromeExecutable()
 	if browserPath == "" {
 		t.Skip("no Chrome/Chromium executable found")
@@ -38,7 +40,7 @@ func TestE2E_WebUI_LogScrollSurvivesRefresh(t *testing.T) {
 	configBody := `
 [job-local "chatty"]
   schedule = @every 3s
-  command = sh -c 'seq 1 300 | sed "s/^/log line /"'
+  command = sh -c 'seq 1 300 | sed "s/^/log line /" && seq 1 300 | sed "s/^/err line /" 1>&2'
 `
 	configPath := writeConfig(t, configBody)
 	daemon := startDaemon(t, configPath, "--enable-web", "--web-address="+addr)
@@ -62,7 +64,10 @@ func TestE2E_WebUI_LogScrollSurvivesRefresh(t *testing.T) {
 	const (
 		jobRow        = `#jobs tbody tr[data-job-name="chatty"] button.job-name`
 		historyToggle = `#history tbody button[data-action="toggle-output"]`
-		openOutput    = `#history tbody tr.output-row.open pre`
+		// The stderr block, i.e. the second <pre> of the expanded subrow —
+		// the one whose scroll key would be wrong if the state were keyed by
+		// position instead of by stream.
+		lastOpenPre = `(() => { const p = document.querySelectorAll('#history tbody tr.output-row.open pre'); return p[p.length - 1]; })()`
 	)
 
 	var scrolledTo, maxScroll, afterRefresh float64
@@ -72,18 +77,27 @@ func TestE2E_WebUI_LogScrollSurvivesRefresh(t *testing.T) {
 		chromedp.Click(jobRow, chromedp.ByQuery),
 		chromedp.WaitVisible(historyToggle, chromedp.ByQuery),
 
-		// Expand a run's output, then scroll it to the bottom the way the
-		// reporter did.
-		chromedp.Evaluate(`document.querySelector('`+historyToggle+`').click(); true`, nil),
+		// Expand the NEWEST run, not the first: the history is capped, so
+		// the oldest row is the one about to be evicted, and picking it
+		// makes the test flaky on a slow runner for reasons that have
+		// nothing to do with scrolling. Same rationale as
+		// TestE2E_WebUI_ExpandedOutputSurvivesRefresh.
+		chromedp.Evaluate(`(() => {
+			const all = document.querySelectorAll('`+historyToggle+`');
+			const btn = all[all.length - 1];
+			if (!btn) return false;
+			btn.click();
+			return true;
+		})()`, nil),
 		chromedp.Sleep(500*time.Millisecond),
 		chromedp.Evaluate(`(() => {
-			const pre = document.querySelector('`+openOutput+`');
+			const pre = `+lastOpenPre+`;
 			if (!pre) return -1;
 			pre.scrollTop = pre.scrollHeight;
 			return pre.scrollTop;
 		})()`, &scrolledTo),
 		chromedp.Evaluate(`(() => {
-			const pre = document.querySelector('`+openOutput+`');
+			const pre = `+lastOpenPre+`;
 			return pre ? pre.scrollHeight - pre.clientHeight : -1;
 		})()`, &maxScroll),
 
@@ -91,7 +105,7 @@ func TestE2E_WebUI_LogScrollSurvivesRefresh(t *testing.T) {
 		// history genuinely changes and the table is genuinely rebuilt.
 		chromedp.Sleep(uiRefreshInterval+4*time.Second),
 		chromedp.Evaluate(`(() => {
-			const pre = document.querySelector('`+openOutput+`');
+			const pre = `+lastOpenPre+`;
 			return pre ? pre.scrollTop : -1;
 		})()`, &afterRefresh),
 	); err != nil {
@@ -105,8 +119,14 @@ func TestE2E_WebUI_LogScrollSurvivesRefresh(t *testing.T) {
 	if scrolledTo <= 0 {
 		t.Fatalf("could not scroll the output block (scrollTop %.0f)", scrolledTo)
 	}
-	if afterRefresh <= 0 {
-		t.Fatalf("the refresh reset the log to the top: scrollTop was %.0f before and %.0f after "+
-			"(issue #808)", scrolledTo, afterRefresh)
+	// Not merely "non-zero": a jump to a small offset would satisfy that
+	// while still losing the reader's place. The fixture scrolled to the
+	// bottom, so the position afterwards has to still be the bottom, give
+	// or take sub-pixel rounding.
+	const tolerance = 4
+	if afterRefresh < scrolledTo-tolerance {
+		t.Fatalf("the refresh moved the log away from where the reader left it: scrollTop was "+
+			"%.0f (bottom, max %.0f) before and %.0f after (issue #808)",
+			scrolledTo, maxScroll, afterRefresh)
 	}
 }

--- a/static/ui/app.js
+++ b/static/ui/app.js
@@ -840,6 +840,14 @@ function renderHistory() {
       ? Array.from(tbody.querySelectorAll('tr.output-row.open')).map(r => r.dataset.key)
       : []
   );
+  // Preserve where the user had scrolled inside each expanded output. The
+  // rebuild below replaces every <pre>, and a fresh element starts at
+  // scrollTop 0 — so a job that keeps producing runs yanked the reader
+  // back to the top of the log on every 5s tick, which made a long log
+  // impossible to read (#808). Same keying as openOutputs, plus the index
+  // of the block within the subrow, because stdout and stderr each get
+  // their own scroller.
+  const openScroll = tbody.dataset.job === name ? captureOutputScroll(tbody) : new Map();
   tbody.dataset.job = name;
   tbody.innerHTML = '';
   if (historyCache.length === 0) {
@@ -877,6 +885,35 @@ function renderHistory() {
     frag.appendChild(sub);
   });
   tbody.appendChild(frag);
+  restoreOutputScroll(tbody, openScroll);
+}
+
+/* Where each expanded output block is scrolled to, keyed by run and by
+   position within the subrow. A reader sitting at the bottom is recorded
+   as such rather than by offset: for a run that is still growing, the
+   offset that was the bottom a tick ago is no longer the bottom, and
+   pinning it there would drift away from the newest output. */
+function captureOutputScroll(tbody) {
+  const scroll = new Map();
+  tbody.querySelectorAll('tr.output-row.open').forEach(row => {
+    row.querySelectorAll('pre').forEach((pre, i) => {
+      if (pre.scrollTop === 0) return;
+      const atBottom = pre.scrollHeight - pre.scrollTop - pre.clientHeight <= 2;
+      scroll.set(`${row.dataset.key}\u0000${i}`, atBottom ? 'bottom' : pre.scrollTop);
+    });
+  });
+  return scroll;
+}
+
+function restoreOutputScroll(tbody, scroll) {
+  if (scroll.size === 0) return;
+  tbody.querySelectorAll('tr.output-row.open').forEach(row => {
+    row.querySelectorAll('pre').forEach((pre, i) => {
+      const at = scroll.get(`${row.dataset.key}\u0000${i}`);
+      if (at === undefined) return;
+      pre.scrollTop = at === 'bottom' ? pre.scrollHeight : at;
+    });
+  });
 }
 
 /* Toggle an output subrow open/closed; the run's own row is highlighted

--- a/static/ui/app.js
+++ b/static/ui/app.js
@@ -900,18 +900,19 @@ function outputScrollKey(row, pre) {
   return `${row.dataset.key}\u0000${outputStream(pre)}`;
 }
 
-/* Where each expanded output block is scrolled to. A reader sitting at
-   the bottom is recorded as such rather than by offset: for a run that is
-   still growing, the offset that was the bottom a tick ago is no longer
-   the bottom, and pinning it there would drift away from the newest
-   output. */
+/* Where each expanded output block is scrolled to.
+   The offset is enough — no separate "was at the bottom" state. The table
+   only ever shows COMPLETED runs (SetLastRun runs in jobWrapper.stop,
+   after ctx.Stop), so an expanded run's output is immutable: its
+   scrollHeight after a rebuild is the height it had before, and the saved
+   offset still means the same place. An earlier version carried a
+   'bottom' sentinel for runs that keep growing; no such run is ever in
+   this table, so it could not differ from the offset it replaced. */
 function captureOutputScroll(tbody) {
   const scroll = new Map();
   tbody.querySelectorAll('tr.output-row.open').forEach(row => {
     row.querySelectorAll('pre').forEach(pre => {
-      if (pre.scrollTop === 0) return;
-      const atBottom = pre.scrollHeight - pre.scrollTop - pre.clientHeight <= 2;
-      scroll.set(outputScrollKey(row, pre), atBottom ? 'bottom' : pre.scrollTop);
+      if (pre.scrollTop > 0) scroll.set(outputScrollKey(row, pre), pre.scrollTop);
     });
   });
   return scroll;
@@ -922,8 +923,7 @@ function restoreOutputScroll(tbody, scroll) {
   tbody.querySelectorAll('tr.output-row.open').forEach(row => {
     row.querySelectorAll('pre').forEach(pre => {
       const at = scroll.get(outputScrollKey(row, pre));
-      if (at === undefined) return;
-      pre.scrollTop = at === 'bottom' ? pre.scrollHeight : at;
+      if (at !== undefined) pre.scrollTop = at;
     });
   });
 }

--- a/static/ui/app.js
+++ b/static/ui/app.js
@@ -844,9 +844,9 @@ function renderHistory() {
   // rebuild below replaces every <pre>, and a fresh element starts at
   // scrollTop 0 — so a job that keeps producing runs yanked the reader
   // back to the top of the log on every 5s tick, which made a long log
-  // impossible to read (#808). Same keying as openOutputs, plus the index
-  // of the block within the subrow, because stdout and stderr each get
-  // their own scroller.
+  // impossible to read (#808). Same keying as openOutputs, plus which
+  // stream the block shows, because stdout and stderr each get their own
+  // scroller.
   const openScroll = tbody.dataset.job === name ? captureOutputScroll(tbody) : new Map();
   tbody.dataset.job = name;
   tbody.innerHTML = '';
@@ -888,18 +888,30 @@ function renderHistory() {
   restoreOutputScroll(tbody, openScroll);
 }
 
-/* Where each expanded output block is scrolled to, keyed by run and by
-   position within the subrow. A reader sitting at the bottom is recorded
-   as such rather than by offset: for a run that is still growing, the
-   offset that was the bottom a tick ago is no longer the bottom, and
-   pinning it there would drift away from the newest output. */
+/* Which stream an output block shows. Used as part of the scroll key so
+   the saved position follows the stream rather than its position in the
+   subrow: a run that has only stderr renders one block at index 0, and
+   keying by index would hand that offset to stdout if the same key ever
+   rendered both. */
+function outputStream(pre) {
+  return pre.classList.contains('stderr') ? 'stderr' : 'stdout';
+}
+function outputScrollKey(row, pre) {
+  return `${row.dataset.key}\u0000${outputStream(pre)}`;
+}
+
+/* Where each expanded output block is scrolled to. A reader sitting at
+   the bottom is recorded as such rather than by offset: for a run that is
+   still growing, the offset that was the bottom a tick ago is no longer
+   the bottom, and pinning it there would drift away from the newest
+   output. */
 function captureOutputScroll(tbody) {
   const scroll = new Map();
   tbody.querySelectorAll('tr.output-row.open').forEach(row => {
-    row.querySelectorAll('pre').forEach((pre, i) => {
+    row.querySelectorAll('pre').forEach(pre => {
       if (pre.scrollTop === 0) return;
       const atBottom = pre.scrollHeight - pre.scrollTop - pre.clientHeight <= 2;
-      scroll.set(`${row.dataset.key}\u0000${i}`, atBottom ? 'bottom' : pre.scrollTop);
+      scroll.set(outputScrollKey(row, pre), atBottom ? 'bottom' : pre.scrollTop);
     });
   });
   return scroll;
@@ -908,8 +920,8 @@ function captureOutputScroll(tbody) {
 function restoreOutputScroll(tbody, scroll) {
   if (scroll.size === 0) return;
   tbody.querySelectorAll('tr.output-row.open').forEach(row => {
-    row.querySelectorAll('pre').forEach((pre, i) => {
-      const at = scroll.get(`${row.dataset.key}\u0000${i}`);
+    row.querySelectorAll('pre').forEach(pre => {
+      const at = scroll.get(outputScrollKey(row, pre));
       if (at === undefined) return;
       pre.scrollTop = at === 'bottom' ? pre.scrollHeight : at;
     });


### PR DESCRIPTION
Fixes the one open issue that is a genuine, user-reported bug. Closes #808.

## What happens

Scroll to the bottom of a long run output in the history modal and about a second later you are back at the top, which makes a long log effectively unreadable. Reported against 0.30.0 by @radoeka.

The 5s poll rebuilds the history table through `innerHTML`, so every `<pre>` that owns the scrollbar is replaced and the fresh element starts at `scrollTop` 0. Which rows stay expanded across a refresh was already preserved (#764); *where* the reader had scrolled inside them was not.

## The fix

`renderHistory` captures the scroll offset of each open output block before the wipe and restores it afterwards, keyed by run and by stream — stdout and stderr each get their own scroller, and keying by position instead would hand one stream's offset to the other if a run ever rendered a different set of blocks.

An earlier revision also carried a "was at the bottom" sentinel so a reader at the end of a growing log would stay at the end. Review caught that as dead code, and it was: this table only ever shows completed runs — `SetLastRun` runs in `jobWrapper.stop`, after `ctx.Stop` — so an expanded run's output is immutable and its `scrollHeight` after a rebuild is the height it had before. The branch could not produce a different result from the offset it replaced, and it is gone.

## Reproduced first, then fixed

`e2e/web_ui_log_scroll_test.go` drives a real browser, scrolls a 300-line log to the bottom, and then waits for the newest run's key to change — proving a new execution landed *and* that the table was re-rendered around the block under test, where a fixed sleep would have passed even with refreshing switched off entirely.

It asserts the position both against where the reader left it and against the bottom as measured after the rebuild, so a block that had grown would fail even with the old absolute offset preserved. The fixture job writes to both stdout and stderr, so the subrow renders two scrollers and the per-stream key is exercised rather than assumed; the test targets the stderr block, the one a position-based key would have got wrong.

Against the pre-fix build it fails with `scrollTop was 4284 (bottom, max 4284) before and 0 after`. With the fix it passes. Both directions were run locally after every revision.

## Also for the reporter

@radoeka asked where to find the version in the GUI. It is in the footer as of the dashboard rebuild in #797, which is on `main` but not yet released — so it will be there in the next version, not in 0.30.0.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_016HMCWKo6LHV83osTnC2MW2)_
