### PR TITLE
docs(agents): describe the release process that exists

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,12 @@ This file explains repo‑wide conventions and where to find scoped rules.
   permanently. The order is: cut the release PR, merge it, tag `main`'s merge
   commit with `git tag -s vX.Y.Z`, push the tag, wait.
 - `gh release edit vX.Y.Z --notes-file notes.md` afterwards is the supported
-  way to replace CI's generated notes, and the only `gh release edit` flag to
-  use.
+  way to replace CI's generated notes. `--notes-file` and `--repo` are the
+  flags to use; the rest of that command's flags are blocked.
+- `scripts/update-release-notes.sh` appends an "Included in this release"
+  index linking the `released:vX.Y.Z` label filter. It exists and the labels
+  are maintained, but no release currently carries that section — treat it as
+  available, not as a step the flow depends on.
 - Follow the narrative release notes style from previous releases: user-facing
   highlights first, then categorized changes, contributors `@mentioned` inline
   at the change they touched rather than in a section of their own.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,10 +46,21 @@ This file explains repo‑wide conventions and where to find scoped rules.
 - Reusable workflows pinned `@main` are intentional (own org, post-trivy-action-incident policy) — the related hotspots are accepted, not third-party actions.
 
 ## Release process
-- Releases trigger on `release: published` event via `release-slsa.yml`
-- Create signed tags locally, then create a GitHub release: `gh release create vX.Y.Z --title "vX.Y.Z" --notes-file notes.md --verify-tag`
-- The Release workflow builds SLSA Level 3 provenance, container images, and binary artifacts
-- Follow the narrative release notes style from previous releases (user-facing highlights first, then categorized changes)
+- **Pushing the tag is the release.** `release.yml` triggers on `push` of a
+  `v*` tag and calls `netresearch/.github/.github/workflows/release-go-app.yml@main`,
+  which creates the GitHub release, the binaries, the SLSA provenance, the
+  SBOMs and the `ghcr.io/netresearch/ofelia` image tags. `verify-release.yml`
+  runs afterwards against the published result.
+- **Never run `gh release create`.** CI owns creation, and under immutable
+  releases a lightweight tag from that command burns the version name
+  permanently. The order is: cut the release PR, merge it, tag `main`'s merge
+  commit with `git tag -s vX.Y.Z`, push the tag, wait.
+- `gh release edit vX.Y.Z --notes-file notes.md` afterwards is the supported
+  way to replace CI's generated notes, and the only `gh release edit` flag to
+  use.
+- Follow the narrative release notes style from previous releases: user-facing
+  highlights first, then categorized changes, contributors `@mentioned` inline
+  at the change they touched rather than in a section of their own.
 
 ## Dependencies
 - `github.com/netresearch/go-cron` — maintained fork of robfig/cron with DAG engine, pause/resume, @triggered schedules


### PR DESCRIPTION
`AGENTS.md`'s Release section described a setup this repository does not have. Cutting [v1.0.0](https://github.com/netresearch/ofelia/releases/tag/v1.0.0) is what surfaced it — the documented steps and the actual ones do not meet.

## What it said, and what is true

| `AGENTS.md` | Verified |
|---|---|
| triggers on `release: published` via `release-slsa.yml` | that file does not exist; `release.yml` fires on `push` of a `v*` tag |
| "create a GitHub release: `gh release create …`" | CI creates it — v1.0.0's author is `github-actions[bot]` |

The second one is the harmful half. `gh release create` is blocked by tooling for a reason: under immutable releases a lightweight tag from that command burns the version name permanently, and it cannot be reclaimed. Someone following the file on a release whose tag was not pushed first would have hit exactly that.

## Everything in the replacement was checked

Not carried over from the old text or from memory:

- `release.yml`'s trigger and the reusable workflow it calls (`netresearch/.github/.github/workflows/release-go-app.yml@main`) — read from the file.
- The release author — `gh release view --json author`.
- What the workflow produces — 41 provenance, SBOM and signature assets on the release, and the `ghcr.io/netresearch/ofelia` tags `1.0.0`, `1.0`, `1`, `latest`.
- That `verify-release.yml` runs afterwards — its run against the published tag is in the run list.

The notes step is named explicitly because CI's generated body is a commit list until it is replaced, and `--notes-file` is the one `gh release edit` flag that is allowed.

## Sweep

`release-slsa` now appears nowhere in `AGENTS.md`, `.github/`, `docs/` or `CONTRIBUTING.md`, and the only remaining `gh release create` in the repository's Markdown is the line forbidding it.
