### PR TITLE
docs(agents): record the backlog, deprecation and major-bump rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,21 @@ This file explains repo‑wide conventions and where to find scoped rules.
 - Extracting a route constant named `*Token` (e.g. `pathAPICSRFToken`) trips gosec G101 (hardcoded credentials) in the GHAS code-scanning gate — suppress with `// #nosec G101 -- reason`. The standalone `go-check / gosec` and the GHAS `gosec` check are separate.
 - Reusable workflows pinned `@main` are intentional (own org, post-trivy-action-incident policy) — the related hotspots are accepted, not third-party actions.
 
+## Backlog — picking the next issue
+- There are no priority labels. The signals that exist: **`upstream`** (12 of 24 open issues) marks work inherited from `mcuadros/ofelia` — such an issue describes that project's behaviour and is not automatically a defect here, so check the code before treating it as one. `bug` separates a defect from `feature`/`enhancement`; `security` outranks both.
+- **Read the body, not the title, before proposing an issue as work.** Two of sixty issues state their own impact, and where one does, that grading is the answer rather than context: [#718](https://github.com/netresearch/ofelia/issues/718) rates itself "low/theoretical in practice … Filing for the record" and lists *document the reservation* as its first option — which is what closed it. Recommending such an issue as a real defect contradicts its reporter and needs a stated reason.
+- An issue's **proposed solution** is the reporter's hypothesis from the day they wrote it; re-derive it from the code. Its **scope claims** ("affects X and Y") are a reading of the call graph, not a measurement.
+
+## Deprecation policy
+- Deprecated options keep working until a **major** release. The single source of truth is `deprecationRemovalVersion` in `cli/deprecations.go` (currently `v2.0.0`); the warning text is generated from it, and `cli/deprecations_test.go` asserts every entry uses it rather than a literal.
+- **Extending the window beats dropping options in a non-major.** For [v1.0.0](https://github.com/netresearch/ofelia/releases/tag/v1.0.0) the three options `slack-webhook`, `poll-interval` and `no-poll` were scheduled for removal; the window moved to `v2.0.0` instead, so upgrading required no configuration change.
+- Changing that constant is a **declared-value sweep**, and the prose surfaces do not follow automatically: `middlewares/slack.go`'s `// Deprecated:` doc comment (pkg.go.dev renders it), `CHANGELOG.md`, and `docs/`. Grep **without** an extension filter — the enforcing surfaces include dotfiles.
+
+## What earns a major bump
+- Removing a deprecated option, changing what an existing configuration key means, or dropping a supported input form. These are the changes that make a working config stop working.
+- **Raising the minimum Go version is not one of them.** Users consume binaries and the `ghcr.io` image, not the module; the floor binds whoever compiles the source. [#824](https://github.com/netresearch/ofelia/pull/824) raised it to 1.27 without a major being proposed.
+- New options, new job types and new endpoints are minors. Fixes that keep every documented input working are patches.
+
 ## Release process
 - **Pushing the tag is the release.** `release.yml` triggers on `push` of a
   `v*` tag and calls `netresearch/.github/.github/workflows/release-go-app.yml@main`,


### PR DESCRIPTION
`AGENTS.md` did not answer three questions that came up repeatedly while working this repository: which issue to pick next, how long a deprecated option lives, and what makes a release a major. Each is written from what the repository already does, not from preference — the measurements are below so a wrong one can be argued with.

## Backlog — picking the next issue

There is no priority label in this repository. What exists: `upstream` on **12 of 24** open issues, `bug`, and `security`. An `upstream` issue was inherited from `mcuadros/ofelia` and describes that project's behaviour, so it is not automatically a defect here — the section says to check the code first.

The second rule is the one that cost something. **2 of the 60 most recent issues state their own impact**, and where an issue does, that grading answers the question rather than providing background. [#718](https://github.com/netresearch/ofelia/issues/718) rates itself *"low/theoretical in practice … Filing for the record so the design tradeoff is explicit and discoverable"* and lists *document the reservation* as its first option — which is how it was closed. I recommended it as a real defect without reading that section and had to withdraw the recommendation.

## Deprecation policy

Deprecated options survive to a major. `deprecationRemovalVersion` in `cli/deprecations.go` is the single source (`v2.0.0` today), and `cli/deprecations_test.go` pins it for **every** entry — the loop is `for _, dep := range Deprecations` asserting against the constant, so a hand-written version on one deprecation cannot slip in.

The precedent is recorded because it is the non-obvious half: for [v1.0.0](https://github.com/netresearch/ofelia/releases/tag/v1.0.0) the three options `slack-webhook`, `poll-interval` and `no-poll` were scheduled for removal and the window was extended instead, so upgrading needed no configuration change.

Moving that constant is a declared-value sweep. The prose surfaces do not follow it: `middlewares/slack.go`'s `// Deprecated:` doc comment, `CHANGELOG.md`, `docs/`. The section says to grep without an extension filter, because that is what went wrong last time — `.envrc` cannot match `--include='*.md'`.

## What earns a major bump

Removing a deprecated option, changing what an existing key means, dropping a supported input form — the changes that make a working configuration stop working.

Explicitly **not** a major: raising the minimum Go version. Users consume the binaries and the `ghcr.io` image rather than the module, so the floor binds whoever compiles the source. [#824](https://github.com/netresearch/ofelia/pull/824) raised it to 1.27 on that basis.

## Verification

Every number above was queried against the live repository while writing, not recalled: the label distribution, the 24/12 split, the 2-of-60 impact count, [#718](https://github.com/netresearch/ofelia/issues/718)'s state, and the value of the constant. The test-coverage claim was checked by reading the loop rather than the assertion line.

Documentation only — no code, no behaviour change.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01FaJYTTjfqhBJisARa6g5BE)_
