### PR TITLE
fix(web,cli): let API-created run jobs inherit [global] max-runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   orchestrator probes `/live` and `/ready` were exempt before the move
   and stay exempt
   ([#804](https://github.com/netresearch/ofelia/issues/804)).
+- **API-created run jobs inherit `[global] max-runtime`.** An INI
+  `[job-run]` section with no per-job bound picks up the operator's
+  global at config load; a run job created over the API skipped that
+  rung and landed on the scheduler's 24h constant, so one daemon applied
+  two different bounds to the same job type depending on where the job
+  came from. The divergence was invisible until an operator overrode the
+  global, since the constant and the documented default are both 24h —
+  which is to say it appeared exactly when someone had expressed an
+  intent. Creation and restore-from-state-file both inherit now, and the
+  state file keeps what the caller asked for rather than the resolved
+  value, so a changed global reaches restored jobs at the next start the
+  way it reaches INI ones. `"0s"` still means the same as omitting the
+  field ([#806](https://github.com/netresearch/ofelia/issues/806)).
 - **A delete landing mid-update can no longer leave a ghost job.**
   `RemoveJob` drops the cron entry before it takes the scheduler lock, so
   it can complete inside `UpdateJob`'s window; the update then reinserted

--- a/cli/config.go
+++ b/cli/config.go
@@ -577,6 +577,20 @@ func (c *Config) mergeJobsFromDockerContainers() {
 	c.refreshRuntimeKnobsAfterGlobalMerge(prevLogLevel, prevCooldown)
 }
 
+// GlobalMaxRuntime reports the operator's `[global] max-runtime`.
+//
+// It exists for the web server, which holds this configuration as `any`
+// and reads it through web.GlobalMaxRuntimeProvider so an API-created run
+// job inherits the same bound an INI one gets from registerAllJobs (#806).
+//
+// Takes the read lock: the label reconcile writes Global under c.mu while
+// the web server serves requests.
+func (c *Config) GlobalMaxRuntime() time.Duration {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.Global.MaxRuntime
+}
+
 // mergeJobs copies jobs from src into dst while respecting INI precedence.
 func mergeJobs[T jobConfig](c *Config, dst map[string]T, src map[string]T, kind string) {
 	for name, j := range src {

--- a/cli/config.go
+++ b/cli/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/netresearch/ofelia/config"
 	"github.com/netresearch/ofelia/core"
 	"github.com/netresearch/ofelia/middlewares"
+	"github.com/netresearch/ofelia/web"
 )
 
 const (
@@ -576,6 +577,14 @@ func (c *Config) mergeJobsFromDockerContainers() {
 	_ = c.applyAllowListedGlobals(parsed)
 	c.refreshRuntimeKnobsAfterGlobalMerge(prevLogLevel, prevCooldown)
 }
+
+// The web server holds this configuration as `any`, so nothing links the
+// two sides of #806 except this line. It lives here rather than in a test
+// on purpose: in a _test.go file `go build ./...` would still succeed
+// after a rename, the server's type assertion would start failing at
+// runtime, and every API-created run job would be back on the 24h
+// constant -- the bug, restored silently in exactly the builds that ship.
+var _ web.GlobalMaxRuntimeProvider = (*Config)(nil)
 
 // GlobalMaxRuntime reports the operator's `[global] max-runtime`.
 //

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -131,6 +131,13 @@ func (c *DaemonCommand) boot() (err error) {
 	config.levelVar = c.LevelVar
 	c.applyOptions(config)
 	c.applyConfigDefaults(config)
+	// Held from here rather than after the scheduler and docker handler are
+	// wired up: config is a pointer, so everything those steps add stays
+	// visible, and nothing in between reads c.config. The later assignment
+	// left a window in which a restore path that consults the config would
+	// silently see nil -- review read the source as already having that bug,
+	// which is reason enough not to leave the window there (#806).
+	c.config = config
 
 	c.pprofServer = &http.Server{
 		Addr:              c.PprofAddr,
@@ -156,7 +163,6 @@ func (c *DaemonCommand) boot() (err error) {
 	// Restore job history from saved files if configured
 	c.restoreJobHistory(config)
 	c.dockerHandler = config.dockerHandler
-	c.config = config
 
 	// Initialize health checker with Docker provider
 	var dockerProvider core.DockerProvider

--- a/cli/daemon.go
+++ b/cli/daemon.go
@@ -679,6 +679,16 @@ func (c *DaemonCommand) buildPersistedRunJob(name string, j *persist.Job, provid
 	if err != nil {
 		return nil, fmt.Errorf("job %q: %w", name, err)
 	}
+	// The same inheritance web.Server.newRunJobFromRequest applies when
+	// the job is created. It has to be repeated here rather than resolved
+	// once and persisted: the state file keeps what the caller asked for,
+	// so a job that named no bound picks up whatever the global says at
+	// the next start, exactly as an INI job does. Without this, the first
+	// restart would silently move every such job back to the 24h constant
+	// (#806).
+	if maxRuntime == 0 && c.config != nil {
+		maxRuntime = c.config.GlobalMaxRuntime()
+	}
 	rj.MaxRuntime = maxRuntime
 	return rj, nil
 }

--- a/cli/daemon_persist_global_max_runtime_test.go
+++ b/cli/daemon_persist_global_max_runtime_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/netresearch/ofelia/core"
+	"github.com/netresearch/ofelia/core/persist"
+)
+
+// buildPersistedRunJob reads the global off c.config, and boot assigns that
+// field at one point and calls the restore at another. Review read those two
+// as being in the wrong order, which would have made the inheritance a no-op
+// on every real restart while the unit test around the builder stayed green.
+//
+// They are in the right order — c.config is set before initPersistStore runs
+// — but an ordering that a reader can get wrong from the source is not
+// something to leave asserted only in a commit message. This drives the real
+// restore entry point instead of the builder, so a future reordering of boot
+// fails here rather than silently returning every restored job to the 24h
+// default (#806).
+func TestInitPersistStore_RestoredRunJobInheritsGlobalMaxRuntime(t *testing.T) {
+	t.Parallel()
+
+	path := writePersistFile(t, persist.State{
+		Jobs: map[string]*persist.Job{
+			// No MaxRuntime: the case that has to pick up the global.
+			"restored-run": {Type: persist.JobTypeRun, Schedule: "@hourly", Image: "busybox"},
+			// An explicit bound must survive untouched.
+			"restored-run-bounded": {
+				Type: persist.JobTypeRun, Schedule: "@hourly", Image: "busybox",
+				MaxRuntime: "45m",
+			},
+		},
+	})
+
+	cfg := &Config{}
+	cfg.Global.MaxRuntime = 2 * time.Hour
+
+	c := newDaemonForPersistTest(t)
+	c.StateFile = path
+	c.config = cfg
+	c.dockerHandler = &DockerHandler{dockerProvider: &mockDockerProvider{}}
+
+	if err := c.initPersistStore(); err != nil {
+		t.Fatalf("initPersistStore: %v", err)
+	}
+
+	for name, want := range map[string]time.Duration{
+		"restored-run":         2 * time.Hour,
+		"restored-run-bounded": 45 * time.Minute,
+	} {
+		job := c.scheduler.GetJob(name)
+		if job == nil {
+			t.Fatalf("%s was not applied to the scheduler", name)
+		}
+		rj, ok := job.(*core.RunJob)
+		if !ok {
+			t.Fatalf("%s materialized as %T, want *core.RunJob", name, job)
+		}
+		if rj.MaxRuntime != want {
+			t.Errorf("%s: MaxRuntime = %v, want %v", name, rj.MaxRuntime, want)
+		}
+	}
+}

--- a/cli/global_max_runtime_test.go
+++ b/cli/global_max_runtime_test.go
@@ -6,15 +6,7 @@ import (
 
 	"github.com/netresearch/ofelia/core"
 	"github.com/netresearch/ofelia/core/persist"
-	"github.com/netresearch/ofelia/web"
 )
-
-// The web server holds this configuration as `any`, so nothing in the
-// compiler links the two sides of #806 except this line. Without it, a
-// rename of GlobalMaxRuntime would leave the server's type assertion
-// failing at runtime and every API-created run job back on the 24h
-// constant — the exact bug, restored silently.
-var _ web.GlobalMaxRuntimeProvider = (*Config)(nil)
 
 func TestConfig_GlobalMaxRuntime(t *testing.T) {
 	t.Parallel()

--- a/cli/global_max_runtime_test.go
+++ b/cli/global_max_runtime_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/netresearch/ofelia/core"
+	"github.com/netresearch/ofelia/core/persist"
+	"github.com/netresearch/ofelia/web"
+)
+
+// The web server holds this configuration as `any`, so nothing in the
+// compiler links the two sides of #806 except this line. Without it, a
+// rename of GlobalMaxRuntime would leave the server's type assertion
+// failing at runtime and every API-created run job back on the 24h
+// constant — the exact bug, restored silently.
+var _ web.GlobalMaxRuntimeProvider = (*Config)(nil)
+
+func TestConfig_GlobalMaxRuntime(t *testing.T) {
+	t.Parallel()
+
+	c := &Config{}
+	c.Global.MaxRuntime = 90 * time.Minute
+	if got := c.GlobalMaxRuntime(); got != 90*time.Minute {
+		t.Errorf("GlobalMaxRuntime() = %v, want 90m", got)
+	}
+}
+
+// A run job restored from the state file has to inherit the global the
+// same way the API applied it at creation, or the first restart moves
+// every such job back to the scheduler default.
+func TestPersistedRunJob_InheritsGlobalMaxRuntime(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{}
+	cfg.Global.MaxRuntime = 2 * time.Hour
+
+	build := func(t *testing.T, stored string) *core.RunJob {
+		t.Helper()
+		c := &DaemonCommand{config: cfg}
+		job, err := c.buildPersistedRunJob(
+			"restored",
+			&persist.Job{Type: persist.JobTypeRun, Image: "alpine", MaxRuntime: stored},
+			&hangingDoctorProvider{},
+		)
+		if err != nil {
+			t.Fatalf("buildPersistedRunJob(%q): %v", stored, err)
+		}
+		rj, ok := job.(*core.RunJob)
+		if !ok {
+			t.Fatalf("got %T, want *core.RunJob", job)
+		}
+		return rj
+	}
+
+	if got := build(t, "").MaxRuntime; got != 2*time.Hour {
+		t.Errorf("a stored job with no bound got %v, want the global 2h", got)
+	}
+	if got := build(t, "45m").MaxRuntime; got != 45*time.Minute {
+		t.Errorf("a stored job with its own bound got %v, want 45m", got)
+	}
+
+	// No configuration at all must not panic and must leave the job at
+	// zero, where the scheduler's default applies.
+	noCfg := &DaemonCommand{}
+	job, err := noCfg.buildPersistedRunJob(
+		"restored",
+		&persist.Job{Type: persist.JobTypeRun, Image: "alpine"},
+		&hangingDoctorProvider{},
+	)
+	if err != nil {
+		t.Fatalf("buildPersistedRunJob without config: %v", err)
+	}
+	if rj, ok := job.(*core.RunJob); !ok || rj.MaxRuntime != 0 {
+		t.Errorf("without a config the job must stay at 0, got %v", job)
+	}
+}

--- a/docs/API.md
+++ b/docs/API.md
@@ -184,7 +184,7 @@ The request body (`jobRequest`) accepts:
 | `file` | string | `compose` jobs |
 | `service` | string | `compose` jobs: the service to run or exec |
 | `exec` | bool | `compose` jobs: exec in a running service |
-| `maxRuntime` | string | `run` jobs; Go duration, e.g. `30m`. Omitted means the scheduler's 24h default; `"0s"` means the same and is not a way to ask for no bound. Unlike an INI `[job-run]` section, an API-created job does not inherit `[global] max-runtime` — see [#806](https://github.com/netresearch/ofelia/issues/806) |
+| `maxRuntime` | string | `run` jobs; Go duration, e.g. `30m`. Omitting it inherits `[global] max-runtime`, and falls back to the scheduler's 24h default only when no global is set; `"0s"` means the same and is not a way to ask for no bound. Same ladder an INI `[job-run]` section climbs ([#806](https://github.com/netresearch/ofelia/issues/806)) |
 
 Returns `201 Created`. Validation failures return `400 Bad Request`.
 API-created jobs are persisted and survive restarts.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -315,10 +315,11 @@ components:
         maxRuntime:
           type: string
           description: >-
-            run jobs; a Go duration such as "30m". Omitting it means the
-            scheduler's 24h default, and "0s" means the same — it is not a way
-            to ask for no bound. An API-created job does not inherit
-            [global] max-runtime the way an INI [job-run] section does.
+            run jobs; a Go duration such as "30m". Omitting it inherits
+            [global] max-runtime, and reaches the scheduler's 24h default only
+            when no global is set; "0s" means the same as omitting it — it is
+            not a way to ask for no bound. Same fallback an INI [job-run]
+            section gets.
           example: 30m
     Job:
       type: object

--- a/web/global_max_runtime_test.go
+++ b/web/global_max_runtime_test.go
@@ -32,6 +32,11 @@ type ptrGlobalConfig struct{ d time.Duration }
 
 func (p *ptrGlobalConfig) GlobalMaxRuntime() time.Duration { return p.d }
 
+// funcGlobalConfig is nil-capable without being a pointer.
+type funcGlobalConfig func() time.Duration
+
+func (f funcGlobalConfig) GlobalMaxRuntime() time.Duration { return f() }
+
 func runJobFor(t *testing.T, cfg any, requested string) *core.RunJob {
 	t.Helper()
 
@@ -93,7 +98,10 @@ func TestRunJob_WithoutGlobalStaysZero(t *testing.T) {
 		// A nil pointer stored in an `any` satisfies the interface and
 		// panics on the call. NewServer takes `any` and is exported, so
 		// this arrives from outside the repo, not from the daemon.
-		"typed-nil provider": (*ptrGlobalConfig)(nil),
+		"typed-nil pointer provider": (*ptrGlobalConfig)(nil),
+		// The same hazard in a kind that is not a pointer: calling a nil
+		// func panics exactly as dereferencing a nil pointer does.
+		"typed-nil func provider": funcGlobalConfig(nil),
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/web/global_max_runtime_test.go
+++ b/web/global_max_runtime_test.go
@@ -24,6 +24,14 @@ type stubGlobalConfig struct{ d time.Duration }
 
 func (s stubGlobalConfig) GlobalMaxRuntime() time.Duration { return s.d }
 
+// ptrGlobalConfig has a pointer receiver, so a nil *ptrGlobalConfig in an
+// `any` satisfies the interface and panics when called — the shape a nil
+// *cli.Config would take. The method body is unreachable in that case and
+// exists only to satisfy the interface.
+type ptrGlobalConfig struct{ d time.Duration }
+
+func (p *ptrGlobalConfig) GlobalMaxRuntime() time.Duration { return p.d }
+
 func runJobFor(t *testing.T, cfg any, requested string) *core.RunJob {
 	t.Helper()
 
@@ -82,6 +90,10 @@ func TestRunJob_WithoutGlobalStaysZero(t *testing.T) {
 		"nil config":            nil,
 		"config without global": struct{ Unrelated int }{},
 		"global of zero":        stubGlobalConfig{d: 0},
+		// A nil pointer stored in an `any` satisfies the interface and
+		// panics on the call. NewServer takes `any` and is exported, so
+		// this arrives from outside the repo, not from the daemon.
+		"typed-nil provider": (*ptrGlobalConfig)(nil),
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()

--- a/web/global_max_runtime_test.go
+++ b/web/global_max_runtime_test.go
@@ -1,0 +1,93 @@
+package web
+
+import (
+	"testing"
+	"time"
+
+	"github.com/netresearch/ofelia/core"
+)
+
+// An API-created run job that named no bound of its own used to skip the
+// operator's `[global] max-runtime` and land on the scheduler's 24h
+// constant, while an INI run job in the same daemon inherited the global
+// at config load. Same type, same field, different origin (#806).
+//
+// The divergence is invisible on a default configuration, because the
+// constant and the documented global default are both 24h. These tests use
+// a global that differs from it, which is the only case where an operator
+// expressed an intent at all.
+
+// stubGlobalConfig stands in for *cli.Config, which this package cannot
+// import. cli asserts at compile time that the real one satisfies the same
+// interface, so this stub cannot drift into testing only itself.
+type stubGlobalConfig struct{ d time.Duration }
+
+func (s stubGlobalConfig) GlobalMaxRuntime() time.Duration { return s.d }
+
+func runJobFor(t *testing.T, cfg any, requested string) *core.RunJob {
+	t.Helper()
+
+	// Any non-nil provider will do: newRunJobFromRequest only checks that
+	// one exists before building the job.
+	srv := &Server{config: cfg, provider: newHangingDockerProvider()}
+	job, err := srv.newRunJobFromRequest(&jobRequest{
+		Name: "guard", Type: jobTypeRun, Image: "alpine", MaxRuntime: requested,
+	})
+	if err != nil {
+		t.Fatalf("newRunJobFromRequest(%q): %v", requested, err)
+	}
+	rj, ok := job.(*core.RunJob)
+	if !ok {
+		t.Fatalf("got %T, want *core.RunJob", job)
+	}
+	return rj
+}
+
+func TestRunJob_InheritsGlobalMaxRuntime(t *testing.T) {
+	t.Parallel()
+
+	cfg := stubGlobalConfig{d: 2 * time.Hour}
+
+	t.Run("omitted inherits the global", func(t *testing.T) {
+		t.Parallel()
+		if got := runJobFor(t, cfg, "").MaxRuntime; got != 2*time.Hour {
+			t.Errorf("MaxRuntime = %v, want the global 2h", got)
+		}
+	})
+
+	// "0s" is equivalent to omitting the field (#789), so it inherits too.
+	// It is not a way to ask for no bound.
+	t.Run("0s inherits the global", func(t *testing.T) {
+		t.Parallel()
+		if got := runJobFor(t, cfg, "0s").MaxRuntime; got != 2*time.Hour {
+			t.Errorf("MaxRuntime = %v, want the global 2h", got)
+		}
+	})
+
+	t.Run("an explicit value wins over the global", func(t *testing.T) {
+		t.Parallel()
+		if got := runJobFor(t, cfg, "30m").MaxRuntime; got != 30*time.Minute {
+			t.Errorf("MaxRuntime = %v, want the requested 30m", got)
+		}
+	})
+}
+
+// A configuration that exposes no global — or none at all — must leave the
+// job at zero, where the scheduler's own default takes over. Servers built
+// with a nil config are the common case in tests and embedders.
+func TestRunJob_WithoutGlobalStaysZero(t *testing.T) {
+	t.Parallel()
+
+	for name, cfg := range map[string]any{
+		"nil config":            nil,
+		"config without global": struct{ Unrelated int }{},
+		"global of zero":        stubGlobalConfig{d: 0},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := runJobFor(t, cfg, "").MaxRuntime; got != 0 {
+				t.Errorf("MaxRuntime = %v, want 0 so the scheduler default applies", got)
+			}
+		})
+	}
+}

--- a/web/server.go
+++ b/web/server.go
@@ -967,17 +967,26 @@ type GlobalMaxRuntimeProvider interface {
 // caller who has no configuration meant.
 func (s *Server) globalMaxRuntime() time.Duration {
 	p, ok := s.config.(GlobalMaxRuntimeProvider)
-	if !ok || isNilPointer(p) {
+	if !ok || isNilValue(p) {
 		return 0
 	}
 	return p.GlobalMaxRuntime()
 }
 
-// isNilPointer reports whether v holds a nil pointer, which a plain
-// `v == nil` misses once the value carries a type.
-func isNilPointer(v any) bool {
+// isNilValue reports whether v holds a nil of any kind that can be nil,
+// which a plain `v == nil` misses once the value carries a type. Limiting
+// it to pointers would be arbitrary: a nil func-backed implementor panics
+// on the call just as a nil *cli.Config does.
+func isNilValue(v any) bool {
 	rv := reflect.ValueOf(v)
-	return rv.Kind() == reflect.Pointer && rv.IsNil()
+	//nolint:exhaustive // reflect.Kind has many values; only the nil-capable ones matter here
+	switch rv.Kind() {
+	case reflect.Pointer, reflect.Func, reflect.Map, reflect.Chan,
+		reflect.Slice, reflect.Interface, reflect.UnsafePointer:
+		return rv.IsNil()
+	default:
+		return false
+	}
 }
 
 func (s *Server) newRunJobFromRequest(req *jobRequest) (core.Job, error) {

--- a/web/server.go
+++ b/web/server.go
@@ -960,12 +960,24 @@ type GlobalMaxRuntimeProvider interface {
 // when the server was built without a configuration that exposes one --
 // which is every test that passes nil, and any embedder that does not
 // implement the interface.
+//
+// The typed-nil check is not ceremony: config arrives as `any` through an
+// exported constructor, and a nil *cli.Config stored in one satisfies the
+// assertion while panicking on the call. Falling back to zero is what a
+// caller who has no configuration meant.
 func (s *Server) globalMaxRuntime() time.Duration {
 	p, ok := s.config.(GlobalMaxRuntimeProvider)
-	if !ok {
+	if !ok || isNilPointer(p) {
 		return 0
 	}
 	return p.GlobalMaxRuntime()
+}
+
+// isNilPointer reports whether v holds a nil pointer, which a plain
+// `v == nil` misses once the value carries a type.
+func isNilPointer(v any) bool {
+	rv := reflect.ValueOf(v)
+	return rv.Kind() == reflect.Pointer && rv.IsNil()
 }
 
 func (s *Server) newRunJobFromRequest(req *jobRequest) (core.Job, error) {

--- a/web/server.go
+++ b/web/server.go
@@ -677,16 +677,17 @@ type jobRequest struct {
 	Service   string `json:"service,omitempty"`
 	ExecFlag  bool   `json:"exec,omitempty"`
 	// MaxRuntime is a Go duration string (e.g. "30m"), run-jobs only —
-	// see core.ParseMaxRuntime. Empty means "no per-job override", and
-	// the job then falls back to the scheduler's 24h default
-	// (defaultJobMaxRuntime). "0s" is equivalent to omitting it: it is
-	// not a way to ask for no bound.
+	// see core.ParseMaxRuntime. Empty means "no per-job override": the
+	// job then inherits `[global] max-runtime`, and only falls through
+	// to the scheduler's 24h default (defaultJobMaxRuntime) when there
+	// is no global either. "0s" is equivalent to omitting it: it is not
+	// a way to ask for no bound.
 	//
-	// Note this is NOT the same fallback a config.ini [job-run] section
-	// gets: an INI or label run-job with no per-job max-runtime inherits
-	// `[global] max-runtime` first (cli/config.go, registerRunJobs), and
-	// only reaches the 24h default when the global is unset too. An
-	// API-created job never sees the global — issue #806.
+	// That is the same ladder a config.ini [job-run] section climbs
+	// (cli/config.go, registerAllJobs). It used to stop one rung short
+	// here — an API-created job never saw the global, so an operator who
+	// set one got it for INI run jobs and 24h for API ones — which was
+	// issue #806.
 	MaxRuntime string `json:"maxRuntime,omitempty"`
 }
 
@@ -944,6 +945,29 @@ func (s *Server) updateJobHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(status)
 }
 
+// GlobalMaxRuntimeProvider is satisfied by the configuration the daemon
+// hands NewServer. The server holds that configuration as `any` to keep
+// this package from importing cli, so this is how an API-created run job
+// reaches `[global] max-runtime`.
+//
+// Implemented by *cli.Config; cli asserts the link at compile time so a
+// rename cannot quietly reduce this to the nil case.
+type GlobalMaxRuntimeProvider interface {
+	GlobalMaxRuntime() time.Duration
+}
+
+// globalMaxRuntime returns the operator's `[global] max-runtime`, or zero
+// when the server was built without a configuration that exposes one --
+// which is every test that passes nil, and any embedder that does not
+// implement the interface.
+func (s *Server) globalMaxRuntime() time.Duration {
+	p, ok := s.config.(GlobalMaxRuntimeProvider)
+	if !ok {
+		return 0
+	}
+	return p.GlobalMaxRuntime()
+}
+
 func (s *Server) newRunJobFromRequest(req *jobRequest) (core.Job, error) {
 	if s.provider == nil {
 		return nil, fmt.Errorf("docker provider unavailable for run job")
@@ -957,6 +981,15 @@ func (s *Server) newRunJobFromRequest(req *jobRequest) (core.Job, error) {
 	maxRuntime, err := core.ParseMaxRuntime(req.MaxRuntime)
 	if err != nil {
 		return nil, fmt.Errorf("invalid maxRuntime: %w", err)
+	}
+	// Same rule registerAllJobs applies to an INI run job: a job that
+	// named no bound of its own inherits the operator's global, and only
+	// falls through to the scheduler's 24h constant when there is no
+	// global either. "0s" parses to zero and therefore inherits too,
+	// which is what makes it equivalent to omitting the field (#789)
+	// rather than a way to ask for no bound. See #806.
+	if maxRuntime == 0 {
+		maxRuntime = s.globalMaxRuntime()
 	}
 	j.MaxRuntime = maxRuntime
 	return j, nil


### PR DESCRIPTION
Closes [#806](https://github.com/netresearch/ofelia/issues/806).

An INI `[job-run]` section with no per-job bound picks up the operator's `[global] max-runtime` in `registerAllJobs`. A run job created over the API skipped that rung and landed on the scheduler's 24h constant, so one daemon applied two different bounds to the same job type depending on where the job came from.

## Why this is a defect and not a choice

The issue offered two options — merge the global, or document the constant as the API default. The second was never open. `core/scheduler.go:988` states the invariant in its own words: the constant "mirrors the documented default for `[global] max-runtime` (24h) **so behavior is consistent regardless of whether a job inherits the global default at config-load time**". An overridden global breaks exactly that sentence, so documenting the divergence would have documented the thing the code says it exists to prevent.

It is also invisible on a default configuration, because the constant and the documented global default are both 24h. The two part company only once an operator overrides the global — which is the only case in which they expressed an intent at all.

## Scope

Narrower than the issue's framing. `[global] max-runtime` reaches exactly two job kinds and only at config load; only `RunJob` and `RunServiceJob` implement `MaxRuntimeProvider`, and service jobs are not creatable over the API ([#816](https://github.com/netresearch/ofelia/issues/816)). So this is one job type and one field.

It is **not** the wider question of whether API-created jobs should inherit `[global]` values generally — they still inherit none, including notification defaults. That would be a real decision with real blast radius, and it is not this.

## How the value gets there

`web.Server` holds the configuration as `any` to keep the package from importing `cli`, so it arrives through a small interface, `GlobalMaxRuntimeProvider`, that `*cli.Config` satisfies. `cli/config.go` — not a test file — asserts that link:

```go
var _ web.GlobalMaxRuntimeProvider = (*Config)(nil)
```

Nothing else in the build would catch a rename: the server's type assertion would simply start failing at runtime and put every API-created job back on 24h, the original bug restored silently. In a `_test.go` file the assertion would not have covered `go build ./...`, which is where review caught it; renaming the method now fails the build outright.

`globalMaxRuntime` also treats a typed-nil as "no configuration". A nil `*cli.Config` in the `any` satisfies the assertion and panics on the call — unreachable from the daemon, but `NewServer` is exported and takes `any`.

The accessor takes the read lock: the label reconcile writes `Global` under `c.mu` while the web server is serving.

## Both ends of the round trip

Restore-from-state-file inherits as well. Without it the first restart would undo the fix for every existing job — the same shape as the `defaults.Set` gap that needed a second commit in [#797](https://github.com/netresearch/ofelia/pull/797). The state file keeps what the caller asked for rather than the resolved duration, so a changed global reaches restored jobs at the next start exactly as it reaches INI ones.

`"0s"` parses to zero and therefore inherits too, which is what keeps it equivalent to omitting the field ([#789](https://github.com/netresearch/ofelia/pull/789)) rather than a way to ask for no bound.

## Documentation

Three places asserted the opposite, all written for [#789](https://github.com/netresearch/ofelia/pull/789): the `jobRequest.MaxRuntime` field comment, the `docs/API.md` request table, and the OpenAPI description. All three now describe the ladder.

## Each half was seen to fail

| Injected defect | Result |
|---|---|
| inheritance removed at creation (`web`) | `TestRunJob_InheritsGlobalMaxRuntime` red |
| inheritance removed at restore (`cli`) | `TestPersistedRunJob_InheritsGlobalMaxRuntime` red |
| accessor returns zero instead of the global | both `cli` tests red |
| typed-nil guard removed | `typed-nil provider` subtest panics |
| provider method renamed | `go build ./...` fails |

The first three are test results — no mutation among them compiled away the thing it was
meant to break. The last is a build failure on purpose: that is the whole point of moving
the assertion out of the test file.

Gates on the final tree: `go build ./...`, `go vet ./...`, `go test ./...` (14 packages), `golangci-lint run ./...` — clean.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_016HMCWKo6LHV83osTnC2MW2)_
