### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   where the run used to be skipped — the same behavior INI-defined and
   label-defined jobs have always had. Also `RetryDelayMs` 1000 and
   `compose.yml` as a compose job's default file.
+- **The deprecation window for `slack-webhook`, `poll-interval` and `no-poll` runs to v2.0.0.** All three were scheduled for removal in v1.0.0 and still work. The window was extended rather than the options dropped, so upgrading to 1.0.0 does not require a configuration change. `poll-interval` and `no-poll` are migrated automatically to `config-poll-interval` / `docker-poll-interval` and the polling defaults; `slack-webhook` is not, and a `[webhook "name"]` section with `preset = slack` replaces it. The removal target in the warning text moved with the window, so a 1.0.0 daemon no longer reports that an option "will be removed in v1.0.0" while running it.
 - **The health report is served from a snapshot.** `GetHealth` called
   `runtime.ReadMemStats` per request, which stops the world, and `/ready`
   is exempt from rate limiting — an unauthenticated caller could force a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,7 @@ to v2.0.0.
   where the run used to be skipped — the same behavior INI-defined and
   label-defined jobs have always had. Also `RetryDelayMs` 1000 and
   `compose.yml` as a compose job's default file.
-- **The deprecation window for `slack-webhook`, `poll-interval` and `no-poll` runs to v2.0.0.** All three were scheduled for removal in v1.0.0 and still work. The window was extended rather than the options dropped, so upgrading to 1.0.0 does not require a configuration change. `poll-interval` and `no-poll` are migrated automatically to `config-poll-interval` / `docker-poll-interval` and the polling defaults; `slack-webhook` is not, and a `[webhook "name"]` section with `preset = slack` replaces it. The removal target in the warning text moved with the window, so a 1.0.0 daemon no longer reports that an option "will be removed in v1.0.0" while running it.
+- **The deprecation window for `slack-webhook`, `poll-interval` and `no-poll` runs to v2.0.0.** All three were scheduled for removal in v1.0.0 and still work. The window was extended rather than the options dropped, so upgrading to `v1.0.0` does not require a configuration change. `poll-interval` and `no-poll` are migrated automatically to `config-poll-interval` / `docker-poll-interval` and the polling defaults; `slack-webhook` is not, and a `[webhook "name"]` section with `preset = slack` replaces it. The removal target in the warning text moved with the window, so a `v1.0.0` daemon no longer reports that an option "will be removed in v1.0.0" while running it.
 - **The health report is served from a snapshot.** `GetHealth` called
   `runtime.ReadMemStats` per request, which stops the world, and `/ready`
   is exempt from rate limiting — an unauthenticated caller could force a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-09-03
+
+The first stable release. The number is the commitment it implies: from here, a
+breaking change to the documented HTTP API or to the INI and label
+configuration takes a major bump, and the "pre-1.0" allowance the two
+source-only breaks below were taken under no longer applies.
+
+Most of the surface is the rebuilt dashboard and the API it runs on — an
+aggregate `/api/dashboard` endpoint, response compression, ETagged assets,
+per-job sparklines and duration stats, search and sorting. The API grew a gate:
+jobs owned by the INI file or by Docker labels can no longer be created,
+updated or deleted through it, and jobs it does own now survive a restart.
+
+Upgrading needs no configuration change. `slack-webhook`, `poll-interval` and
+`no-poll` were scheduled for removal here and still work; that window now runs
+to v2.0.0.
+
 ### Added
 
 - **Origin badges and honest delete buttons.** Config-owned jobs (INI or

--- a/cli/deprecations.go
+++ b/cli/deprecations.go
@@ -11,7 +11,12 @@ import (
 	"time"
 )
 
-const deprecationRemovalVersion = "v1.0.0"
+// deprecationRemovalVersion is the release in which the options listed in
+// Deprecations stop being accepted. Moved from v1.0.0 to v2.0.0 when 1.0.0
+// was cut: the window was deliberately extended rather than the options
+// dropped, and leaving the constant behind would have made a v1.0.0 daemon
+// print "will be removed in v1.0.0" at every start.
+const deprecationRemovalVersion = "v2.0.0"
 
 // Names of currently deprecated options. Exported so callers (e.g. doctor
 // reports, label allowlists) can reference the canonical name without

--- a/cli/deprecations.go
+++ b/cli/deprecations.go
@@ -12,7 +12,7 @@ import (
 )
 
 // deprecationRemovalVersion is the release in which the options listed in
-// Deprecations stop being accepted. Moved from v1.0.0 to v2.0.0 when 1.0.0
+// Deprecations stop being accepted. Moved from v1.0.0 to v2.0.0 when v1.0.0
 // was cut: the window was deliberately extended rather than the options
 // dropped, and leaving the constant behind would have made a v1.0.0 daemon
 // print "will be removed in v1.0.0" at every start.

--- a/cli/deprecations_test.go
+++ b/cli/deprecations_test.go
@@ -303,10 +303,16 @@ func TestDeprecations_AllHaveRequiredFields(t *testing.T) {
 func TestDeprecations_RemovalVersionFormat(t *testing.T) {
 	t.Parallel()
 
+	// Asserted against the constant rather than a literal. The window moves
+	// -- it went from v1.0.0 to v2.0.0 when 1.0.0 was cut -- and a literal
+	// only has to be edited in step, catching nothing on the way. What is
+	// worth pinning is that every entry shares one target, so a hand-written
+	// version on a single deprecation cannot slip in unnoticed.
 	for _, dep := range Deprecations {
-		// All deprecations should target v1.0.0
-		assert.Equal(t, "v1.0.0", dep.RemovalVersion,
-			"Deprecation %s should target v1.0.0", dep.Option)
+		assert.Equal(t, deprecationRemovalVersion, dep.RemovalVersion,
+			"Deprecation %s must use the shared removal version", dep.Option)
+		assert.Regexp(t, `^v\d+\.\d+\.\d+$`, dep.RemovalVersion,
+			"Deprecation %s must name a tag-shaped version", dep.Option)
 	}
 }
 

--- a/cli/deprecations_test.go
+++ b/cli/deprecations_test.go
@@ -304,7 +304,7 @@ func TestDeprecations_RemovalVersionFormat(t *testing.T) {
 	t.Parallel()
 
 	// Asserted against the constant rather than a literal. The window moves
-	// -- it went from v1.0.0 to v2.0.0 when 1.0.0 was cut -- and a literal
+	// -- it went from v1.0.0 to v2.0.0 when v1.0.0 was cut -- and a literal
 	// only has to be edited in step, catching nothing on the way. What is
 	// worth pinning is that every entry shares one target, so a hand-written
 	// version on a single deprecation cannot slip in unnoticed.

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -812,7 +812,7 @@ command = /run-task.sh
 webhooks = slack
 ```
 
-The deprecated `slack-webhook` option keeps working and prints a deprecation warning naming its removal version. That version is `v2.0.0`: removal was scheduled for `v1.0.0` and the window was extended when 1.0.0 was cut, so upgrading to 1.0.0 does not force this migration.
+The deprecated `slack-webhook` option keeps working and prints a deprecation warning naming its removal version. That version is `v2.0.0`: removal was scheduled for `v1.0.0` and the window was extended when `v1.0.0` was cut, so upgrading to `v1.0.0` does not force this migration.
 
 ## Troubleshooting
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -812,7 +812,7 @@ command = /run-task.sh
 webhooks = slack
 ```
 
-The deprecated `slack-webhook` option will continue to work but will show a deprecation warning. It will be removed in a future version.
+The deprecated `slack-webhook` option keeps working and prints a deprecation warning naming its removal version. That version is `v2.0.0`: removal was scheduled for `v1.0.0` and the window was extended when 1.0.0 was cut, so upgrading to 1.0.0 does not force this migration.
 
 ## Troubleshooting
 

--- a/middlewares/slack.go
+++ b/middlewares/slack.go
@@ -31,7 +31,7 @@ type SlackConfig struct {
 
 // NewSlack returns a Slack middleware if the given configuration is not empty
 //
-// Deprecated: The Slack middleware is deprecated and will be removed in v1.0.0.
+// Deprecated: The Slack middleware is deprecated and will be removed in v2.0.0.
 // Please migrate to the generic webhook notification system with the "slack" preset:
 //
 //	[webhook "slack-alerts"]


### PR DESCRIPTION
Cuts `[Unreleased]` to `[1.0.0]` and moves the deprecation window that was due here.

## The window, and why it moved

`slack-webhook`, `poll-interval` and `no-poll` all carry `RemovalVersion: v1.0.0` and are all still accepted. Tagging 1.0.0 without addressing that would have shipped a daemon printing

```
DEPRECATION WARNING: 'slack-webhook' is deprecated and will be removed in v1.0.0.
```

while running v1.0.0 — `logWarning` formats the constant straight into the message, so the contradiction is visible to every operator who still sets one of the three.

The window is extended to v2.0.0 rather than the options removed, so upgrading to 1.0.0 needs no configuration change. `poll-interval` and `no-poll` migrate automatically; `slack-webhook` has `MigrateFunc: nil` and needs a `[webhook "name"]` section with `preset = slack` written by hand, which is the reason not to force it in the same step as a version bump.

## The test that pinned it

`TestDeprecations_RemovalVersionFormat` asserted the literal `"v1.0.0"`. That is a value which legitimately moves, so the literal only ever had to be edited in step with the constant — it would not have caught anything on the way. It now asserts the two invariants that are worth pinning:

| Injected defect | Result |
|---|---|
| one entry given `"v3.1.4"` instead of the shared constant | red: "must use the shared removal version" |
| the constant set to `"2.0"` | red: "must name a tag-shaped version" |

## Release content

284 lines moved from `[Unreleased]` into `[1.0.0]`, unchanged apart from the new deprecation entry: the rebuilt dashboard and the API behind it, the gate that keeps the API out of INI- and label-owned jobs, persistence of API-created jobs across restarts, and five changes already marked `**BREAKING**`.

Two of those five are marked "source-only, pre-1.0". That allowance ends with this tag, which is worth stating in the release rather than discovering later.

No version file to bump — the binary takes its version from the tag via goreleaser's `-X main.version={{.Version}}`.

Gates on the final tree: `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run ./...` — clean.
