### PR TITLE
fix(renovate): let Renovate process this fork

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
+  "forkProcessing": "enabled",
   "automerge": true,
   "automergeType": "pr",
   "platformAutomerge": true


### PR DESCRIPTION
Renovate has never opened a pull request in this repository and no Dependency Dashboard was ever created, while Dependabot kept running. The Mend portal shows the repository as `Renovate Status: disabled` with no jobs at all and "No dependencies detected", despite a valid `renovate.json` being present.

The cause is not this repository's configuration. Renovate's `forkProcessing` defaults to `auto`, which means *disabled* when Renovate runs in autodiscover mode — and that is how the Mend app is installed for this organization (`GET /orgs/netresearch/installations` reports `repository_selection=all`). Forks are then skipped with "Repository is a fork and not manually configured - skipping". Had the app been installed against selected repositories instead, forks would be processed.

`"forkProcessing": "enabled"` opts this repository back in. The setting is read only from a `renovate.json` in the repository root, which is where this file already lives.

The second line of the diff renames `config:base` to `config:recommended`. That is the same preset — it was renamed in Renovate 36 and is migrated automatically on every run — so this changes no behaviour; it only removes the "Config migration necessary" warning that `renovate-config-validator` prints.

Verified by running Renovate's own validator against the file: `INFO: Config validated successfully`, with no migration warning remaining.

Not addressed here, and worth a separate decision: this config extends `config:recommended` directly rather than `github>netresearch/renovate-config`, so it does not inherit the organization policy (stability days, the automerge rules, the `deps-no-automerge` label). It also sets a bare top-level `automerge: true`, which is broader than the org preset's rule. Both are pre-existing and out of scope for enabling the bot.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01Gcm3GRuYBxJGtyj7qviJF8)_
