### PR TITLE
chore: raise the minimum Go version to 1.27

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -19,7 +19,7 @@ fi
 echo -e "${BLUE}🔧 Verifying Ofelia development environment...${NC}"
 
 # Check Go version requirement
-REQUIRED_VERSION="1.26"
+REQUIRED_VERSION="1.27"
 
 if ! command -v go &> /dev/null; then
     echo -e "${RED}❌ Go not found. Please install Go ${REQUIRED_VERSION}+${NC}"
@@ -29,7 +29,7 @@ fi
 GO_VERSION=$(go version | grep -o 'go[0-9]\+\.[0-9]\+' | sed 's/go//')
 
 # Compare major.minor as integers, not floats — naive numeric comparison
-# would incorrectly treat 1.9 as greater than 1.26.
+# would incorrectly treat 1.9 as greater than 1.27.
 go_major=${GO_VERSION%%.*}
 go_minor=${GO_VERSION#*.}
 req_major=${REQUIRED_VERSION%%.*}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **The minimum Go version is 1.27.** The toolchain moved to go1.27.0 in [v0.30.0](https://github.com/netresearch/ofelia/releases/tag/v0.30.0) while `go.mod` kept a `go 1.26` directive, which is what the Go-version badge reads. That directive is not just a floor for who can build: Go compiles a module declaring an older version with that version's compatibility defaults, so the released binary carried `DefaultGODEBUG=tracebacklabels=0,x509sslcertoverrideplatform=0` — the two behaviours Go 1.27 changed, pinned back — despite being built by go1.27.0. Raising the directive drops those pins and makes the 1.27 language features available. Building from source now needs a 1.27 toolchain, which `toolchain go1.27.0` already fetches unless `GOTOOLCHAIN=local` forbids it; nothing imports this module as a library, and the published images and binaries are unaffected either way.
+- **The minimum Go version is 1.27.** The toolchain moved to go1.27.0 in
+  [v0.30.0](https://github.com/netresearch/ofelia/releases/tag/v0.30.0)
+  while `go.mod` kept a `go 1.26` directive, which is what the
+  Go-version badge reads. That directive is not just a floor for who can
+  build: Go compiles a module declaring an older version with that
+  version's compatibility defaults, so the released binary carried
+  `DefaultGODEBUG=tracebacklabels=0,x509sslcertoverrideplatform=0` — the
+  two behaviours Go 1.27 changed, pinned back — despite being built by
+  go1.27.0. Raising the directive drops those pins and makes the 1.27
+  language features available. Building from source now needs a 1.27
+  toolchain, which `toolchain go1.27.0` already fetches unless
+  `GOTOOLCHAIN=local` forbids it; nothing imports this module as a
+  library, and the published images and binaries are unaffected either
+  way.
 
 ## [1.0.0] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The minimum Go version is 1.27.** The toolchain moved to go1.27.0 in [v0.30.0](https://github.com/netresearch/ofelia/releases/tag/v0.30.0) while `go.mod` kept a `go 1.26` directive, which is what the Go-version badge reads. That directive is not just a floor for who can build: Go compiles a module declaring an older version with that version's compatibility defaults, so the released binary carried `DefaultGODEBUG=tracebacklabels=0,x509sslcertoverrideplatform=0` — the two behaviours Go 1.27 changed, pinned back — despite being built by go1.27.0. Raising the directive drops those pins and makes the 1.27 language features available. Building from source now needs a 1.27 toolchain, which `toolchain go1.27.0` already fetches unless `GOTOOLCHAIN=local` forbids it; nothing imports this module as a library, and the published images and binaries are unaffected either way.
+
 ## [1.0.0] - 2026-09-03
 
 The first stable release. The number is the commitment it implies: from here, a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ The project's lefthook `commit-msg` hook validates the presence of
 
 ### Prerequisites
 
-- Go 1.26 or higher
+- Go 1.27 or higher
 - Docker (for integration and E2E tests)
 - Docker Swarm enabled (for service job tests)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 ### Prerequisites
 
-- Go 1.26+
+- Go 1.27+
 - Docker and Docker Compose
 - Git
 - **Recommended**: [direnv](https://direnv.net/) for automatic environment setup
@@ -30,7 +30,7 @@ direnv allow
 ```
 
 The `.envrc` file automatically:
-- ✅ Verifies Go 1.26+ installation
+- ✅ Verifies Go 1.27+ installation
 - ✅ Checks required tools (golangci-lint, gosec, docker)
 - ✅ **Enforces Git hooks setup** - prevents commits without hooks
 - ✅ Sets up development aliases and environment variables

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/netresearch/ofelia
 
-go 1.26
+go 1.27
 
 toolchain go1.27.0
 


### PR DESCRIPTION
The toolchain moved to `go1.27.0` in [v0.30.0](https://github.com/netresearch/ofelia/releases/tag/v0.30.0) while `go.mod` kept `go 1.26`. That directive is what the README's Go-version badge reads, which is how a release built and shipped with 1.27 came to advertise 1.26.

## It is not only a build-time floor

Go compiles a module declaring an older version with **that version's compatibility defaults**. The [v1.0.0](https://github.com/netresearch/ofelia/releases/tag/v1.0.0) binary carries them:

```
$ go version -m ofelia
ofelia: go1.27.0
	build	DefaultGODEBUG=tracebacklabels=0,x509sslcertoverrideplatform=0
```

Built by `go1.27.0`, running 1.26 behaviour for the two things 1.27 changed — [`tracebacklabels`](https://go.dev/doc/godebug) (goroutine labels in tracebacks, off) and `x509sslcertoverrideplatform` (on Windows and Darwin, whether `SSL_CERT_FILE` / `SSL_CERT_DIR` override the platform certificate store).

Verified as a controlled comparison — same tree, same toolchain, only the directive differs:

| `go` directive | binary | `DefaultGODEBUG` |
|---|---|---|
| `go 1.26` | `go1.27.0` | `tracebacklabels=0,x509sslcertoverrideplatform=0` |
| `go 1.27` | `go1.27.0` | *absent* |

Security-motivated GODEBUGs are exempt from this pinning and applied regardless, so the old floor was never withholding security fixes — only behaviour changes and the language feature set.

## What the floor was buying

Nothing measurable, for this repository:

| Possible reason | Finding |
|---|---|
| Modules importing ofelia as a library | pkg.go.dev: *"No known importers for this package!"* |
| Distributions building from source | The `Dockerfile` does not compile Go — it is `FROM alpine` and packages a prebuilt binary |
| CI on an older Go | CI resolves its toolchain from `go.mod` and was already building with 1.27 |
| Contributors on 1.26 | `toolchain go1.27.0` fetches 1.27 unless `GOTOOLCHAIN=local` forbids it |

The sibling libraries keep their 1.26 floor on purpose: `netresearch/go-cron` and `netresearch/simple-ldap-go` both have importers, and there the floor is a promise to other people's code. Ofelia is an application and had inherited the same line without inheriting the reason.

## Scope

`go.mod`, plus the two documents that state the requirement (`docs/DEVELOPMENT.md`, `CONTRIBUTING.md`). The badge follows `go.mod` on its own. `go mod tidy` leaves `go.mod` and `go.sum` untouched after the change.

Gates on the final tree: `go build ./...`, `go vet ./...`, `go test ./...` (14 packages), `golangci-lint run ./...`, `govulncheck ./...` — all clean, the last reporting 0 vulnerabilities.
