### PR TITLE
docs: document the Docker startup retry and the hash-password command

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -274,7 +274,7 @@ You can enable `include-stopped` via the env var **`OFELIA_DOCKER_INCLUDE_STOPPE
 - Avoid defining the same job-run name on multiple stopped containers if you need a predictable result.
 - Prefer specifying a **Docker filter** (`--docker-filter` or `[docker]` `filters`) to limit which containers Ofelia inspects; this reduces the set of running and stopped containers considered.
 
-#### Retry the Docker connection at startup (OFELIA_DOCKER_STARTUP_RETRY_COUNT, --docker-startup-retry-count)
+#### Retry the Docker connection at startup (OFELIA_DOCKER_STARTUP_RETRY_*, --docker-startup-retry-*)
 
 Ofelia pings Docker once at startup and exits when that ping fails. On a TCP-based Docker host — a socket proxy, a remote daemon, Docker-in-Docker — the daemon is often not reachable yet in the first seconds after the stack comes up, and Ofelia exits before it becomes reachable ([#522](https://github.com/netresearch/ofelia/issues/522)).
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -288,9 +288,10 @@ Two settings make it wait instead. Both are available as an environment variable
 **Behaviour**
 
 - The count is **extra attempts beyond the initial ping**, so the total budget is `count + 1`. The default `0` keeps the original behaviour of a single ping.
-- Backoff is exponential: the wait before attempt *n* is `interval × 2^(n-1)`. With the count at `5` and the default interval, that is 1s → 2s → 4s → 8s → 16s, about 31s in total.
-- Each individual attempt is bounded by a 10s ping timeout, so a wedged daemon cannot hang startup.
-- Accepted range is `0`–`20` for the count; each backoff step is capped at 5 minutes. An interval of `0` retries immediately, without sleeping between attempts.
+- Backoff is exponential: the wait before attempt *n* is `interval × 2^(n-1)`. With the count at `5` and the default interval that is 1s → 2s → 4s → 8s → 16s — 31s of sleeping.
+- Each individual attempt is additionally bounded by a 10s ping timeout, so a wedged daemon cannot hang startup. Those timeouts are not part of the 31s: if all six pings run into them, startup takes about 91s before it gives up.
+- Accepted ranges are `0`–`20` for the count and `0`–`5m` for the interval; a larger interval is rejected when the configuration is validated, not silently reduced. An interval of `0` retries immediately, without sleeping between attempts.
+- The 5-minute cap applies to each *computed* backoff step, which the exponent can push past the interval itself — with `1m` and a count of `20`, the later waits sit at the cap rather than doubling on.
 - Each failed attempt that still has a retry left is logged at `WARN` with the wait before the next one; the final failure becomes the startup error instead. Connecting after one or more retries logs how many it took at `INFO`.
 
 **Example**
@@ -1152,10 +1153,10 @@ On a machine without the binary — writing a Compose file elsewhere, for instan
 
 ```bash
 # Using htpasswd (Apache utils)
-htpasswd -bnBC 12 "" 'your-password' | tr -d ':\n'
+htpasswd -nBC 12 "" | tr -d ':\n'
 
 # Using Python
-python3 -c "import bcrypt; print(bcrypt.hashpw(b'your-password', bcrypt.gensalt(12)).decode())"
+python3 -c "import bcrypt, getpass; print(bcrypt.hashpw(getpass.getpass('Password: ').encode(), bcrypt.gensalt(12)).decode())"
 ```
 
 **Authentication flow:**

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -274,6 +274,42 @@ You can enable `include-stopped` via the env var **`OFELIA_DOCKER_INCLUDE_STOPPE
 - Avoid defining the same job-run name on multiple stopped containers if you need a predictable result.
 - Prefer specifying a **Docker filter** (`--docker-filter` or `[docker]` `filters`) to limit which containers Ofelia inspects; this reduces the set of running and stopped containers considered.
 
+#### Retry the Docker connection at startup (OFELIA_DOCKER_STARTUP_RETRY_COUNT, --docker-startup-retry-count)
+
+Ofelia pings Docker once at startup and exits when that ping fails. On a TCP-based Docker host — a socket proxy, a remote daemon, Docker-in-Docker — the daemon is often not reachable yet in the first seconds after the stack comes up, and Ofelia exits before it becomes reachable ([#522](https://github.com/netresearch/ofelia/issues/522)).
+
+Two settings make it wait instead. Both are available as an environment variable, a flag, and a key under `[docker]`:
+
+| Setting | Env var | Flag | `[docker]` key | Default |
+|---|---|---|---|---|
+| Extra attempts | `OFELIA_DOCKER_STARTUP_RETRY_COUNT` | `--docker-startup-retry-count` | `startup-retry-count` | `0` |
+| Base interval | `OFELIA_DOCKER_STARTUP_RETRY_INTERVAL` | `--docker-startup-retry-interval` | `startup-retry-interval` | `1s` |
+
+**Behaviour**
+
+- The count is **extra attempts beyond the initial ping**, so the total budget is `count + 1`. The default `0` keeps the original behaviour of a single ping.
+- Backoff is exponential: the wait before attempt *n* is `interval × 2^(n-1)`. With the count at `5` and the default interval, that is 1s → 2s → 4s → 8s → 16s, about 31s in total.
+- Each individual attempt is bounded by a 10s ping timeout, so a wedged daemon cannot hang startup.
+- Accepted range is `0`–`20` for the count; each backoff step is capped at 5 minutes. An interval of `0` retries immediately, without sleeping between attempts.
+- Each failed attempt that still has a retry left is logged at `WARN` with the wait before the next one; the final failure becomes the startup error instead. Connecting after one or more retries logs how many it took at `INFO`.
+
+**Example**
+
+```ini
+[docker]
+startup-retry-count = 5
+startup-retry-interval = 1s
+```
+
+```bash
+ofelia daemon --docker-startup-retry-count=5 --docker-startup-retry-interval=1s
+```
+
+**Recommendations**
+
+- Prefer `depends_on` with `condition: service_healthy` in Docker Compose where you control the stack; it removes the wait entirely rather than absorbing it.
+- Reach for these settings when the ordering is not yours to control — an external socket proxy, a remote daemon, a host that restarts both at once.
+
 ## INI Configuration
 
 ### Environment Variable Substitution
@@ -1105,6 +1141,14 @@ web-max-login-attempts = 5          # Per minute per IP
 ```
 
 **Generating a password hash:**
+
+Ofelia generates it itself. `hash-password` prompts twice with the input masked, refuses anything under eight characters, and prints the hash together with ready-made `config.ini` and environment-variable snippets:
+
+```bash
+ofelia hash-password            # cost 12; --cost accepts 4-31, 10-14 recommended
+```
+
+On a machine without the binary — writing a Compose file elsewhere, for instance — either of these produces the same kind of hash:
 
 ```bash
 # Using htpasswd (Apache utils)

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -139,7 +139,7 @@ allow-host-jobs-from-labels = false  # Restrict LocalJobs
 ofelia hash-password
 
 # Without the binary at hand:
-python3 -c "import bcrypt; print(bcrypt.hashpw(b'your-password', bcrypt.gensalt(12)).decode())"
+python3 -c "import bcrypt, getpass; print(bcrypt.hashpw(getpass.getpass('Password: ').encode(), bcrypt.gensalt(12)).decode())"
 
 # Generate secret key
 openssl rand -base64 48
@@ -412,7 +412,7 @@ webhook-allowed-hosts = hooks.slack.com, discord.com, ntfy.internal, 192.168.1.2
 ofelia hash-password            # --cost accepts 4-31; 10-14 recommended, 12 default
 
 # Without the binary at hand:
-python3 -c "import bcrypt; print(bcrypt.hashpw(b'your-password', bcrypt.gensalt(12)).decode())"
+python3 -c "import bcrypt, getpass; print(bcrypt.hashpw(getpass.getpass('Password: ').encode(), bcrypt.gensalt(12)).decode())"
 ```
 
 **Usage**:

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -135,7 +135,10 @@ allow-host-jobs-from-labels = false  # Restrict LocalJobs
 
 **Best Practices**:
 ```bash
-# Generate bcrypt password hash
+# Generate bcrypt password hash (prompts twice, prints ready-made config snippets)
+ofelia hash-password
+
+# Without the binary at hand:
 python3 -c "import bcrypt; print(bcrypt.hashpw(b'your-password', bcrypt.gensalt(12)).decode())"
 
 # Generate secret key
@@ -406,6 +409,9 @@ webhook-allowed-hosts = hooks.slack.com, discord.com, ntfy.internal, 192.168.1.2
 **Password Hashing**:
 ```bash
 # Generate bcrypt hash for configuration
+ofelia hash-password            # --cost accepts 4-31; 10-14 recommended, 12 default
+
+# Without the binary at hand:
 python3 -c "import bcrypt; print(bcrypt.hashpw(b'your-password', bcrypt.gensalt(12)).decode())"
 ```
 


### PR DESCRIPTION
Two documentation gaps, found by diffing the declared surfaces against the code rather than reading prose for feel.

## What was measured, and what was clean

| Surface | Method | Result |
|---|---|---|
| API routes | route table in `web/server.go` (constants resolved) vs `docs/openapi.yaml` paths vs `docs/API.md` headings | 20 routes, **no drift in any direction** |
| Config keys | every `gcfg:` and `mapstructure:` tag vs all of `docs/`, README, CHANGELOG | 90 keys, **all mentioned** |
| CLI flags | every `long:` tag vs `--flag` and env-var spellings in the docs | 24 flags, **2 undocumented** (below) |
| README images | referenced local paths vs files on disk | `docs/images/dashboard-light-dark.png` present |

Three earlier "findings" were artifacts of my own extraction and are not in this PR: route constants my first regex did not resolve, config keys gcfg derives from the field name rather than a tag, and `retry-delay`, which is documented in `docs/webhooks.md` — a file my first pass forgot to read.

## Docker startup retry was in no document at all

`[docker] startup-retry-count` / `startup-retry-interval`, the matching `--docker-startup-retry-*` flags and the `OFELIA_DOCKER_STARTUP_RETRY_*` variables appear nowhere in `docs/` or the README. `grep -rl` finds them in exactly one file: `CHANGELOG.md`, in the entry for the release that added them. That is history, not instructions — an operator hitting the problem the feature exists for ([#522](https://github.com/netresearch/ofelia/issues/522): ofelia exits when a socket proxy is not reachable yet) had no way to find the setting.

The new section sits beside the `include-stopped` one and copies its shape. Its facts come from the implementation, not from [#523](https://github.com/netresearch/ofelia/issues/523)'s proposal — which matters, because the two differ: the issue proposed `--docker-retry-count` defaulting to 5, and what shipped is `--docker-startup-retry-count` defaulting to 0. Documented from `pingWithRetry` and the struct tags: the count is *extra* attempts beyond the initial ping (budget `count + 1`), the wait before attempt *n* is `interval × 2^(n-1)`, each step is capped at five minutes, each attempt is bounded by the 10s ping timeout, an interval of `0` retries without sleeping, and only a failure that still has a retry left is logged at `WARN` — the last one becomes the startup error.

## The docs recommended python for something the binary does

`ofelia hash-password` was mentioned once in the whole documentation set, inside a code comment in a config snippet. Meanwhile three places — `docs/CONFIGURATION.md` and twice in `docs/SECURITY.md` — told the reader to generate the bcrypt hash with a `python3 -c "import bcrypt; …"` one-liner.

None of the three framed it as a fallback; they presented it as the way. So the documentation sent readers to an external dependency for something the shipped binary does better: `hash-password` prompts twice with the input masked, refuses anything under eight characters, validates the cost, and prints ready-made `config.ini` and environment-variable snippets alongside the hash. Verified against `cli/hashpw.go` and `ofelia hash-password --help` before writing it down.

All three now lead with the command and keep `htpasswd` and python as what they legitimately are — what to use on a machine that does not have the binary, such as when writing a Compose file elsewhere.

## Scope

Documentation only; no code, no CHANGELOG entry (the `[Unreleased]` section carries no documentation-only entries, so adding one would invent a convention), and `openapi.yaml`'s `info.version` is left alone — it has been `1.3.0` since the file was created and was not bumped across any of the eleven changes since, so there is no convention to honour there either.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_016HMCWKo6LHV83osTnC2MW2)_
