### PR TITLE
test(web): hold the OpenAPI job types to what the handler accepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   value, so a changed global reaches restored jobs at the next start the
   way it reaches INI ones. `"0s"` still means the same as omitting the
   field ([#806](https://github.com/netresearch/ofelia/issues/806)).
+- **The OpenAPI job-request schema is now held to what the handler
+  accepts.** Nothing validated `docs/openapi.yaml`, so it drifted: it
+  advertised a job type `service-run` that `jobFromRequest` rejects and
+  `jobType` never emits, and it marked `type` as required although an
+  omitted type is a valid request that yields a local job. Both were
+  found by reading the diff, which is not a mechanism. A test now
+  compares the documented `type` enum against the tokens the real handler
+  dispatches on, and fails rather than skips when it cannot find the enum
+  ([#816](https://github.com/netresearch/ofelia/issues/816)).
 - **A delete landing mid-update can no longer leave a ghost job.**
   `RemoveJob` drops the cron entry before it takes the scheduler lock, so
   it can complete inside `UpdateJob`'s window; the update then reinserted

--- a/web/openapi_job_types_test.go
+++ b/web/openapi_job_types_test.go
@@ -142,9 +142,10 @@ func literalString(expr ast.Expr) (string, bool) {
 }
 
 // candidateJobTypes is the population offered to the handler: everything the
-// handler dispatches on, everything the document claims, and two tokens that
-// must come back rejected -- jobTypeService, which is documented as not
-// creatable, and one no code path knows.
+// handler dispatches on, everything the document claims, and three tokens
+// that must come back rejected -- jobTypeService and "service-run", the two
+// spellings of the type that is documented as not creatable over the API
+// (#816), and "nonesuch", which no code path knows.
 func candidateJobTypes(t *testing.T, documented []string) []string {
 	t.Helper()
 

--- a/web/openapi_job_types_test.go
+++ b/web/openapi_job_types_test.go
@@ -1,13 +1,19 @@
 package web
 
 import (
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/netresearch/ofelia/core"
 )
 
 // The published OpenAPI description of a job-create request and the switch
@@ -23,6 +29,9 @@ import (
 
 const openAPIRelPath = "../docs/openapi.yaml"
 
+// handlerFile is read from the package directory the test runs in.
+const handlerFile = "server.go"
+
 // unknownTypeMarker is the substring of the error jobFromRequest's default
 // arm returns. It is the only signal that separates "the switch refused this
 // token" from "the switch dispatched and construction failed later".
@@ -33,22 +42,122 @@ const openAPIRelPath = "../docs/openapi.yaml"
 // sentinel in candidateJobTypes is for. Reflect the new wording here.
 const unknownTypeMarker = "unknown job type"
 
-// candidateJobTypes is the population offered to the handler. It deliberately
-// includes jobTypeService, which is documented as not creatable and must come
-// back rejected, and a token no code path knows.
+// handlerJobTypes reads the tokens jobFromRequest dispatches on straight out
+// of its type switch, resolving the jobType* constants from the same file.
 //
-// This slice is the one hand-kept part of the test: a new jobType* constant
-// has to be added here, or it goes unexercised.
-func candidateJobTypes() []string {
-	return []string{
-		jobTypeRun,
-		jobTypeExec,
-		jobTypeLocal,
-		jobTypeService,
-		jobTypeCompose,
-		"service-run",
-		"nonesuch",
+// A hand-kept list would have left the guard's main case open: a new arm in
+// the handler that nobody documents is exactly the drift this test exists to
+// catch, and a list that has to be remembered would not have contained it.
+//
+// The empty string is dropped. `case "", jobTypeLocal` makes an omitted type
+// valid, but "omitted" is not an enum value -- TestOpenAPI_JobTypeNotRequired
+// covers that half.
+func handlerJobTypes(t *testing.T) []string {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, handlerFile, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", handlerFile, err)
 	}
+
+	consts := stringConsts(file)
+
+	var found []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		fn, ok := n.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "jobFromRequest" {
+			return true
+		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			clause, ok := n.(*ast.CaseClause)
+			if !ok {
+				return true
+			}
+			for _, expr := range clause.List { // nil for `default`
+				if tok, ok := caseToken(expr, consts); ok && tok != "" {
+					found = append(found, tok)
+				}
+			}
+			return true
+		})
+		return false
+	})
+
+	if len(found) == 0 {
+		t.Fatalf("no case tokens found in jobFromRequest in %s — the handler "+
+			"was restructured and this test no longer reads it", handlerFile)
+	}
+	sort.Strings(found)
+	return found
+}
+
+// stringConsts maps every top-level string constant in the file to its value,
+// so a case written as jobTypeRun resolves to "run".
+func stringConsts(file *ast.File) map[string]string {
+	out := map[string]string{}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if i >= len(vs.Values) {
+					continue
+				}
+				if lit, ok := literalString(vs.Values[i]); ok {
+					out[name.Name] = lit
+				}
+			}
+		}
+	}
+	return out
+}
+
+func caseToken(expr ast.Expr, consts map[string]string) (string, bool) {
+	switch e := expr.(type) {
+	case *ast.Ident:
+		v, ok := consts[e.Name]
+		return v, ok
+	default:
+		return literalString(expr)
+	}
+}
+
+func literalString(expr ast.Expr) (string, bool) {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	v, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return v, true
+}
+
+// candidateJobTypes is the population offered to the handler: everything the
+// handler dispatches on, everything the document claims, and two tokens that
+// must come back rejected -- jobTypeService, which is documented as not
+// creatable, and one no code path knows.
+func candidateJobTypes(t *testing.T, documented []string) []string {
+	t.Helper()
+
+	seen := map[string]bool{}
+	var out []string
+	for _, tok := range append(append(handlerJobTypes(t), documented...),
+		jobTypeService, "service-run", "nonesuch") {
+		if tok != "" && !seen[tok] {
+			seen[tok] = true
+			out = append(out, tok)
+		}
+	}
+	return out
 }
 
 // openAPIJobRequest is the slice of the spec this test reads.
@@ -92,12 +201,12 @@ func readOpenAPIJobRequest(t *testing.T) openAPIJobRequest {
 //
 // A nil provider makes the run and exec constructors fail, which is what we
 // want: it proves the switch reached them without needing Docker.
-func acceptedJobTypes(t *testing.T) []string {
+func acceptedJobTypes(t *testing.T, documented []string) []string {
 	t.Helper()
 
 	s := &Server{}
 	var accepted []string
-	for _, typ := range candidateJobTypes() {
+	for _, typ := range candidateJobTypes(t, documented) {
 		_, err := s.jobFromRequest(&jobRequest{Name: "guard", Type: typ})
 		if err != nil && strings.Contains(err.Error(), unknownTypeMarker) {
 			continue
@@ -113,7 +222,7 @@ func TestOpenAPI_JobTypeEnumMatchesHandler(t *testing.T) {
 	documented := append([]string(nil), spec.Components.Schemas.JobRequest.Properties.Type.Enum...)
 	sort.Strings(documented)
 
-	accepted := acceptedJobTypes(t)
+	accepted := acceptedJobTypes(t, documented)
 
 	if strings.Join(documented, ",") != strings.Join(accepted, ",") {
 		t.Errorf("docs/openapi.yaml documents job types %v, jobFromRequest accepts %v.\n"+
@@ -135,9 +244,16 @@ func TestOpenAPI_JobTypeNotRequired(t *testing.T) {
 		}
 	}
 
-	if _, err := (&Server{}).jobFromRequest(&jobRequest{Name: "guard"}); err != nil &&
-		strings.Contains(err.Error(), unknownTypeMarker) {
-		t.Errorf("an empty type is rejected by the switch; the spec's "+
-			"%q description no longer holds", "omitted means local")
+	// Not just "the switch did not refuse it" — the request has to succeed
+	// and yield a local job, which is what "omitted means local" claims. The
+	// weaker form accepted any failure that was not `unknown job type`, so a
+	// local constructor that started erroring would have passed it.
+	job, err := (&Server{}).jobFromRequest(&jobRequest{Name: "guard"})
+	if err != nil {
+		t.Fatalf("an empty type is not accepted: %v — the spec's "+
+			"%q description no longer holds", err, "omitted means local")
+	}
+	if _, ok := job.(*core.LocalJob); !ok {
+		t.Errorf("an empty type produced %T, want *core.LocalJob", job)
 	}
 }

--- a/web/openapi_job_types_test.go
+++ b/web/openapi_job_types_test.go
@@ -59,7 +59,7 @@ type openAPIJobRequest struct {
 						Enum []string `yaml:"enum"`
 					} `yaml:"type"`
 				} `yaml:"properties"`
-			} `yaml:"JobRequest"`
+			} `yaml:"JobRequest"` //nolint:tagliatelle // schema key is spelled by the OpenAPI document, must match exactly
 		} `yaml:"schemas"`
 	} `yaml:"components"`
 }

--- a/web/openapi_job_types_test.go
+++ b/web/openapi_job_types_test.go
@@ -1,0 +1,142 @@
+//go:build !e2e
+
+package web
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The published OpenAPI description of a job-create request and the switch
+// that implements it drifted apart without anything objecting: the schema
+// advertised a type "service-run" that jobFromRequest rejects and jobType
+// never emits, and it listed "type" as required although an omitted type is
+// a valid request. Both were found by a reviewer reading the diff, which is
+// not a mechanism (issue #816).
+//
+// No workflow validates docs/openapi.yaml, so this test is the whole gate.
+// It compares the documented enum against the tokens the real handler takes,
+// classifying by the one error the type switch itself produces.
+
+const openAPIRelPath = "../docs/openapi.yaml"
+
+// unknownTypeMarker is the substring of the error jobFromRequest's default
+// arm returns. It is the only signal that separates "the switch refused this
+// token" from "the switch dispatched and construction failed later", so a
+// reworded error must be reflected here or this test silently accepts
+// everything.
+const unknownTypeMarker = "unknown job type"
+
+// candidateJobTypes is the population offered to the handler. It deliberately
+// includes jobTypeService, which is documented as not creatable and must come
+// back rejected, and a token no code path knows.
+//
+// This slice is the one hand-kept part of the test: a new jobType* constant
+// has to be added here, or it goes unexercised.
+func candidateJobTypes() []string {
+	return []string{
+		jobTypeRun,
+		jobTypeExec,
+		jobTypeLocal,
+		jobTypeService,
+		jobTypeCompose,
+		"service-run",
+		"nonesuch",
+	}
+}
+
+// openAPIJobRequest is the slice of the spec this test reads.
+type openAPIJobRequest struct {
+	Components struct {
+		Schemas struct {
+			JobRequest struct {
+				Required   []string `yaml:"required"`
+				Properties struct {
+					Type struct {
+						Enum []string `yaml:"enum"`
+					} `yaml:"type"`
+				} `yaml:"properties"`
+			} `yaml:"JobRequest"`
+		} `yaml:"schemas"`
+	} `yaml:"components"`
+}
+
+func readOpenAPIJobRequest(t *testing.T) openAPIJobRequest {
+	t.Helper()
+
+	raw, err := os.ReadFile(filepath.Clean(openAPIRelPath))
+	if err != nil {
+		t.Fatalf("read %s: %v", openAPIRelPath, err)
+	}
+	var spec openAPIJobRequest
+	if err := yaml.Unmarshal(raw, &spec); err != nil {
+		t.Fatalf("parse %s: %v", openAPIRelPath, err)
+	}
+	// A renamed or restructured schema yields a zero value that would make
+	// every assertion below vacuous, so it fails here instead.
+	if len(spec.Components.Schemas.JobRequest.Properties.Type.Enum) == 0 {
+		t.Fatalf("no components.schemas.JobRequest.properties.type.enum in %s — "+
+			"the schema moved and this test no longer reads it", openAPIRelPath)
+	}
+	return spec
+}
+
+// acceptedJobTypes returns the candidates the type switch dispatches on,
+// driving the real handler rather than a second copy of the list.
+//
+// A nil provider makes the run and exec constructors fail, which is what we
+// want: it proves the switch reached them without needing Docker.
+func acceptedJobTypes(t *testing.T) []string {
+	t.Helper()
+
+	s := &Server{}
+	var accepted []string
+	for _, typ := range candidateJobTypes() {
+		_, err := s.jobFromRequest(&jobRequest{Name: "guard", Type: typ})
+		if err != nil && strings.Contains(err.Error(), unknownTypeMarker) {
+			continue
+		}
+		accepted = append(accepted, typ)
+	}
+	sort.Strings(accepted)
+	return accepted
+}
+
+func TestOpenAPI_JobTypeEnumMatchesHandler(t *testing.T) {
+	spec := readOpenAPIJobRequest(t)
+	documented := append([]string(nil), spec.Components.Schemas.JobRequest.Properties.Type.Enum...)
+	sort.Strings(documented)
+
+	accepted := acceptedJobTypes(t)
+
+	if strings.Join(documented, ",") != strings.Join(accepted, ",") {
+		t.Errorf("docs/openapi.yaml documents job types %v, jobFromRequest accepts %v.\n"+
+			"Whichever is wrong, the two have to say the same thing — see issue #816.",
+			documented, accepted)
+	}
+}
+
+// TestOpenAPI_JobTypeNotRequired pins the second half of the same drift: an
+// omitted type is a valid request that yields a local job, so a generated
+// client must not be told the field is mandatory.
+func TestOpenAPI_JobTypeNotRequired(t *testing.T) {
+	spec := readOpenAPIJobRequest(t)
+
+	for _, field := range spec.Components.Schemas.JobRequest.Required {
+		if field == "type" {
+			t.Errorf("docs/openapi.yaml marks type as required, but jobFromRequest "+
+				"has a `case \"\", %s` arm — an omitted type is a valid body", jobTypeLocal)
+		}
+	}
+
+	if _, err := (&Server{}).jobFromRequest(&jobRequest{Name: "guard"}); err != nil &&
+		strings.Contains(err.Error(), unknownTypeMarker) {
+		t.Errorf("an empty type is rejected by the switch; the spec's "+
+			"%q description no longer holds", "omitted means local")
+	}
+}

--- a/web/openapi_job_types_test.go
+++ b/web/openapi_job_types_test.go
@@ -1,5 +1,3 @@
-//go:build !e2e
-
 package web
 
 import (

--- a/web/openapi_job_types_test.go
+++ b/web/openapi_job_types_test.go
@@ -25,9 +25,12 @@ const openAPIRelPath = "../docs/openapi.yaml"
 
 // unknownTypeMarker is the substring of the error jobFromRequest's default
 // arm returns. It is the only signal that separates "the switch refused this
-// token" from "the switch dispatched and construction failed later", so a
-// reworded error must be reflected here or this test silently accepts
-// everything.
+// token" from "the switch dispatched and construction failed later".
+//
+// Rewording that error does not quietly weaken the test: every candidate
+// then counts as accepted, and the assertion fails naming "nonesuch" and
+// "service-run" among them — a result wrong on sight, which is what the
+// sentinel in candidateJobTypes is for. Reflect the new wording here.
 const unknownTypeMarker = "unknown job type"
 
 // candidateJobTypes is the population offered to the handler. It deliberately


### PR DESCRIPTION
Closes [#816](https://github.com/netresearch/ofelia/issues/816).

`docs/openapi.yaml` drifted from the handler twice, and both times a person reading the diff was the only thing that caught it: the schema advertised a job type `service-run` that `jobFromRequest` rejects and `jobType` never emits, and it marked `type` as required although an omitted type is a valid request that yields a local job. No workflow in `.github/workflows` validates the spec, so nothing else was ever going to notice.

## What the test does

`TestOpenAPI_JobTypeEnumMatchesHandler` reads `components.schemas.JobRequest.properties.type.enum` and compares it to the tokens the real handler dispatches on. The accepted set is obtained by calling `s.jobFromRequest` over a candidate list and classifying by the one error the type switch itself produces — `unknown job type` means refused, anything else means the switch dispatched and construction failed later. A nil provider is deliberate: the run and exec constructors then fail, which proves the switch reached them without needing Docker. Comparing against a second hand-kept copy of the list would have made the test agree with itself.

`jobTypeService` is in the candidates on purpose and must come back rejected. That turns "service jobs cannot be created over the API" from a comment into an asserted fact.

`TestOpenAPI_JobTypeNotRequired` pins the other half: `type` must not appear in the schema's `required` list, and an empty type must still be accepted by the switch.

A missing, renamed or empty enum is a `t.Fatal`, never a skip. A guard that goes quiet when it loses its input reads as green while checking nothing.

## Verified by injecting the defects

Each mutation was applied, the test run, and the tree restored:

| Injected defect | Result |
|---|---|
| `compose` removed from the documented enum | red in `EnumMatchesHandler` |
| `service-run` put back into the enum | red in `EnumMatchesHandler` |
| `case jobTypeService:` added to `jobFromRequest` | red in `EnumMatchesHandler` |
| `enum:` key renamed so parsing finds nothing | red in **both** — fatal, not skipped |
| `type` restored to `required` | red in `JobTypeNotRequired` |

Five for five, each in the test that is supposed to own it.

## Scope

Test and changelog only; no production code changes. `docs/API.md` carries the same information as prose and is deliberately left out — substring-matching markdown would give a guard that breaks on rewording rather than on drift.

The candidate list is the one hand-kept part, and the residual hole: a new `jobType*` constant has to be added there or it goes unexercised. The comment in the file says so rather than leaving it to be discovered.

Gates run locally on the final tree: `go build ./...`, `go vet ./web/`, `go test ./...` (14 packages), `golangci-lint run ./...` — all clean.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_016HMCWKo6LHV83osTnC2MW2)_
