### PR TITLE
fix(web): count unauthenticated /api/* requests in the rate limiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,9 +200,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   every static asset it fetched. Measured before the fix, 400
   unauthenticated requests to `/api/jobs` from one address produced 400
   `401`s and no `429` at any point. The limiter now wraps auth from
-  outside. Paths auth lets through unauthenticated — the page, static
-  assets, the orchestrator probes — were always counted and are
-  unaffected, and `/live` and `/ready` stay exempt
+  outside. Nothing else changes: auth only guards `/api/*`, so the
+  rendered page and the static assets were already counted, and the
+  orchestrator probes `/live` and `/ready` were exempt before the move
+  and stay exempt
   ([#804](https://github.com/netresearch/ofelia/issues/804)).
 - **A delete landing mid-update can no longer leave a ghost job.**
   `RemoveJob` drops the cron entry before it takes the scheduler lock, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Unauthenticated `/api/*` requests are counted by the rate limiter.**
+  The limiter sat inside the auth middleware, so a request answered with
+  `401` never reached it: token guessing against `/api/*` was the one
+  kind of traffic it never saw, while the same address was metered on
+  every static asset it fetched. Measured before the fix, 400
+  unauthenticated requests to `/api/jobs` from one address produced 400
+  `401`s and no `429` at any point. The limiter now wraps auth from
+  outside. Paths auth lets through unauthenticated — the page, static
+  assets, the orchestrator probes — were always counted and are
+  unaffected, and `/live` and `/ready` stay exempt
+  ([#804](https://github.com/netresearch/ofelia/issues/804)).
 - **A delete landing mid-update can no longer leave a ghost job.**
   `RemoveJob` drops the cron entry before it takes the scheduler lock, so
   it can complete inside `UpdateJob`'s window; the update then reinserted

--- a/web/ratelimit_unauthenticated_test.go
+++ b/web/ratelimit_unauthenticated_test.go
@@ -25,9 +25,10 @@ func newAuthedTestServer(t *testing.T) http.Handler {
 	authCfg := &SecureAuthConfig{
 		Enabled:  true,
 		Username: "operator",
-		// bcrypt of an arbitrary password; these tests never log in.
-		PasswordHash: "$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy",
-		SecretKey:    "0123456789abcdef0123456789abcdef",
+		// The placeholders every other auth test in this package uses;
+		// nothing here ever logs in.
+		PasswordHash: "$2a$04$placeholder",
+		SecretKey:    "test-secret-key-32-bytes-long!!!",
 		TokenExpiry:  24,
 		MaxAttempts:  5,
 	}

--- a/web/ratelimit_unauthenticated_test.go
+++ b/web/ratelimit_unauthenticated_test.go
@@ -1,0 +1,100 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/netresearch/ofelia/core"
+)
+
+// The rate limiter used to sit inside the auth middleware, so a request
+// answered with 401 was never counted: /api/* token guessing was the one
+// kind of traffic the limiter never saw, while the same address was being
+// metered on every static asset it fetched. Measured before the fix, 400
+// unauthenticated requests to /api/jobs produced map[401:400] — no 429 at
+// any point (#804).
+//
+// These tests pin both halves of the move: that unauthenticated API traffic
+// is now counted, and that pushing the limiter outward did not start
+// metering the orchestrator probes, which must never see a 429.
+
+func newAuthedTestServer(t *testing.T) http.Handler {
+	t.Helper()
+
+	authCfg := &SecureAuthConfig{
+		Enabled:  true,
+		Username: "operator",
+		// bcrypt of an arbitrary password; these tests never log in.
+		PasswordHash: "$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy",
+		SecretKey:    "0123456789abcdef0123456789abcdef",
+		TokenExpiry:  24,
+		MaxAttempts:  5,
+	}
+	srv := NewServerWithAuth("", core.NewScheduler(newDiscardLogger()), nil, nil, authCfg)
+	if srv == nil {
+		t.Fatal("NewServerWithAuth returned nil")
+	}
+	// The probe routes exist only after health registration.
+	srv.RegisterHealthEndpoints(NewHealthChecker(nil, nil, "test"))
+	t.Cleanup(func() {
+		srv.rl.close()
+		srv.tokenManager.Close()
+	})
+	return srv.HTTPServer().Handler
+}
+
+// requestFrom sends one request from a fixed address and returns the status.
+func requestFrom(h http.Handler, path, addr string) int {
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.RemoteAddr = addr
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w.Code
+}
+
+func TestRateLimit_CountsUnauthenticatedAPIRequests(t *testing.T) {
+	t.Parallel()
+
+	h := newAuthedTestServer(t)
+	const addr = "192.0.2.11:33333"
+
+	// Every one of these is rejected by auth. The question is only whether
+	// the limiter got to see them on the way.
+	var sawUnauthorized bool
+	for range 400 {
+		switch requestFrom(h, "/api/jobs", addr) {
+		case http.StatusUnauthorized:
+			sawUnauthorized = true
+		case http.StatusTooManyRequests:
+			if !sawUnauthorized {
+				t.Fatal("limited before a single request was answered by auth")
+			}
+			return // counted, and the budget ran out: what this test exists for
+		}
+	}
+	t.Fatal("400 unauthenticated /api/jobs requests from one address never hit " +
+		"the rate limit — 401s are not being counted (#804)")
+}
+
+func TestRateLimit_ExemptsProbesFromTheOuterPosition(t *testing.T) {
+	t.Parallel()
+
+	h := newAuthedTestServer(t)
+	const addr = "192.0.2.12:44444"
+
+	// Exhaust the address's budget on API traffic first.
+	for range 400 {
+		if requestFrom(h, "/api/jobs", addr) == http.StatusTooManyRequests {
+			break
+		}
+	}
+
+	// An orchestrator must never see a 429 on its probes, whichever side of
+	// the auth middleware the limiter sits on.
+	for _, probe := range []string{"/live", "/ready"} {
+		if got := requestFrom(h, probe, addr); got == http.StatusTooManyRequests {
+			t.Errorf("%s answered 429 from an exhausted address; probes must stay exempt", probe)
+		}
+	}
+}

--- a/web/server.go
+++ b/web/server.go
@@ -366,10 +366,18 @@ func (s *Server) RegisterHealthEndpoints(hc *HealthChecker) {
 func (s *Server) wrapMiddleware(mux http.Handler) http.Handler {
 	handler := compressMiddleware(mux)
 	handler = securityHeaders(handler)
-	handler = s.rl.middleware(handler)
 	if s.authConfig != nil && s.authConfig.Enabled {
 		handler = s.authMiddleware(handler)
 	}
+	// The limiter goes outside auth, so a request rejected with 401 has
+	// still been counted. With the order reversed, /api/* token guessing
+	// was the one traffic the limiter never saw: authMiddleware answers
+	// it and returns, so a caller could try tokens without limit while
+	// the same IP was being metered on every static asset. Paths auth
+	// lets through unauthenticated (the page, assets, probes) were
+	// always counted and are unaffected — isOrchestratorProbePath still
+	// exempts /live and /ready from the outer position. See #804.
+	handler = s.rl.middleware(handler)
 	return handler
 }
 

--- a/web/server.go
+++ b/web/server.go
@@ -359,8 +359,9 @@ func (s *Server) RegisterHealthEndpoints(hc *HealthChecker) {
 }
 
 // wrapMiddleware layers the shared middleware chain around mux —
-// compression innermost, then security headers, then the rate limiter,
-// with auth outermost when enabled. Single source for both construction sites
+// compression innermost, then security headers, then auth when enabled,
+// with the rate limiter outermost so a request rejected with 401 has
+// still been counted (#804). Single source for both construction sites
 // (NewServerWithAuth and RegisterHealthEndpoints) so the chain cannot
 // drift between them.
 func (s *Server) wrapMiddleware(mux http.Handler) http.Handler {

--- a/web/server.go
+++ b/web/server.go
@@ -374,10 +374,13 @@ func (s *Server) wrapMiddleware(mux http.Handler) http.Handler {
 	// still been counted. With the order reversed, /api/* token guessing
 	// was the one traffic the limiter never saw: authMiddleware answers
 	// it and returns, so a caller could try tokens without limit while
-	// the same IP was being metered on every static asset. Paths auth
-	// lets through unauthenticated (the page, assets, probes) were
-	// always counted and are unaffected — isOrchestratorProbePath still
-	// exempts /live and /ready from the outer position. See #804.
+	// the same IP was being metered on every static asset it fetched.
+	//
+	// Nothing else changes. authMiddleware only guards /api/*, so the
+	// rendered page and the static assets already passed through it and
+	// were already counted; /live and /ready were exempt before the move
+	// and stay exempt, because isOrchestratorProbePath returns early in
+	// the limiter itself and does so from either position. See #804.
 	handler = s.rl.middleware(handler)
 	return handler
 }


### PR DESCRIPTION
Closes [#804](https://github.com/netresearch/ofelia/issues/804).

`wrapMiddleware` builds the chain inside-out, so applying the limiter first and auth second put auth outermost. A request answered with `401` never reached the limiter, and `/api/*` token guessing was the one kind of traffic it never saw.

## Measured, not argued

Four hundred requests from a single address against a server with auth enabled:

| path | before | after |
|---|---|---|
| `/api/jobs`, no token | `401` × 400 — no `429` at any point | `401` × 100, then `429` |
| `/styles.css` | `200` × 100, then `429` | unchanged |
| `/live` | `200` × 400 | `200` × 400 |

The middle row corrects something I had asserted in the issue and had wrong: `authMiddleware` only guards `/api/*` (`web/server.go:1267`), so the rendered page and the static assets always passed through it and were always counted. The limiter's own comment about an unauthenticated flood targeting per-request-compressed static responses held all along. What escaped counting is exactly what the issue title says and nothing wider.

The bottom row is the third category and not the same thing: `/live` and `/ready` reach the limiter but `isOrchestratorProbePath` returns before the accounting, from either position in the chain. They were exempt before this change and are exempt after it — an orchestrator must never see a `429` on a probe.

## Why one shared bucket is the right answer

The reason to consider a separate limiter for `401`s is starvation — unauthenticated traffic eating a legitimate client's allowance. It does not arise: `rateLimiter.clientIP` (`web/middleware.go:215`) resolves the real client address and honours `X-Forwarded-For` / `X-Real-IP` only when the direct peer is in `trustedProxies`, falling back to the peer otherwise. A flood spends its own budget, including behind a proxy. What remains is ordinary: a client with a stale token spends its own allowance retrying.

## Both tests were seen to fail

Each in its own position, since a green test on a fixed tree proves only that it runs:

| Injected defect | Result |
|---|---|
| limiter put back inside auth | `TestRateLimit_CountsUnauthenticatedAPIRequests` red, with its own message |
| `isOrchestratorProbePath` exemption removed | `TestRateLimit_ExemptsProbesFromTheOuterPosition` red, naming `/live` and `/ready` |

The second mutation exists because the first leaves that test green — it guards the exemption surviving the move, which nothing else pins.

Gates on the final tree: `go build ./...`, `go vet ./...`, `go test ./...` (14 packages), `golangci-lint run ./...` — clean.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_016HMCWKo6LHV83osTnC2MW2)_
