### PR TITLE
docs: state how default-user and a job's user resolve, and the reserved value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`default-user` is documented as the four states it actually has.**
-  The setting was described in half a sentence per job type, and the
-  reservation of the value `default` was not written down anywhere: a
-  container user of that name cannot be selected, because the value is
-  always read as the sentinel for "the container's own default user".
-  `docs/CONFIGURATION.md` now carries the state table — absent yields
-  `nobody`, empty and `default` both yield the container's own user,
-  anything else is taken literally — and names the reservation, with an
-  empty value recommended as the spelling that expresses the same intent
-  without the collision
-  ([#718](https://github.com/netresearch/ofelia/issues/718)).
+- **`default-user` and a job's own `user` are documented as the distinct
+  states they have.** The setting had half a sentence per job type, and
+  an empty value means something different at the two levels — which the
+  documentation did not say and is the easy mistake. For
+  `[global] default-user`: absent yields `nobody`, empty and `default`
+  both yield the container's own user, anything else is taken literally.
+  For a job's own `user`: absent or empty *inherits* whatever the global
+  resolved to, and only `default` bypasses it. Both are now tables in
+  `docs/CONFIGURATION.md`, and the three per-job descriptions in
+  `docs/jobs.md` say which of the two they are.
+
+  The reservation of `default` is written down for the first time: a
+  container user of that name cannot be selected at either level. The
+  global has a second spelling that avoids the collision — an empty
+  value — while a job's `user` has none, since empty already means
+  inherit ([#718](https://github.com/netresearch/ofelia/issues/718)).
 
 - **The minimum Go version is 1.27.** The toolchain moved to go1.27.0 in
   [v0.30.0](https://github.com/netresearch/ofelia/releases/tag/v0.30.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`default-user` is documented as the four states it actually has.**
+  The setting was described in half a sentence per job type, and the
+  reservation of the value `default` was not written down anywhere: a
+  container user of that name cannot be selected, because the value is
+  always read as the sentinel for "the container's own default user".
+  `docs/CONFIGURATION.md` now carries the state table — absent yields
+  `nobody`, empty and `default` both yield the container's own user,
+  anything else is taken literally — and names the reservation, with an
+  empty value recommended as the spelling that expresses the same intent
+  without the collision
+  ([#718](https://github.com/netresearch/ofelia/issues/718)).
+
 - **The minimum Go version is 1.27.** The toolchain moved to go1.27.0 in
   [v0.30.0](https://github.com/netresearch/ofelia/releases/tag/v0.30.0)
   while `go.mod` kept a `go 1.26` directive, which is what the

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -363,7 +363,9 @@ command = pg_dump ${DB_NAME:-mydb}
 
 [job-TYPE "NAME"]
 # Job-specific configuration
-# TYPE: exec, run, local, service, compose
+# TYPE: exec, run, local, service-run, compose
+#       (so the sections are [job-exec], [job-run], [job-local],
+#        [job-service-run] and [job-compose])
 # NAME: Unique job identifier
 ```
 
@@ -1140,7 +1142,7 @@ This is a **daemon-wide** setting configured in the Ofelia `[global]` section (I
 
 1. **Circular dependencies are detected** - Ofelia will reject configurations with circular dependency chains
 2. **Dependencies must exist** - Referenced jobs must be defined in the configuration
-3. **All job types supported** - Dependencies work across all job types (exec, run, local, service, compose)
+3. **All job types supported** - Dependencies work across all job types (exec, run, local, service-run, compose)
 4. **Multiple dependencies** - Use multiple `depends-on` lines in INI format to specify multiple dependencies
 5. **Service name precedence** - Docker Compose service names take precedence over container names for job naming
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -462,7 +462,8 @@ enable-strict-validation = false
 #### The default-user setting
 
 `default-user` supplies the user for `job-exec`, `job-run` and `job-service-run`
-jobs that do not name one themselves. It has four distinct outcomes:
+jobs that do not name one themselves. Four spellings resolve to three
+outcomes — an empty value and `default` mean the same thing:
 
 | `[global] default-user` | A job without its own `user` runs as |
 |---|---|

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -377,7 +377,7 @@ command = pg_dump ${DB_NAME:-mydb}
 # Event/polling settings (events, docker-poll-interval, ...) belong in the
 # [docker] section — see "Docker label configurations" in the README.
 allow-host-jobs-from-labels = false
-default-user = nobody        # Default for exec/run/service; empty uses container default
+default-user = nobody        # Default for exec/run/service; see "The default-user setting" below
 
 # How label-defined job-exec names are scoped (see "Cross-Container Job
 # References" below). Default `service` is collision-prone when one daemon
@@ -456,6 +456,29 @@ pprof-address = :6060
 # Security
 enable-strict-validation = false
 ```
+
+#### The default-user setting
+
+`default-user` supplies the user for `job-exec`, `job-run` and `job-service-run`
+jobs that do not name one themselves. It has four distinct outcomes:
+
+| `[global] default-user` | A job without its own `user` runs as |
+|---|---|
+| absent | `nobody` — the built-in default |
+| empty (`default-user =`) | the container's own default user |
+| `default` | the container's own default user |
+| any other value | that user |
+
+A job can set `user` itself to override the global, and the same two spellings
+apply there: an empty `user` inherits the global, `user = default` asks for the
+container's own default regardless of what the global says.
+
+**`default` is reserved for that meaning.** A container user literally named
+`default` cannot be selected, because the value is always read as the sentinel
+([#718](https://github.com/netresearch/ofelia/issues/718)). Leaving the value
+empty expresses the same intent without the collision, and is the spelling to
+prefer.
+
 
 ## Job Types
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -377,7 +377,7 @@ command = pg_dump ${DB_NAME:-mydb}
 # Event/polling settings (events, docker-poll-interval, ...) belong in the
 # [docker] section — see "Docker label configurations" in the README.
 allow-host-jobs-from-labels = false
-default-user = nobody        # Default for exec/run/service; see "The default-user setting" below
+default-user = nobody        # For job-exec, job-run and job-service-run; see "The default-user setting" below
 
 # How label-defined job-exec names are scoped (see "Cross-Container Job
 # References" below). Default `service` is collision-prone when one daemon
@@ -469,16 +469,26 @@ jobs that do not name one themselves. It has four distinct outcomes:
 | `default` | the container's own default user |
 | any other value | that user |
 
-A job can set `user` itself to override the global, and the same two spellings
-apply there: an empty `user` inherits the global, `user = default` asks for the
-container's own default regardless of what the global says.
+A job can set `user` itself, and the empty value means something different at
+that level — this is the easy mistake:
+
+| A job's own `user` | Result |
+|---|---|
+| absent or empty | inherit whatever the table above resolves the global to |
+| `default` | the container's own default user, whatever the global says |
+| any other value | that user |
+
+So an empty `user` on a job is "inherit", not "container default". Only
+`user = default` bypasses the global.
 
 **`default` is reserved for that meaning.** A container user literally named
-`default` cannot be selected, because the value is always read as the sentinel
-([#718](https://github.com/netresearch/ofelia/issues/718)). Leaving the value
-empty expresses the same intent without the collision, and is the spelling to
-prefer.
+`default` cannot be selected at either level, because the value is always read
+as the sentinel ([#718](https://github.com/netresearch/ofelia/issues/718)).
 
+For `[global] default-user` there is a second spelling that avoids the
+collision — an empty value means the same thing — and it is the one to prefer.
+A job's own `user` has no such alternative: empty means inherit, so `default`
+is the only way to ask for the container's user there.
 
 ## Job Types
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -20,7 +20,7 @@ This job is executed inside a running container, similar to `docker exec`.
   - Name of the container you want to execute the command in.
 - `user`: string = `nobody`
   - User as which the command should be executed, similar to `docker exec --user <user>`
-  - If not set, uses the global `default-user` (default `nobody`); set to `default` or leave it empty to use the container's own default user. `default` is reserved for that meaning and cannot name a real user of that name
+  - If not set, inherits the global `default-user` (default `nobody`) — an empty value here means "inherit", not "container default". Set `user = default` for the container's own default user regardless of the global; `default` is reserved for that meaning and cannot name a real user
 - `tty`: boolean = `false`
   - Allocate a pseudo-tty, similar to `docker exec -t`. See this [Stack Overflow answer](https://stackoverflow.com/questions/30137135/confused-about-docker-t-option-to-allocate-a-pseudo-tty) for more info.
 - `console-height`: uint = `0`
@@ -103,7 +103,7 @@ This job can be used in 2 situations:
   - Override the image entrypoint. Use an empty value to remove it.
 - `user`: string = `nobody` (1)
   - User as which the command should be executed, similar to `docker run --user <user>`
-  - If not set, uses the global `default-user` (default `nobody`); set to `default` or leave it empty to use the container's own default user. `default` is reserved for that meaning and cannot name a real user of that name
+  - If not set, inherits the global `default-user` (default `nobody`) — an empty value here means "inherit", not "container default". Set `user = default` for the container's own default user regardless of the global; `default` is reserved for that meaning and cannot name a real user
 - `network`: string (1)
   - Connect the container to this network
 - `hostname`: string (1)
@@ -260,7 +260,7 @@ This job can be used to:
   - Delete the container after the job is finished.
 - `user`: string = `nobody` (1, 2)
   - User as which the command should be executed.
-  - If not set, uses the global `default-user` (default `nobody`); set to `default` or leave it empty to use the container's own default user. `default` is reserved for that meaning and cannot name a real user of that name
+  - If not set, inherits the global `default-user` (default `nobody`) — an empty value here means "inherit", not "container default". Set `user = default` for the container's own default user regardless of the global; `default` is reserved for that meaning and cannot name a real user
 - `tty`: boolean = `false` (1, 2)
   - Allocate a pseudo-tty, similar to `docker exec -t`. See this [Stack Overflow answer](https://stackoverflow.com/questions/30137135/confused-about-docker-t-option-to-allocate-a-pseudo-tty) for more info.
 - `environment`

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -20,7 +20,7 @@ This job is executed inside a running container, similar to `docker exec`.
   - Name of the container you want to execute the command in.
 - `user`: string = `nobody`
   - User as which the command should be executed, similar to `docker exec --user <user>`
-  - If not set, uses the global `default-user` (default `nobody`); set to `default` to use the container's default user
+  - If not set, uses the global `default-user` (default `nobody`); set to `default` or leave it empty to use the container's own default user. `default` is reserved for that meaning and cannot name a real user of that name
 - `tty`: boolean = `false`
   - Allocate a pseudo-tty, similar to `docker exec -t`. See this [Stack Overflow answer](https://stackoverflow.com/questions/30137135/confused-about-docker-t-option-to-allocate-a-pseudo-tty) for more info.
 - `console-height`: uint = `0`
@@ -103,7 +103,7 @@ This job can be used in 2 situations:
   - Override the image entrypoint. Use an empty value to remove it.
 - `user`: string = `nobody` (1)
   - User as which the command should be executed, similar to `docker run --user <user>`
-  - If not set, uses the global `default-user` (default `nobody`); set to `default` to use the container's default user
+  - If not set, uses the global `default-user` (default `nobody`); set to `default` or leave it empty to use the container's own default user. `default` is reserved for that meaning and cannot name a real user of that name
 - `network`: string (1)
   - Connect the container to this network
 - `hostname`: string (1)
@@ -260,7 +260,7 @@ This job can be used to:
   - Delete the container after the job is finished.
 - `user`: string = `nobody` (1, 2)
   - User as which the command should be executed.
-  - If not set, uses the global `default-user` (default `nobody`); set to `default` to use the container's default user
+  - If not set, uses the global `default-user` (default `nobody`); set to `default` or leave it empty to use the container's own default user. `default` is reserved for that meaning and cannot name a real user of that name
 - `tty`: boolean = `false` (1, 2)
   - Allocate a pseudo-tty, similar to `docker exec -t`. See this [Stack Overflow answer](https://stackoverflow.com/questions/30137135/confused-about-docker-t-option-to-allocate-a-pseudo-tty) for more info.
 - `environment`


### PR DESCRIPTION
Closes [#718](https://github.com/netresearch/ofelia/issues/718). Documentation only — no behaviour change.

## Why this and not a refactor

[#718](https://github.com/netresearch/ofelia/issues/718) rates its own impact as *"low/theoretical in practice — a passwd user literally named `default` is extremely rare to nonexistent. Filing for the record so the design tradeoff is explicit and discoverable"*, and lists **"document the reservation"** as its first option. This takes that option. Typing the field as `*string` — its third — would be a config-layer change carrying real risk for a problem the reporter classified as theoretical.

## Measured, not read off the struct tag

Four spellings resolving to three outcomes — an empty value and `default` mean the same thing, which is what makes the empty one usable as the collision-free spelling. Established by driving `BuildFromFile` with each:

| `[global] default-user` | `Global.DefaultUser` | a job with no `user` of its own runs as |
|---|---|---|
| absent | `nobody` | `nobody` |
| `default-user =` (empty) | `""` | the container's own default user |
| `default-user = default` | `default` | the container's own default user |
| `default-user = alice` | `alice` | `alice` |

`docs/CONFIGURATION.md` now carries that table where it previously had a trailing comment, and states the reservation: a container user named `default` cannot be selected, because the value is always read as the sentinel. **At this level** the empty spelling avoids the collision and is the one to prefer — which is not true one level down, see below.

A job's own `user` behaves differently and gets its own table, because conflating the two is the easy mistake — I made it in the first version of this PR and review caught it:

| A job's own `user` | Result |
|---|---|
| absent or empty | inherit whatever the global resolved to |
| `default` | the container's own default user, whatever the global says |
| any other value | that user |

So the collision has no workaround at the job level: empty already means inherit, leaving `default` as the only spelling for "the container's user" there. The three per-job descriptions in `docs/jobs.md` now say that rather than repeating the global's rule.

## This also settles the companion issue

[#719](https://github.com/netresearch/ofelia/issues/719) asks whether a string default can distinguish *unset* from *explicitly empty*, and proposes auditing the string config fields. Both were done:

- **The audit.** Every global→job string inheritance is `if job.X == "" { job.X = global.X }`, across `SlackWebhook`, the six `SMTP*`/`Email*` fields and the three `Save*` fields. For all of those an empty value means *not configured*, so the two states are not distinguishable and not meant to be. `default-user` is the one field where empty carries a meaning of its own, which is why it needed a sentinel at all.
- **The measurement.** For that one field the ambiguity does not currently bite: `creasty/defaults` leaves an explicitly empty value alone, so unset yields `nobody` while empty yields the container default — two different outcomes, both reachable. The concern in [#719](https://github.com/netresearch/ofelia/issues/719) is latent, not active.

Posted there so the discussion has data rather than a second opinion; that issue is left open for the maintainer to close or keep.

## Verification

`go build ./...` and `go test ./cli/` clean. The probe that produced the table was a throwaway and is not in the diff — checked with `git status` before committing.
