### PR TITLE
fix(mock): stop discarding a pending subscribe error at end of stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A flaky mock made unrelated pull requests fail.**
+  `mock.EventService.Subscribe` buffers a configured subscribe error and
+  then closes both channels, so once its goroutine had run the pending
+  error and the closed event channel were ready in the same instant —
+  and `SubscribeWithCallback` selected between them at random, returning
+  `nil` whenever the closed-channel arm won. Measured at 89 losses in
+  200 runs with the goroutine given a head start, which is what a loaded
+  runner arranges; `TestEventService_SubscribeWithCallback_SubscribeError`
+  failed that way on a PR touching no part of that package. The end of
+  the stream is now only reported as success once no error is pending,
+  and an error channel that closed without carrying one is dropped from
+  the select instead of competing with events still buffered behind it
+  ([#820](https://github.com/netresearch/ofelia/issues/820)).
 - **Unauthenticated `/api/*` requests are counted by the rate limiter.**
   The limiter sat inside the auth middleware, so a request answered with
   `401` never reached it: token guessing against `/api/*` was the one

--- a/core/adapters/mock/event.go
+++ b/core/adapters/mock/event.go
@@ -75,6 +75,15 @@ func (s *EventService) Subscribe(ctx context.Context, filter domain.EventFilter)
 }
 
 // SubscribeWithCallback subscribes to events with a callback.
+//
+// A pending error is reported even when the event channel has already been
+// closed. Subscribe's goroutine buffers a configured subscribe error and
+// then closes both channels, so once it has run to completion the error and
+// the closed event channel are ready in the same instant — and a select
+// picks between ready cases at random, which made the error reported or
+// silently swallowed on a coin flip. Measured at 89 losses in 200 runs once
+// the goroutine got there first, which is what a loaded CI runner arranges
+// (#820).
 func (s *EventService) SubscribeWithCallback(ctx context.Context, filter domain.EventFilter, callback ports.EventCallback) error {
 	events, errs := s.Subscribe(ctx, filter)
 
@@ -82,13 +91,37 @@ func (s *EventService) SubscribeWithCallback(ctx context.Context, filter domain.
 		select {
 		case <-ctx.Done():
 			return nil
-		case err := <-errs:
+		case err, ok := <-errs:
+			if !ok {
+				// Closed and carrying nothing. Left in the select it would
+				// stay permanently ready and keep competing with buffered
+				// events for the random pick, ending the stream before they
+				// were delivered. A nil channel blocks forever, which takes
+				// this arm out for good.
+				errs = nil
+				continue
+			}
 			if err != nil {
 				return err
 			}
 			return nil
 		case event, ok := <-events:
 			if !ok {
+				// The stream ended -- but Subscribe closes both channels in
+				// one breath after buffering the error, so this arm and the
+				// error arm are ready together and the pick between them is
+				// random. Reporting success without looking is how the
+				// configured error went missing on roughly half the
+				// schedules that got here (#820). Checking here rather than
+				// before the select leaves no window: this is the only path
+				// that turns "no more events" into a nil return.
+				select {
+				case err := <-errs:
+					if err != nil {
+						return err
+					}
+				default:
+				}
 				return nil
 			}
 			if err := callback(event); err != nil {

--- a/core/adapters/mock/event_subscribe_error_test.go
+++ b/core/adapters/mock/event_subscribe_error_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2025-2026 Netresearch DTT GmbH
+// SPDX-License-Identifier: MIT
+
+package mock_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/netresearch/ofelia/core/adapters/mock"
+	"github.com/netresearch/ofelia/core/domain"
+)
+
+var errSubscribeSentinel = errors.New("subscribe failed")
+
+// Subscribe buffers a configured error and then closes both channels, so
+// once its goroutine has run to completion the pending error and the closed
+// event channel are ready in the same instant. A plain select picks between
+// ready cases at random, and SubscribeWithCallback returned nil whenever the
+// closed-channel arm won — 89 times in 200 runs with the goroutine given a
+// head start, and never locally without one, which is why this surfaced as
+// an occasional CI failure on unrelated pull requests (#820).
+//
+// The OnSubscribe hook lets the test hand over channels already in that
+// state, so the race is not reproduced by timing but constructed. Against
+// the unfixed implementation this fails within a few iterations.
+func TestSubscribeWithCallback_ReportsErrorWhenEventChannelAlreadyClosed(t *testing.T) {
+	t.Parallel()
+
+	es := mock.NewEventService()
+	es.OnSubscribe = func(_ context.Context, _ domain.EventFilter) (<-chan domain.Event, <-chan error) {
+		events := make(chan domain.Event)
+		close(events)
+
+		errs := make(chan error, 1)
+		errs <- errSubscribeSentinel
+		close(errs)
+
+		return events, errs
+	}
+
+	// Both arms are ready on every iteration, so a random pick would show up
+	// as a nil return well before this count is reached.
+	for i := range 200 {
+		err := es.SubscribeWithCallback(t.Context(), domain.EventFilter{},
+			func(domain.Event) error { return nil })
+		if !errors.Is(err, errSubscribeSentinel) {
+			t.Fatalf("iteration %d: got %v, want the configured subscribe error — "+
+				"a closed event channel must not swallow a pending error", i, err)
+		}
+	}
+}
+
+// The end-to-end path through Subscribe, for the case the failing CI test
+// exercises: a configured error must come back whichever side of the race
+// the goroutine lands on.
+func TestSubscribeWithCallback_ReportsConfiguredSubscribeError(t *testing.T) {
+	t.Parallel()
+
+	for i := range 50 {
+		es := mock.NewEventService()
+		es.SetSubscribeError(errSubscribeSentinel)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+		err := es.SubscribeWithCallback(ctx, domain.EventFilter{},
+			func(domain.Event) error { return nil })
+		cancel()
+
+		if !errors.Is(err, errSubscribeSentinel) {
+			t.Fatalf("iteration %d: got %v, want the configured subscribe error", i, err)
+		}
+	}
+}
+
+// The mirror of the same defect: an errs channel that closed without ever
+// carrying an error still reads as ready and yields nil, so leaving it in
+// the select lets it compete with buffered events for the random pick and
+// end the stream early. Taking it out of the select is what stops that.
+//
+// Iterated for the same reason as the test above — the defect it guards
+// against is a coin flip, and a single call passes half the time. One
+// iteration was enough to let a mutation of the fix through unnoticed.
+func TestSubscribeWithCallback_DeliversBufferedEventsAfterErrChannelClosed(t *testing.T) {
+	t.Parallel()
+
+	es := mock.NewEventService()
+	es.OnSubscribe = func(_ context.Context, _ domain.EventFilter) (<-chan domain.Event, <-chan error) {
+		events := make(chan domain.Event, 2)
+		events <- domain.Event{Action: "start"}
+		events <- domain.Event{Action: "stop"}
+		close(events)
+
+		errs := make(chan error) // closed, never carried an error
+		close(errs)
+
+		return events, errs
+	}
+
+	for i := range 200 {
+		var seen []string
+		err := es.SubscribeWithCallback(t.Context(), domain.EventFilter{},
+			func(e domain.Event) error {
+				seen = append(seen, e.Action)
+				return nil
+			})
+		if err != nil {
+			t.Fatalf("iteration %d: unexpected error: %v", i, err)
+		}
+		if len(seen) != 2 || seen[0] != "start" || seen[1] != "stop" {
+			t.Fatalf("iteration %d: delivered %v, want both buffered events "+
+				"before the stream ends", i, seen)
+		}
+	}
+}


### PR DESCRIPTION
Closes [#820](https://github.com/netresearch/ofelia/issues/820).

`mock.EventService.Subscribe` buffers a configured subscribe error and then closes both channels, so once its goroutine has run to completion the pending error and the closed event channel are ready in the same instant. `SubscribeWithCallback` selected between them, and Go picks between ready cases at random: the error was reported or silently swallowed on a coin flip.

That is why it passed everywhere and then failed once on [#819](https://github.com/netresearch/ofelia/pull/819), a pull request touching nothing in that package. The failure rate is not small — the window is. Measured with the goroutine given a head start: **89 losses in 200 runs**; without one, none.

## The fix, and why it sits where it does

The end of the stream is only reported as success once no error is pending. Checking there rather than before the select is what leaves no window: it is the only path that turns "no more events" into a `nil` return.

This is worth stating because the first version of this change checked up front instead, and **failed its own end-to-end test at iteration 6 under `-race`** — a goroutine that finishes between the early check and the select puts the coin flip right back. That run is the only reason the incomplete fix did not ship.

The mirror of the same defect is fixed alongside it: an error channel that closed without ever carrying an error also reads as ready and yields `nil`, so leaving it in the select let it compete with events still buffered behind it and end the stream before they were delivered. It is dropped from the select once seen closed.

## Tests

`OnSubscribe` lets the test hand over channels already in the both-ready state, so the race is constructed rather than reproduced by timing — no sleeps, no retries.

| Injected defect | Result |
|---|---|
| closing error check removed | `ReportsErrorWhenEventChannelAlreadyClosed` red |
| closed error channel left in the select | `DeliversBufferedEventsAfterErrChannelClosed` red |

The second test needed iterating before it counted as coverage. With a single call it passed the mutation aimed at it about half the time — the same coin flip, moved from the code into the guard. That is what the first mutation run reported, and why the loop is there.

Beyond the mutations: 20 runs of the package with `-race` and 20 without, plus `go test ./... -race` across the module. Gates on the final tree: `go build ./...`, `go vet ./...`, `go test ./...` (14 packages), `go test ./... -race`, `golangci-lint run ./...` — clean.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_016HMCWKo6LHV83osTnC2MW2)_
